### PR TITLE
refactor(viz): Use module-specific imports

### DIFF
--- a/examples/visualizations/visualize_become.ipynb
+++ b/examples/visualizations/visualize_become.ipynb
@@ -43,7 +43,8 @@
     "data_dir = Path(os.getcwd()) / \"..\" / \"data\"\n",
     "output_dir = Path(os.getcwd()) / \"output\"\n",
     "\n",
-    "from examples.utils import calculate_agreement_level, load_data_from_txt\n",
+    "from examples.utils.analysis import calculate_agreement_level\n",
+    "from examples.utils.data_loading import load_data_from_txt\n",
     "from src.calculators.become_calculator import BeCoMeCalculator\n",
     "\n",
     "# Plot settings\n",
@@ -1113,7 +1114,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2490b40712934191bd9ef36f33b5ccbe",
+       "model_id": "a6506cfdec6b404c95de9a5d6b5f39dc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1155,7 +1156,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fa2d4023f0874a8c98e46fe7cb5e06bc",
+       "model_id": "ceb03e452f7046cca6817f5f6e9aaeb6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1203,7 +1204,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bab508c006f94ed09000f9269ea83882",
+       "model_id": "654ce7bac4aa4c5e8720a3b4f06fe590",
        "version_major": 2,
        "version_minor": 0
       },
@@ -2837,7 +2838,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "become",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
This pull request updates the `examples/visualizations/visualize_become.ipynb` notebook to improve code organization and update environment metadata. The most important changes are grouped below:

Code organization improvements:
* Imports for utility functions have been refactored to use module-specific imports, moving `calculate_agreement_level` and `load_data_from_txt` to their respective submodules: `examples.utils.analysis` and `examples.utils.data_loading`.

Environment and metadata updates:
* The notebook's kernel display name has been changed from `.venv` to `become` to better reflect the intended environment.
* Several widget `model_id` values have been updated, likely reflecting reruns or refreshes of interactive visualizations. [[1]](diffhunk://#diff-e70630137dc7a2087553d27678619c59022dea3158140a28fa23c6fa95c099fdL1116-R1117) [[2]](diffhunk://#diff-e70630137dc7a2087553d27678619c59022dea3158140a28fa23c6fa95c099fdL1158-R1159) [[3]](diffhunk://#diff-e70630137dc7a2087553d27678619c59022dea3158140a28fa23c6fa95c099fdL1206-R1207)