### PR TITLE
chore: harden database roles, tokens, and auditing

### DIFF
--- a/api/db/models.py
+++ b/api/db/models.py
@@ -194,13 +194,23 @@ class ExpertOpinion(SQLModel, table=True):
 
 
 class PasswordResetToken(SQLModel, table=True):
-    """Token for password reset via email."""
+    """Token for password reset via email.
+
+    Only the SHA-256 hash of the reset token is stored, never the raw value. The
+    reset flow is expected to generate a high-entropy token (for example via
+    ``secrets.token_urlsafe``), email the RAW token to the user, and persist only
+    ``hashlib.sha256(raw.encode()).hexdigest()`` in ``token_hash``. Validation
+    re-hashes the incoming token and looks it up by ``token_hash``, so a database
+    leak never exposes a usable token. (The reset flow itself is not implemented
+    yet; this schema is secure by default for when it is.)
+    """
 
     __tablename__ = "password_reset_tokens"
 
     id: UUID = Field(default_factory=uuid4, primary_key=True)
     user_id: UUID = Field(foreign_key=_USERS_FK, index=True, ondelete="CASCADE")
-    token: UUID = Field(default_factory=uuid4, unique=True, index=True)
+    # SHA-256 hex digest of the raw token (64 chars); the raw token is never stored.
+    token_hash: str = Field(unique=True, index=True, max_length=64)
     created_at: datetime = Field(default_factory=utc_now)
     expires_at: datetime
     used_at: datetime | None = Field(default=None)

--- a/api/db/models.py
+++ b/api/db/models.py
@@ -209,8 +209,8 @@ class PasswordResetToken(SQLModel, table=True):
 
     id: UUID = Field(default_factory=uuid4, primary_key=True)
     user_id: UUID = Field(foreign_key=_USERS_FK, index=True, ondelete="CASCADE")
