### PR TITLE
docs(viz): Expand visualization notebook documentation

### DIFF
--- a/examples/visualizations/visualize_become.ipynb
+++ b/examples/visualizations/visualize_become.ipynb
@@ -320,7 +320,7 @@
     "**Floods Case (Arable land reduction in %, 13 experts):**\n",
     "- Shows the greatest spread among all three scenarios\n",
     "- Expert opinions range from near 0% to over 40% reduction\n",
-    "- Clear separation into distinct opinion clusters: pessimistic (0-10%), moderate (10-25%), optimistic (25-40+%)\n",
+    "- Clear separation into distinct opinion clusters: optimistic (0-10%), moderate (10-25%), pessimistic (25-40+%)\n",
     "- The arithmetic mean (red) is pulled toward higher values by outliers\n",
     "- The median (teal) is more conservative, sitting in the middle cluster\n",
     "- Large distance between Gamma and Omega indicates **high disagreement** (high delta_max)\n",
@@ -665,8 +665,8 @@
     "**Floods Case (Arable land reduction in %, 13 experts):**\n",
     "- Expert centroids range from ~0.5% to ~47% (nearly 100x spread!)\n",
     "- Clear **bimodal distribution**: Two distinct clusters\n",
-    "   - Low cluster: 5 experts with centroids 0.5-8% (pessimistic about land loss)\n",
-    "   - High cluster: 5 experts with centroids 37-47% (optimistic about land loss)\n",
+    "   - Low cluster: 5 experts with centroids 0.5-8% (optimistic scenario - low land loss)\n",
+    "   - High cluster: 5 experts with centroids 37-47% (pessimistic scenario - high land loss)\n",
     "   - Middle zone: 3 experts around 14-42% (bridge the gap)\n",
     " - Large gap between clusters around 8-14% reveals fundamental disagreement\n",
     " - Aggregated values:\n",
@@ -1113,7 +1113,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "93f22fb334d74b9d93f7a8da7f596f92",
+       "model_id": "2490b40712934191bd9ef36f33b5ccbe",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1155,7 +1155,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "34c82576ea2f42159765ac8538931ce4",
+       "model_id": "fa2d4023f0874a8c98e46fe7cb5e06bc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1203,7 +1203,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "65f07965e4ec470a95513da2a5b51800",
+       "model_id": "bab508c006f94ed09000f9269ea83882",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2522,8 +2522,8 @@
     "**Why This Matters:**\n",
     "\n",
     "If decision makers only looked at the Best Compromise value (14.31%) without examining the visualizations, they might implement policies assuming ~14% land reduction, when in reality:\n",
-    "- The outcome could be much lower (~5%) if the pessimistic group is correct → policies might be over-cautious\n",
-    "- The outcome could be much higher (~40%) if the optimistic group is correct → policies might be under-prepared\n",
+    "- The outcome could be much lower (~5%) if the optimistic group is correct → policies might be over-cautious\n",
+    "- The outcome could be much higher (~40%) if the pessimistic group is correct → policies might be under-prepared\n",
     "\n",
     "The **value of the BeCoMe visualizations** is precisely in revealing this underlying disagreement that a single consensus number would mask.\n",
     "\n",


### PR DESCRIPTION
This PR significantly expands the documentation in the BeCoMe visualization notebook by replacing brief descriptions with comprehensive, educational explanations of the visualizations and their interpretations.

**Documentation enhancements:**

- Added detailed documentation for triangular membership functions and centroid charts, including mathematical formulas, visualization components, and interpretation guidelines
- Provided case-specific interpretations for all three example datasets (Budget, Floods, Pendlers), helping users understand how to read and analyze the results in different contexts
- Enhanced explanations of visualization elements to make the notebook more accessible for new users and suitable for educational purposes

**Technical updates:**

- Updated kernel display name from ".venv" to "become" for consistency with project naming

These changes transform the notebook from a basic visualization tool into a comprehensive educational resource that helps users understand not just what the visualizations show, but how to interpret and apply them to their own fuzzy logic problems.