### PR TITLE
docs: document database security hardening

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -134,7 +134,8 @@ Environment variables (can use `.env` file):
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `APP_ENV` | `dev` | Deployment profile: `dev`, `test`, or `prod`. Selects the `.env.<APP_ENV>` overlay; `prod` rejects a default secret or SQLite. See the root README "Environment profiles". |
-| `DATABASE_URL` | `sqlite:///./become.db` | Database connection string |
+| `DATABASE_URL` | `sqlite:///./become.db` | Database connection string. On deployed environments this is the least-privilege `become_app` role. |
+| `MIGRATION_DATABASE_URL` | *optional* | Privileged connection used only by Alembic migrations (DDL); falls back to `DATABASE_URL` when unset. |
 | `SECRET_KEY` | *required* | JWT signing key (generate with `openssl rand -hex 32`) |
 | `ACCESS_TOKEN_EXPIRE_MINUTES` | `15` | Access token TTL |
 | `REFRESH_TOKEN_EXPIRE_DAYS` | `7` | Refresh token TTL |
@@ -148,6 +149,8 @@ Environment variables (can use `.env` file):
 | `BUCKET_SECRET_ACCESS_KEY` | *optional* | Bucket secret key |
 
 **Note:** Profile photos are stored in a private Railway Storage Bucket (S3-compatible) and served through the `GET /api/v1/users/{id}/photo` proxy. When the bucket variables are absent, photo upload is disabled and the API continues to function with all other features available.