-    # SHA-256 hex digest of the raw token (64 chars); the raw token is never stored.
-    token_hash: str = Field(unique=True, index=True, max_length=64)
+    # SHA-256 hex digest of the raw token (exactly 64 chars); the raw token is never stored.
+    token_hash: str = Field(unique=True, index=True, min_length=64, max_length=64)
     created_at: datetime = Field(default_factory=utc_now)
     expires_at: datetime
     used_at: datetime | None = Field(default=None)

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,81 @@
+# Database Security
+
+How BeCoMe's PostgreSQL databases are locked down, and the runbooks for operating them.
+Deployment topology -- which service connects to which database -- lives in
+[`environments.md`](environments.md); this file covers roles, network exposure, auditing,
+backups, and secret rotation.
+
+## Roles and least privilege
+
+Every environment's database is reached through two roles, never one:
+
+- **`become_app`** -- the application runtime role behind `DATABASE_URL`. It is a plain login
+  role: `NOSUPERUSER`, `NOCREATEDB`, `NOCREATEROLE`, `NOBYPASSRLS`. Its rights stop at
+  `SELECT/INSERT/UPDATE/DELETE` on the application tables plus `USAGE`/`SELECT` on their
+  sequences. It cannot run DDL, create objects in `public`, or read another role's data.
+- **`postgres`** -- the Railway-provisioned superuser, used only by Alembic for schema changes
+  through `MIGRATION_DATABASE_URL`. Railway hands out exactly one superuser, so there is no
+  separate `migrator` role; keeping migrations on a distinct URL is what isolates DDL from the
+  runtime token, without the overhead of in-session `SET ROLE`.
+
+`scripts/db/roles.sql` is the idempotent source of truth for this setup. Running it against an
+environment as `postgres` reconciles the grants, the default privileges that hand every future
+Alembic-created table to `become_app`, the `REVOKE CREATE ON SCHEMA public FROM PUBLIC`
+lockdown, a pinned `search_path` (`pg_catalog, public`, which closes CVE-2018-1058 for the
+exposed role), and the role-level `statement_timeout`/`idle_in_transaction_session_timeout`/
+`lock_timeout`. Passwords stay out of the file -- they live in Railway variables.
+
+The connection itself is hardened in `api/db/engine.py`: TLS is required on deployed databases
+(`sslmode=require`), each connection is tagged with an `application_name`, and the per-session
+statement and idle-in-transaction timeouts are also set client-side through libpq `options`, so
+a single runaway query cannot monopolise the database.
+
+## Network exposure
+
+Production and staging databases answer only on Railway's private network
+(`*.railway.internal`); their public TCP proxies were removed, so a leaked password is not the
+sole barrier between the internet and the data. The dev database is the one exception, and even
+there the proxy is normally closed -- it is opened in the Railway dashboard only for a specific
+hands-on operation and shut again afterwards. That toggle is the project's substitute for an IP
+allowlist, which Railway's platform does not offer.
+
+## Audit logging
+
+Railway's managed Postgres permits `ALTER SYSTEM`, so connection auditing is enabled directly on
+each database and reloaded without a restart:
+
+```sql
+ALTER SYSTEM SET log_connections = 'on';
+ALTER SYSTEM SET log_disconnections = 'on';
+ALTER SYSTEM SET log_statement = 'ddl';
+ALTER SYSTEM SET log_min_duration_statement = '5000';
+SELECT pg_reload_conf();
+```
+
+Connections and disconnections are recorded, every DDL statement is logged -- schema changes
+should only ever originate from Alembic, so anything else here is a red flag -- and statements
+slower than five seconds are captured. The output flows into the Railway service logs. Finer
+read/write auditing would need the `pgaudit` extension, but that requires
+`shared_preload_libraries`, which Railway's image does not expose; `log_statement = 'ddl'` is the
+workable substitute.
+
+## Backups
+
+Railway takes scheduled volume backups of each Postgres service. Confirm the schedule and
+retention for `prod-db` (and `test-db`) under the service's **Backups** tab in the Railway
+dashboard, and keep a periodic restore drill -- the Supabase-to-Railway migration recipe in
+`environments.md` doubles as the restore procedure, since it is the same dump/restore path.
+
+## Secret rotation
+
+Rotating the `become_app` password without downtime uses a second credential so there is never a
+window where the application cannot connect:
+
+1. Create a replacement login with the same grants -- `CREATE ROLE become_app_v2 LOGIN ...`,
+   then apply the `scripts/db/roles.sql` grants to it (or set its password and copy the grants).
+2. Point the environment's `DATABASE_URL` at `become_app_v2` in Railway and redeploy.
+3. Confirm health is 200 and that `pg_stat_activity` shows connections from the new role.
+4. Drop the old role: `DROP ROLE become_app;`. Rename `become_app_v2` back during a later quiet
+   window if you want the canonical name restored.
+
+`SECRET_KEY` rotates the same way: add the new value, redeploy, verify, then remove the old one.

--- a/migrations/versions/2026_05_30_2244-f3a7c2b9d1e4_hash_password_reset_token.py
+++ b/migrations/versions/2026_05_30_2244-f3a7c2b9d1e4_hash_password_reset_token.py
@@ -40,9 +40,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """Downgrade schema."""
-    op.drop_index(
-        op.f("ix_password_reset_tokens_token_hash"), table_name="password_reset_tokens"
-    )
+    op.drop_index(op.f("ix_password_reset_tokens_token_hash"), table_name="password_reset_tokens")
     op.drop_column("password_reset_tokens", "token_hash")
     op.add_column(
         "password_reset_tokens",

--- a/migrations/versions/2026_05_30_2244-f3a7c2b9d1e4_hash_password_reset_token.py
+++ b/migrations/versions/2026_05_30_2244-f3a7c2b9d1e4_hash_password_reset_token.py
@@ -1,0 +1,56 @@
+"""hash password reset token
+
+Revision ID: f3a7c2b9d1e4
+Revises: c83186b79ad7
+Create Date: 2026-05-30 22:44:02.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f3a7c2b9d1e4"
+down_revision: str | Sequence[str] | None = "c83186b79ad7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    password_reset_tokens is an empty scaffold; replace the raw ``token`` column
+    with a SHA-256 ``token_hash`` so a database leak never exposes a usable token.
+    """
+    op.drop_index(op.f("ix_password_reset_tokens_token"), table_name="password_reset_tokens")
+    op.drop_column("password_reset_tokens", "token")
+    op.add_column(
+        "password_reset_tokens",
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+    )
+    op.create_index(
+        op.f("ix_password_reset_tokens_token_hash"),
+        "password_reset_tokens",
+        ["token_hash"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(
+        op.f("ix_password_reset_tokens_token_hash"), table_name="password_reset_tokens"
+    )
+    op.drop_column("password_reset_tokens", "token_hash")
+    op.add_column(
+        "password_reset_tokens",
+        sa.Column("token", sa.Uuid(), nullable=False),
+    )
+    op.create_index(
+        op.f("ix_password_reset_tokens_token"),
+        "password_reset_tokens",
+        ["token"],
+        unique=True,
+    )

--- a/scripts/db/roles.sql
+++ b/scripts/db/roles.sql
@@ -30,8 +30,13 @@ $$;
 ALTER ROLE become_app NOSUPERUSER NOCREATEDB NOCREATEROLE NOBYPASSRLS;
 
 -- 2. Connect + schema usage (deliberately NO create) ------------------------------
--- Database name is the Railway default `railway`; adjust if an environment differs.
-GRANT CONNECT ON DATABASE railway TO become_app;
+-- Grant CONNECT on whichever database this script is connected to, so the file does
+-- not hardcode a database name that differs between Railway environments.
+DO $$
+BEGIN
+  EXECUTE format('GRANT CONNECT ON DATABASE %I TO become_app', current_database());
+END
+$$;
 GRANT USAGE ON SCHEMA public TO become_app;
 
 -- 3. DML on existing objects ------------------------------------------------------

--- a/scripts/db/roles.sql
+++ b/scripts/db/roles.sql
@@ -1,0 +1,56 @@
+-- BeCoMe -- database role provisioning (idempotent, version-controlled source of truth)
+--
+-- Captures the least-privilege role setup that is provisioned on each Railway Postgres.
+-- Safe to re-run. Apply per environment as the Railway superuser (`postgres`), e.g.:
+--     psql "$SUPERUSER_DATABASE_URL" -f scripts/db/roles.sql
+--
+-- Role model -- two connection URLs, no SET ROLE switching:
+--   * become_app -- least-privilege RUNTIME role used by DATABASE_URL.
+--                   DML only, no DDL: NOSUPERUSER / NOCREATEDB / NOCREATEROLE / NOBYPASSRLS.
+--   * postgres   -- the Railway-provisioned superuser, used by MIGRATION_DATABASE_URL for
+--                   Alembic DDL. Railway gives exactly one superuser, so we do not add a
+--                   separate `migrator` role (it would require an ownership refactor for no
+--                   meaningful gain). `postgres` is managed by Railway and is never created
+--                   or altered here.
+--
+-- Passwords are NOT stored in this file -- they live in Railway variables. On a fresh
+-- provision, set the password out of band after running this script:
+--     ALTER ROLE become_app PASSWORD '<value from Railway>';
+
+-- 1. Least-privilege runtime role -------------------------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'become_app') THEN
+    CREATE ROLE become_app LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOBYPASSRLS;
+  END IF;
+END
+$$;
+
+-- Re-assert the privilege flags in case the role pre-existed with different attributes.
+ALTER ROLE become_app NOSUPERUSER NOCREATEDB NOCREATEROLE NOBYPASSRLS;
+
+-- 2. Connect + schema usage (deliberately NO create) ------------------------------
+-- Database name is the Railway default `railway`; adjust if an environment differs.
+GRANT CONNECT ON DATABASE railway TO become_app;
+GRANT USAGE ON SCHEMA public TO become_app;
+
+-- 3. DML on existing objects ------------------------------------------------------
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO become_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO become_app;
+
+-- 4. DML on FUTURE objects (Alembic creates tables as the `postgres` superuser) ----
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO become_app;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO become_app;
+
+-- 5. Lock down the public schema (PG15+ default; explicit for reproducibility) -----
+REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+
+-- 6. Deterministic search_path -- CVE-2018-1058 hardening for the exposed app role -
+ALTER ROLE become_app SET search_path = pg_catalog, public;
+
+-- 7. Resource limits at the role level (mirrors the client-side options= in engine.py)
+ALTER ROLE become_app SET statement_timeout = '30s';
+ALTER ROLE become_app SET idle_in_transaction_session_timeout = '60s';
+ALTER ROLE become_app SET lock_timeout = '10s';

--- a/tests/integration/api/db/test_cascade.py
+++ b/tests/integration/api/db/test_cascade.py
@@ -314,6 +314,7 @@ class TestUserCascadeDelete:
 
         token = PasswordResetToken(
             user_id=user.id,
+            token_hash="a" * 64,
             expires_at=datetime.now(UTC) + timedelta(hours=1),
         )
         session.add(token)

--- a/tests/integration/api/db/test_user_model.py
+++ b/tests/integration/api/db/test_user_model.py
@@ -1,7 +1,6 @@
 """Tests for User and PasswordResetToken models."""
 
 from datetime import UTC, datetime, timedelta
-from uuid import uuid4
 
 import pytest
 from pydantic import ValidationError

--- a/tests/integration/api/db/test_user_model.py
+++ b/tests/integration/api/db/test_user_model.py
@@ -109,6 +109,7 @@ class TestPasswordResetTokenModel:
         # WHEN
         token = PasswordResetToken(
             user_id=user.id,
+            token_hash="a" * 64,
             expires_at=datetime.now(UTC) + timedelta(hours=1),
         )
         session.add(token)
@@ -116,7 +117,7 @@ class TestPasswordResetTokenModel:
         session.refresh(token)
 
         # THEN
-        assert token.token is not None
+        assert token.token_hash == "a" * 64
         assert token.used_at is None
         assert token.user_id == user.id
 
@@ -131,20 +132,20 @@ class TestPasswordResetTokenModel:
         session.add(user)
         session.commit()
 
-        shared_token = uuid4()
+        shared_hash = "b" * 64
 
         token1 = PasswordResetToken(
             user_id=user.id,
-            token=shared_token,
+            token_hash=shared_hash,
             expires_at=datetime.now(UTC) + timedelta(hours=1),
         )
         session.add(token1)
         session.commit()
 
-        # WHEN/THEN - duplicate token should fail
+        # WHEN/THEN - duplicate token hash should fail
         token2 = PasswordResetToken(
             user_id=user.id,
-            token=shared_token,
+            token_hash=shared_hash,
             expires_at=datetime.now(UTC) + timedelta(hours=1),
         )
         session.add(token2)
@@ -165,10 +166,12 @@ class TestPasswordResetTokenModel:
         # WHEN - multiple tokens for same user (e.g., requested reset twice)
         token1 = PasswordResetToken(
             user_id=user.id,
+            token_hash="c" * 64,
             expires_at=datetime.now(UTC) + timedelta(hours=1),
         )
         token2 = PasswordResetToken(
             user_id=user.id,
+            token_hash="d" * 64,
             expires_at=datetime.now(UTC) + timedelta(hours=2),
         )
         session.add_all([token1, token2])


### PR DESCRIPTION
## Summary

Hardens the database security posture and version-controls the role setup that was provisioned out of band, after auditing the live databases against a Postgres security checklist. Most of the checklist turned out to be already satisfied; this PR closes the remaining gaps and captures the setup as code.

## What this changes

- **`scripts/db/roles.sql`** -- idempotent source of truth for the `become_app` least-privilege role: DML-only grants, default privileges that hand future Alembic tables to the app role, `REVOKE CREATE ON SCHEMA public FROM PUBLIC`, a pinned `search_path` (`pg_catalog, public`, closing CVE-2018-1058), and role-level timeouts. Validated idempotent against the dev database.
- **Password reset token is now hashed** -- `PasswordResetToken.token` (raw UUID) becomes `token_hash` (SHA-256 hex), so a database leak never exposes a usable token. Migration `f3a7c2b9d1e4`; the table is an empty scaffold and the reset flow is not implemented yet, so this is secure-by-default for when it is. Up/down migration validated on real Postgres.
- **`docs/security.md`** -- consolidated security posture and runbooks: role model, network exposure, audit logging, backups, and secret rotation.

## Audit result (already in place, confirmed live)

Introspection of the live database found most controls already satisfied: `become_app` is least-privilege (NOSUPERUSER, no DDL, DML-only grants), role-level timeouts and `ALTER DEFAULT PRIVILEGES` are set, inherited Supabase RLS is disabled on all tables, the prod and test public TCP proxies are closed, and passwords use SCRAM-SHA-256. The one role-level gap was the unpinned `search_path`, now closed by `roles.sql`. Connection-level audit logging (`log_connections`/`log_disconnections`, `log_statement=ddl`, slow-query >5s) is enabled via `ALTER SYSTEM`, which Railway's managed Postgres permits.

## Verification

- `ci-local.sh fast` green (924 Python + 688 frontend tests).
- `roles.sql` applies idempotently on dev; `search_path` set to `pg_catalog, public`; `become_app` stays NOSUPERUSER/NOCREATEDB/NOCREATEROLE/NOBYPASSRLS.
- Migration `f3a7c2b9d1e4` upgrade (`token` -> `token_hash`) and downgrade validated on dev Postgres.

## Follow-up (infra ops, not code -- handled outside this PR)

- Apply the `search_path` pin and audit-logging settings to test and prod.
- Close the dev-db public TCP proxy (last public DB exposure).
- Confirm Railway backup retention for prod-db and test-db.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the database security posture by version-controlling the `become_app` least-privilege role setup in an idempotent SQL script, replacing the raw `PasswordResetToken.token` UUID with a `token_hash` SHA-256 hex field (so a DB leak never exposes a usable token), and adding a consolidated security runbook.

- **`scripts/db/roles.sql`**: Idempotent role provisioning -- DML-only grants, `ALTER DEFAULT PRIVILEGES`, `REVOKE CREATE ON SCHEMA public FROM PUBLIC`, pinned `search_path` (CVE-2018-1058), and role-level timeouts; uses `current_database()` instead of a hardcoded name.
- **`migrations/.../f3a7c2b9d1e4`**: Drops the UUID `token` column and replaces it with `token_hash VARCHAR(64) NOT NULL UNIQUE`; symmetric upgrade/downgrade validated on the empty scaffold table.
- **`docs/security.md`**: New runbook covering role model, network exposure, audit logging, backups, and secret rotation procedures.

<h3>Confidence Score: 5/5</h3>

Safe to merge -- all changes are additive hardening with no runtime behaviour changes to existing flows.

The schema change replaces an unused UUID column with a hashed counterpart on an empty scaffold table; the migration is symmetric and the existing test suite covers uniqueness and cascade behaviour. The SQL provisioning script is idempotent and the only structural finding is a small overgrant of DML on `alembic_version`, which cannot be exploited for schema changes by the constrained `become_app` role.

No files require special attention, though the rotation runbook in `docs/security.md` contains a misleading reference to `roles.sql` that should be corrected before an operator follows it under pressure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/db/models.py | Replaces `token: UUID` with `token_hash: str` (min/max length 64) in `PasswordResetToken`; length constraint is correct but hex-format validation is missing. |
| migrations/versions/2026_05_30_2244-f3a7c2b9d1e4_hash_password_reset_token.py | Drops the `token` UUID column and adds `token_hash VARCHAR(64) NOT NULL UNIQUE`; upgrade and downgrade are symmetric and safe for the documented empty-scaffold table. |
| scripts/db/roles.sql | New idempotent role-provisioning script; uses `current_database()` to avoid hardcoded DB name; `GRANT ON ALL TABLES` is a minor overgrant that includes `alembic_version`. |
| docs/security.md | New security runbook covering roles, network exposure, audit logging, backups, and secret rotation; rotation runbook step 1 incorrectly references `roles.sql` for a differently-named role. |
| tests/integration/api/db/test_cascade.py | Adds `token_hash="a" * 64` to the cascade test fixture; straightforward mechanical update, no issues. |
| tests/integration/api/db/test_user_model.py | Updates `PasswordResetToken` tests to use `token_hash` with distinct 64-char strings; uniqueness and multi-token tests are correctly updated. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant ResetFlow as Reset Flow (future)
    participant DB as PostgreSQL

    Note over ResetFlow,DB: Token generation (not yet implemented)
    Client->>ResetFlow: Request password reset
    ResetFlow->>ResetFlow: "raw = secrets.token_urlsafe()"
    ResetFlow->>Client: Email raw token
    ResetFlow->>ResetFlow: "hash = sha256(raw.encode()).hexdigest()"
    ResetFlow->>DB: "INSERT token_hash=hash INTO password_reset_tokens"

    Note over ResetFlow,DB: Token validation (not yet implemented)
    Client->>ResetFlow: Submit raw token from email
    ResetFlow->>ResetFlow: "hash = sha256(raw.encode()).hexdigest()"
    ResetFlow->>DB: "SELECT * WHERE token_hash=hash AND used_at IS NULL"
    DB-->>ResetFlow: Token row (or not found)
    ResetFlow->>DB: "UPDATE used_at=now() WHERE token_hash=hash"
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
api/db/models.py:212-213
The `token_hash` field is constrained to exactly 64 characters but not to lowercase hex characters. The comment and docstring both say "SHA-256 hex digest", so a 64-char string that contains non-hex bytes (e.g. `"z" * 64`) would pass Pydantic validation today. Adding a `pattern` constraint ties the schema to its stated invariant and will surface a missing-hash bug at the model layer rather than silently storing garbage when the reset flow is wired up.

```suggestion
    # SHA-256 hex digest of the raw token (exactly 64 lowercase hex chars); the raw token is never stored.
    token_hash: str = Field(unique=True, index=True, min_length=64, max_length=64, pattern=r"^[0-9a-f]{64}$")
```

### Issue 2 of 3
scripts/db/roles.sql:43-44
`GRANT ... ON ALL TABLES IN SCHEMA public` hands `become_app` full DML on `alembic_version` as well as the application tables. A compromised app credential could INSERT or DELETE rows in `alembic_version`, causing Alembic to skip or re-apply migrations on the next deploy. Excluding it with an explicit exclusion or simply noting it as a known overgrant would make the intent clearer.

### Issue 3 of 3
docs/security.md:68-71
The rotation runbook tells the operator to "apply the `scripts/db/roles.sql` grants to it" for `become_app_v2`, but `roles.sql` is unconditionally scoped to the `become_app` role name throughout. Running it as-is would modify the live `become_app` instead of the new `become_app_v2`, leaving the replacement role without the required grants. The runbook should either say to run the script with a substituted role name or drop the reference to `roles.sql` entirely in favour of the already-present parenthetical "(or set its password and copy the grants)".

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: address ci formatting and review ..."](https://github.com/caitlon/become/commit/99686142296a0430a7005de7b4730ccbf87b6fd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34745096)</sub>

<!-- /greptile_comment -->