+
+**Migrations:** The PostgreSQL schema is managed by Alembic (`migrations/`). `alembic upgrade head` runs automatically before each Railway deploy; to apply it manually against a specific database use `ALEMBIC_DATABASE_URL=<url> uv run alembic upgrade head`. SQLite (local development and the test suite) keeps using `create_all`, so no migration step is needed there.
 
 ## Testing
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -72,7 +72,7 @@ The `api` service in `docker/docker-compose.yml` reads `APP_ENV` with `${APP_ENV
 
 ## CI
 
-`.github/workflows/ci.yml` sets `APP_ENV=test` on the `python-tests`, `backend-e2e`, and `e2e` jobs, including the steps that start a live server. `scripts/ci/e2e-local.sh` sets the same value for local end-to-end runs.
+`.github/workflows/ci.yml` runs on every push and pull request to `main`, `develop`, and `staging`, so the deploy branches get the same full pipeline as `main`: lint, Python and frontend tests, backend and Playwright end-to-end tests, and SonarCloud (the last on pull requests only). It sets `APP_ENV=test` on the `python-tests`, `backend-e2e`, and `e2e` jobs, including the steps that start a live server. `scripts/ci/e2e-local.sh` sets the same value for local end-to-end runs.
 
 ## Development workflow
 
@@ -96,7 +96,8 @@ The root `railway.toml` carries the API build and deploy settings: it points at 
 |----------|----------------|-------------------|
 | `APP_ENV` | `test` | `prod` |
 | `SECRET_KEY` | strong value (`openssl rand -hex 32`) | strong value |
-| `DATABASE_URL` | staging PostgreSQL | production PostgreSQL |
+| `DATABASE_URL` | staging `become_app` role | production `become_app` role |
+| `MIGRATION_DATABASE_URL` | privileged role, Alembic only | privileged role, Alembic only |
 | `CORS_ORIGINS` | staging origin(s) | production origin(s) |
 | `DEBUG` | `false` | `false` |
 | `API_PUBLIC_URL` | staging API URL | production API URL |
@@ -105,13 +106,21 @@ The root `railway.toml` carries the API build and deploy settings: it points at 
 
 If `APP_ENV` is left unset on a deployed service, it falls back to dev, which turns debug on and opens CORS. Production must set `APP_ENV=prod` so the startup guard runs.
 
+## Database schema and access
+
+The schema is versioned with **Alembic**. Migrations live in `migrations/`; `migrations/env.py` reads its target from `MIGRATION_DATABASE_URL` (falling back to `DATABASE_URL`) and treats `SQLModel.metadata` as the source of truth. Every deploy runs `alembic upgrade head` once through the `preDeployCommand` in `railway.toml`, before the new version goes live, so a failed migration blocks the release instead of starting a broken one. `create_db_and_tables()` still builds the schema directly, but only for SQLite (local development) and `TESTING=1` runs (the end-to-end PostgreSQL); on a deployed database it is a no-op and Alembic stays in charge.
+
+The application connects through a **least-privilege role**, `become_app`. It reads and writes the application tables but cannot create, alter, or drop objects, is not a superuser, and cannot bypass row-level security. Each backend therefore carries two database URLs: `DATABASE_URL` points at `become_app` for the running app, while `MIGRATION_DATABASE_URL` points at the privileged role that Alembic uses for DDL. The connection is hardened in `api/db/engine.py` -- TLS is required on deployed databases, each connection is tagged with an `application_name`, and per-session statement and idle-in-transaction timeouts stop a single query from monopolising the database. The schema also carries domain `CHECK` constraints (fuzzy-number ordering, positive expert counts, scale bounds) so the database rejects invalid rows on its own.
+
+On production and staging each Postgres instance is reachable only over Railway's internal network: the public TCP proxies were removed, so those databases are no longer exposed to the internet. A proxy can be recreated briefly when a laptop needs direct access for a migration or a dump.
+
 ## Photo storage
 
 Profile photos live in a per-environment Railway Storage Bucket (`dev-photos`, `test-photos`, `prod-photos`), reached over the S3 API. Buckets are private, so the backend serves each image itself through the public proxy `GET /api/v1/users/{id}/photo`; the `users.photo_url` column stores the object key, and responses carry the proxy URL built from `API_PUBLIC_URL`. Attaching a bucket to a service auto-injects `BUCKET_NAME`, `BUCKET_ENDPOINT`, `BUCKET_ACCESS_KEY_ID`, and `BUCKET_SECRET_ACCESS_KEY`; when they are absent (plain local runs), photo upload is disabled and the rest of the API keeps working.
 
 ## Current status
 
-All three environments run entirely on Railway, each with its own isolated Postgres and photo bucket:
+All three environments run entirely on Railway, each with its own isolated Postgres and photo bucket. The database layer is hardened the same way across them: Alembic owns the schema, the app connects as the least-privilege `become_app` role, and the production and staging databases are internal-only.
 
 - **prod** is live: https://www.becomify.app (frontend) and https://api.becomify.app (API), `APP_ENV=prod`. Database is **Railway Postgres** (`prod-db`); profile photos live in a **Railway Storage Bucket** (`prod-photos`) served through the API photo proxy. Supabase is fully retired -- neither the database nor file storage uses it anymore.
 - **test / staging** is live from `staging`: https://test-backend-staging.up.railway.app (API) and https://test-frontend-staging.up.railway.app, on its own Railway Postgres (`test-db`) and bucket (`test-photos`), `APP_ENV=test`.

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -10,6 +10,7 @@ changes.
 
 import os
 from logging.config import fileConfig
+from typing import Literal
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
@@ -39,7 +40,7 @@ def _database_url() -> str:
     return settings.migration_database_url or settings.database_url
 
 
-def _render_item(type_, obj, autogen_context):
+def _render_item(type_: str, obj: object, autogen_context: object) -> str | Literal[False]:
     """Render SQLModel string types as plain SQLAlchemy strings.
 
     ``AutoString`` is equivalent to ``sa.String`` for DDL, so rendering it

--- a/tests/integration/api/db/test_check_constraints.py
+++ b/tests/integration/api/db/test_check_constraints.py
@@ -33,6 +33,26 @@ def _make_project(session, user: User) -> Project:
     return project
 
 
+def _make_calc(project_id, **overrides) -> CalculationResult:
+    """Build a CalculationResult with valid fuzzy ordering; override to break one rule."""
+    fields: dict[str, object] = {
+        "project_id": project_id,
+        "best_compromise_lower": 1.0,
+        "best_compromise_peak": 2.0,
+        "best_compromise_upper": 3.0,
+        "arithmetic_mean_lower": 1.0,
+        "arithmetic_mean_peak": 2.0,
+        "arithmetic_mean_upper": 3.0,
+        "median_lower": 1.0,
+        "median_peak": 2.0,
+        "median_upper": 3.0,
+        "max_error": 0.0,
+        "num_experts": 3,
+    }
+    fields.update(overrides)
+    return CalculationResult(**fields)
+
+
 class TestCheckConstraints:
     """The database enforces the domain CHECK constraints."""
 
@@ -83,22 +103,68 @@ class TestCheckConstraints:
         # GIVEN
         user = _make_user(session)
         project = _make_project(session, user)
-        result = CalculationResult(
-            project_id=project.id,
-            best_compromise_lower=1.0,
-            best_compromise_peak=2.0,
-            best_compromise_upper=3.0,
-            arithmetic_mean_lower=1.0,
-            arithmetic_mean_peak=2.0,
-            arithmetic_mean_upper=3.0,
-            median_lower=1.0,
-            median_peak=2.0,
-            median_upper=3.0,
-            max_error=0.0,
-            num_experts=0,
-        )
 
         # WHEN / THEN
-        session.add(result)
+        session.add(_make_calc(project.id, num_experts=0))
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+    def test_calculation_best_compromise_order_rejected(self, session):
+        """
+        GIVEN a result whose best_compromise bounds violate lower <= peak <= upper
+        WHEN it is committed
+        THEN the database rejects it with IntegrityError
+        """
+        # GIVEN
+        user = _make_user(session)
+        project = _make_project(session, user)
+
+        # WHEN / THEN
+        session.add(_make_calc(project.id, best_compromise_lower=5.0))
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+    def test_calculation_arithmetic_mean_order_rejected(self, session):
+        """
+        GIVEN a result whose arithmetic_mean bounds violate lower <= peak <= upper
+        WHEN it is committed
+        THEN the database rejects it with IntegrityError
+        """
+        # GIVEN
+        user = _make_user(session)
+        project = _make_project(session, user)
+
+        # WHEN / THEN
+        session.add(_make_calc(project.id, arithmetic_mean_lower=5.0))
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+    def test_calculation_median_order_rejected(self, session):
+        """
+        GIVEN a result whose median bounds violate lower <= peak <= upper
+        WHEN it is committed
+        THEN the database rejects it with IntegrityError
+        """
+        # GIVEN
+        user = _make_user(session)
+        project = _make_project(session, user)
+
+        # WHEN / THEN
+        session.add(_make_calc(project.id, median_lower=5.0))
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+    def test_calculation_likert_value_out_of_range_rejected(self, session):
+        """
+        GIVEN a result with likert_value outside 0..100
+        WHEN it is committed
+        THEN the database rejects it with IntegrityError
+        """
+        # GIVEN
+        user = _make_user(session)
+        project = _make_project(session, user)
+
+        # WHEN / THEN
+        session.add(_make_calc(project.id, likert_value=150))
         with pytest.raises(IntegrityError):
             session.commit()

--- a/tests/integration/api/db/test_check_constraints.py
+++ b/tests/integration/api/db/test_check_constraints.py
@@ -4,7 +4,7 @@ These verify the database independently rejects domain-invalid rows, even when a
 write bypasses the application-layer Pydantic validators (defense in depth).
 """
 
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy.exc import IntegrityError
@@ -33,7 +33,7 @@ def _make_project(session, user: User) -> Project:
     return project
 
 
-def _make_calc(project_id, **overrides) -> CalculationResult:
+def _make_calc(project_id: UUID, **overrides: object) -> CalculationResult:
     """Build a CalculationResult with valid fuzzy ordering; override to break one rule."""
     fields: dict[str, object] = {
         "project_id": project_id,
@@ -154,9 +154,10 @@ class TestCheckConstraints:
         with pytest.raises(IntegrityError):
             session.commit()
 
-    def test_calculation_likert_value_out_of_range_rejected(self, session):
+    @pytest.mark.parametrize("value", [150, -1])
+    def test_calculation_likert_value_out_of_range_rejected(self, session, value):
         """
-        GIVEN a result with likert_value outside 0..100
+        GIVEN a result with likert_value outside 0..100 (either bound)
         WHEN it is committed
         THEN the database rejects it with IntegrityError
         """
@@ -165,6 +166,6 @@ class TestCheckConstraints:
         project = _make_project(session, user)
 
         # WHEN / THEN
-        session.add(_make_calc(project.id, likert_value=150))
+        session.add(_make_calc(project.id, likert_value=value))
         with pytest.raises(IntegrityError):
             session.commit()


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR documents the database security hardening that was previously shipped without written explanation — least-privilege `become_app` application role, separate `MIGRATION_DATABASE_URL` for Alembic DDL, network isolation of prod/staging databases, and the automatic pre-deploy migration step.

- **`api/README.md` and `docs/environments.md`**: Env tables updated with `MIGRATION_DATABASE_URL`; new \"Database schema and access\" section explains the two-role model, Alembic ownership, and network isolation.
- **`migrations/env.py`**: `_render_item` gains precise type annotations (`str | Literal[False]`), matching Alembic's `render_item` callback contract.
- **`tests/integration/api/db/test_check_constraints.py`**: `_make_calc` factory eliminates duplicated `CalculationResult` construction; four new tests cover all three fuzzy-number triplets and both bounds of the `likert_value` constraint (parametrized with `150` and `-1`).

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are documentation, an additive type annotation, and new test coverage with no modifications to runtime logic.

All four changed files are low-risk: the README and environments doc add prose only, the _render_item annotation is a non-breaking refinement that does not alter the function's behaviour, and the new tests expand coverage without touching production code paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/README.md | Adds MIGRATION_DATABASE_URL row to the env table, documents the least-privilege become_app role, and explains the automatic Alembic pre-deploy step; purely documentation, no code changes. |
| docs/environments.md | Expands CI description, adds MIGRATION_DATABASE_URL to the staging/prod table, and adds a new "Database schema and access" section documenting the Alembic + least-privilege + network-isolation hardening. |
| migrations/env.py | Adds Literal import and precise type annotations to _render_item; return type str | Literal[False] correctly models Alembic's render_item contract. |
| tests/integration/api/db/test_check_constraints.py | Extracts _make_calc factory, adds four new CalculationResult CHECK constraint tests (fuzzy ordering for all three triplets, and a parametrized likert bounds test now covering both -1 and 150). |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Railway as Railway Deploy
    participant Alembic as Alembic (MIGRATION_DATABASE_URL)
    participant App as FastAPI App (DATABASE_URL)
    participant DB as PostgreSQL

    Railway->>Alembic: preDeployCommand: alembic upgrade head
    Alembic->>DB: Connect as privileged role (DDL)
    Alembic->>DB: Apply schema migrations
    DB-->>Alembic: OK
    Alembic-->>Railway: migrations applied
    Railway->>App: Start application
    App->>DB: Connect as become_app (least-privilege, DML only)
    Note over App,DB: TLS required, application_name tagged,<br/>statement + idle-in-transaction timeouts set
    App-->>Railway: healthy
```

<sub>Reviews (2): Last reviewed commit: ["test: annotate calc helper and cover lik..."](https://github.com/caitlon/become/commit/d5b405b6d7f80a67ff1bb41dfa2e53c2be85adb1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34728352)</sub>

<!-- /greptile_comment -->