### PR TITLE
chore: add manual db backup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ examples/visualizations/*/output/
 # Deployment logs
 logs/
 logs.zip
+
+# Database backups (contain user data -- never commit)
+/backups/

--- a/docs/security.md
+++ b/docs/security.md
@@ -61,10 +61,24 @@ workable substitute.
 
 ## Backups
 
-Railway takes scheduled volume backups of each Postgres service. Confirm the schedule and
-retention for `prod-db` (and `test-db`) under the service's **Backups** tab in the Railway
-dashboard, and keep a periodic restore drill -- the Supabase-to-Railway migration recipe in
-`environments.md` doubles as the restore procedure, since it is the same dump/restore path.
+Railway's managed backups require the Pro plan, so on the current (free) plan the Postgres
+volumes are **not** backed up automatically. Until that changes, take manual dumps with
+`scripts/db/backup.sh`, which opens a temporary proxy, runs `pg_dump`, and removes the proxy
+again:
+
+```bash
+./scripts/db/backup.sh prod      # writes backups/prod-<timestamp>.dump
+```
+
+Run it before risky migrations and on a regular cadence. The dumps stay out of the repo
+(`backups/` is gitignored -- they contain user data). Restore into any database with:
+
+```bash
+pg_restore --no-owner --no-privileges -d <target-url> backups/<dump>
+```
+
+Upgrading the prod service to the Railway Pro plan would replace this with scheduled backups
+plus point-in-time recovery.
 
 ## Secret rotation
 

--- a/scripts/db/backup.sh
+++ b/scripts/db/backup.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Manual pg_dump backup of a BeCoMe database.
+#
+# Railway's native backups require the Pro plan, so this is the free fallback: it
+# temporarily opens a public TCP proxy on the chosen database, runs pg_dump over it,
+# and ALWAYS removes the proxy again (even on error). Run it before risky changes and
+# periodically; store the dumps somewhere safe -- they contain user data.
+#
+#   Usage:  ./scripts/db/backup.sh [prod|test|dev]      (default: prod)
+#   Output: backups/<env>-<UTC-timestamp>.dump  (custom format)
+#   Restore: pg_restore --no-owner --no-privileges -d <target-url> <dump>
+#
+# Requires: the Railway CLI logged in (token read from ~/.railway/config.json),
+# plus jq and a current pg_dump (>= the server; `brew install libpq` provides one).
+set -uo pipefail
+
+ENV_ARG="${1:-prod}"
+case "$ENV_ARG" in
+  prod) RW_ENV="production"; DB_SVC="prod-db" ;;
+  test) RW_ENV="staging";    DB_SVC="test-db" ;;
+  dev)  RW_ENV="dev";        DB_SVC="dev-db" ;;
+  *) echo "usage: $0 [prod|test|dev]"; exit 1 ;;
+esac
+
+PROJECT_ID="ac3f7cfe-3f92-43bf-9e0c-c70075883469"
+TOKEN=$(python3 -c "import json,os;print(json.load(open(os.path.expanduser('~/.railway/config.json')))['user']['accessToken'])" 2>/dev/null)
+[ -z "$TOKEN" ] && { echo "No Railway token -- run 'railway login' (or 'railway whoami' to refresh)"; exit 1; }
+gql() { curl -s -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" https://backboard.railway.com/graphql/v2 -d "$1"; }
+
+# Resolve environment + service ids by name.
+META=$(gql "$(jq -n --arg id "$PROJECT_ID" '{query:"query($id:String!){project(id:$id){environments{edges{node{id name}}}services{edges{node{id name}}}}}",variables:{id:$id}}')")
+ENV_ID=$(printf '%s' "$META" | jq -r --arg n "$RW_ENV" '.data.project.environments.edges[].node | select(.name==$n) | .id')
+SVC_ID=$(printf '%s' "$META" | jq -r --arg n "$DB_SVC" '.data.project.services.edges[].node | select(.name==$n) | .id')
+{ [ -z "$ENV_ID" ] || [ -z "$SVC_ID" ]; } && { echo "could not resolve $RW_ENV / $DB_SVC"; exit 1; }
+
+# Password + database name from the internal DATABASE_URL (the password is shared with the proxy).
+INTURL=$(gql "$(jq -n --arg p "$PROJECT_ID" --arg e "$ENV_ID" --arg s "$SVC_ID" '{query:"query($p:String!,$e:String!,$s:String!){variables(projectId:$p,environmentId:$e,serviceId:$s)}",variables:{p:$p,e:$e,s:$s}}')" | jq -r '.data.variables.DATABASE_URL // empty')
+[ -z "$INTURL" ] && { echo "no DATABASE_URL for $DB_SVC"; exit 1; }
+PW=$(printf '%s' "$INTURL" | sed -E 's#^postgres(ql)?://[^:]+:([^@]+)@.*#\2#')
+DBN=$(printf '%s' "$INTURL" | sed -E 's#.*/([^/?]+)(\?.*)?$#\1#')
+
+# Open a temporary public proxy and ALWAYS remove it on exit.
+CR=$(gql "$(jq -n --arg e "$ENV_ID" --arg s "$SVC_ID" '{query:"mutation($i:TCPProxyCreateInput!){tcpProxyCreate(input:$i){id domain proxyPort}}",variables:{i:{environmentId:$e,serviceId:$s,applicationPort:5432}}}')")
+PROXY_ID=$(printf '%s' "$CR" | jq -r '.data.tcpProxyCreate.id // empty')
+DOMAIN=$(printf '%s' "$CR" | jq -r '.data.tcpProxyCreate.domain // empty')
+PORT=$(printf '%s' "$CR" | jq -r '.data.tcpProxyCreate.proxyPort // empty')
+[ -z "$PROXY_ID" ] && { echo "proxy create failed: $CR"; exit 1; }
+cleanup() { gql "$(jq -n --arg id "$PROXY_ID" '{query:"mutation($id:String!){tcpProxyDelete(id:$id)}",variables:{id:$id}}')" >/dev/null; echo "temporary proxy removed"; }
+trap cleanup EXIT
+echo "temporary proxy open on $DOMAIN:$PORT"
+
+PG_DUMP=/opt/homebrew/opt/libpq/bin/pg_dump
+command -v "$PG_DUMP" >/dev/null 2>&1 || PG_DUMP=pg_dump
+URL="postgresql://postgres:$PW@$DOMAIN:$PORT/$DBN?sslmode=require&connect_timeout=10"
+
+mkdir -p backups
+OUT="backups/${ENV_ARG}-$(date -u +%Y%m%dT%H%M%SZ).dump"
+ok=""
+for i in $(seq 1 6); do
+  if "$PG_DUMP" "$URL" --no-owner --no-privileges -Fc -f "$OUT" 2>/tmp/become_pgdump.err; then ok=1; break; fi
+  echo "  (proxy warming up, retry $i)..."; sleep 5
+done
+[ -z "$ok" ] && { echo "pg_dump failed:"; cat /tmp/become_pgdump.err; exit 1; }
+echo "OK: $OUT ($(du -h "$OUT" | cut -f1))"
+echo "restore: pg_restore --no-owner --no-privileges -d <target-url> $OUT"

--- a/scripts/db/backup.sh
+++ b/scripts/db/backup.sh
@@ -10,8 +10,8 @@
 #   Output: backups/<env>-<UTC-timestamp>.dump  (custom format)
 #   Restore: pg_restore --no-owner --no-privileges -d <target-url> <dump>
 #
-# Requires: the Railway CLI logged in (token read from ~/.railway/config.json),
-# plus jq and a current pg_dump (>= the server; `brew install libpq` provides one).
+# Requires: the Railway CLI logged in and linked (or RAILWAY_PROJECT_ID set), plus jq
+# and a current pg_dump (>= the server; `brew install libpq` provides one).
 set -uo pipefail
 
 ENV_ARG="${1:-prod}"
@@ -22,10 +22,21 @@ case "$ENV_ARG" in
   *) echo "usage: $0 [prod|test|dev]"; exit 1 ;;
 esac
 
-PROJECT_ID="ac3f7cfe-3f92-43bf-9e0c-c70075883469"
+# Project id from the linked Railway project; override with RAILWAY_PROJECT_ID.
+PROJECT_ID="${RAILWAY_PROJECT_ID:-$(railway status --json 2>/dev/null | jq -r '.id // empty')}"
+[ -z "$PROJECT_ID" ] && { echo "Set RAILWAY_PROJECT_ID, or run 'railway link' in this repo first"; exit 1; }
 TOKEN=$(python3 -c "import json,os;print(json.load(open(os.path.expanduser('~/.railway/config.json')))['user']['accessToken'])" 2>/dev/null)
 [ -z "$TOKEN" ] && { echo "No Railway token -- run 'railway login' (or 'railway whoami' to refresh)"; exit 1; }
 gql() { curl -s -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" https://backboard.railway.com/graphql/v2 -d "$1"; }
+
+# Always clean up: remove the temporary proxy (if opened) and the stderr scratch file.
+ERRFILE=$(mktemp)
+PROXY_ID=""
+cleanup() {
+  [ -n "$PROXY_ID" ] && gql "$(jq -n --arg id "$PROXY_ID" '{query:"mutation($id:String!){tcpProxyDelete(id:$id)}",variables:{id:$id}}')" >/dev/null && echo "temporary proxy removed"
+  rm -f "$ERRFILE"
+}
+trap cleanup EXIT
 
 # Resolve environment + service ids by name.
 META=$(gql "$(jq -n --arg id "$PROJECT_ID" '{query:"query($id:String!){project(id:$id){environments{edges{node{id name}}}services{edges{node{id name}}}}}",variables:{id:$id}}')")
@@ -33,33 +44,32 @@ ENV_ID=$(printf '%s' "$META" | jq -r --arg n "$RW_ENV" '.data.project.environmen
 SVC_ID=$(printf '%s' "$META" | jq -r --arg n "$DB_SVC" '.data.project.services.edges[].node | select(.name==$n) | .id')
 { [ -z "$ENV_ID" ] || [ -z "$SVC_ID" ]; } && { echo "could not resolve $RW_ENV / $DB_SVC"; exit 1; }
 
-# Password + database name from the internal DATABASE_URL (the password is shared with the proxy).
+# Password + database name from the internal DATABASE_URL (password is shared with the proxy).
 INTURL=$(gql "$(jq -n --arg p "$PROJECT_ID" --arg e "$ENV_ID" --arg s "$SVC_ID" '{query:"query($p:String!,$e:String!,$s:String!){variables(projectId:$p,environmentId:$e,serviceId:$s)}",variables:{p:$p,e:$e,s:$s}}')" | jq -r '.data.variables.DATABASE_URL // empty')
 [ -z "$INTURL" ] && { echo "no DATABASE_URL for $DB_SVC"; exit 1; }
 PW=$(printf '%s' "$INTURL" | sed -E 's#^postgres(ql)?://[^:]+:([^@]+)@.*#\2#')
 DBN=$(printf '%s' "$INTURL" | sed -E 's#.*/([^/?]+)(\?.*)?$#\1#')
 
-# Open a temporary public proxy and ALWAYS remove it on exit.
+# Open a temporary public proxy (torn down by the trap above).
 CR=$(gql "$(jq -n --arg e "$ENV_ID" --arg s "$SVC_ID" '{query:"mutation($i:TCPProxyCreateInput!){tcpProxyCreate(input:$i){id domain proxyPort}}",variables:{i:{environmentId:$e,serviceId:$s,applicationPort:5432}}}')")
 PROXY_ID=$(printf '%s' "$CR" | jq -r '.data.tcpProxyCreate.id // empty')
 DOMAIN=$(printf '%s' "$CR" | jq -r '.data.tcpProxyCreate.domain // empty')
 PORT=$(printf '%s' "$CR" | jq -r '.data.tcpProxyCreate.proxyPort // empty')
 [ -z "$PROXY_ID" ] && { echo "proxy create failed: $CR"; exit 1; }
-cleanup() { gql "$(jq -n --arg id "$PROXY_ID" '{query:"mutation($id:String!){tcpProxyDelete(id:$id)}",variables:{id:$id}}')" >/dev/null; echo "temporary proxy removed"; }
-trap cleanup EXIT
 echo "temporary proxy open on $DOMAIN:$PORT"
 
 PG_DUMP=/opt/homebrew/opt/libpq/bin/pg_dump
 command -v "$PG_DUMP" >/dev/null 2>&1 || PG_DUMP=pg_dump
-URL="postgresql://postgres:$PW@$DOMAIN:$PORT/$DBN?sslmode=require&connect_timeout=10"
+# Password goes through PGPASSWORD so it never appears in the process arguments (ps aux).
+URL="postgresql://postgres@$DOMAIN:$PORT/$DBN?sslmode=require&connect_timeout=10"
 
 mkdir -p backups
 OUT="backups/${ENV_ARG}-$(date -u +%Y%m%dT%H%M%SZ).dump"
 ok=""
 for i in $(seq 1 6); do
-  if "$PG_DUMP" "$URL" --no-owner --no-privileges -Fc -f "$OUT" 2>/tmp/become_pgdump.err; then ok=1; break; fi
+  if PGPASSWORD="$PW" "$PG_DUMP" "$URL" --no-owner --no-privileges -Fc -f "$OUT" 2>"$ERRFILE"; then ok=1; break; fi
   echo "  (proxy warming up, retry $i)..."; sleep 5
 done
-[ -z "$ok" ] && { echo "pg_dump failed:"; cat /tmp/become_pgdump.err; exit 1; }
+[ -z "$ok" ] && { echo "pg_dump failed:"; cat "$ERRFILE"; exit 1; }
 echo "OK: $OUT ($(du -h "$OUT" | cut -f1))"
 echo "restore: pg_restore --no-owner --no-privileges -d <target-url> $OUT"


### PR DESCRIPTION
## Summary

Closes the one real gap found in the database security review: the prod Postgres volume has **no backups** (Railway's managed backups require the Pro plan).

- **`scripts/db/backup.sh`** -- one-command manual `pg_dump` backup for any environment. It opens a temporary TCP proxy on the chosen database, dumps with `pg_dump -Fc`, and **always removes the proxy again** (even on error). Usage: `./scripts/db/backup.sh prod`.
- **`docs/security.md`** -- the Backups section was inaccurate (it claimed Railway backs up the volumes). Corrected to describe the free manual path and the restore command, and notes that the Pro plan would add scheduled backups + point-in-time recovery.
- **`.gitignore`** -- ignores `backups/` so dumps (which contain user data) never land in the repo.

## Notes

- The script could not be run end-to-end from CI/here (opening a proxy on a shared database is gated), but it is syntax-checked and reuses the temp-proxy pattern already validated against the live databases. First run will confirm it; the proxy is always torn down.
- No application code changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the backup gap identified in the database security review by adding a manual `pg_dump` script for Railway-hosted Postgres instances, correcting inaccurate documentation that claimed Railway auto-backs up volumes (it does not on the free plan), and gitignoring the `backups/` directory so dumps never land in version control.

- **`scripts/db/backup.sh`**: Opens a temporary Railway TCP proxy, dumps with `pg_dump -Fc` via `PGPASSWORD` (password never in process args), and removes the proxy unconditionally via an `EXIT` trap; uses `mktemp` for the error scratch file and resolves `PROJECT_ID` dynamically.
- **`docs/security.md`**: Replaces the stale "Railway takes scheduled backups" claim with accurate guidance — manual dump command, restore command, and a note that upgrading to Pro would add scheduled + PITR backups.
- **`.gitignore`**: Adds root-anchored `/backups/` with an inline note explaining the sensitivity of the dumps.

<h3>Confidence Score: 5/5</h3>

Safe to merge — adds an optional utility script and corrects docs with no application code changes.

All three security concerns raised in the previous review round have been addressed: the password is passed via PGPASSWORD (not in the process argument list), the error scratch file uses mktemp, and the project ID is resolved dynamically rather than hardcoded. The only remaining finding is a minor retry-loop inefficiency that does not affect correctness or security.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/db/backup.sh | New backup script using Railway GraphQL API; all three previously flagged security issues (password in process table, predictable error file, hardcoded project ID) have been addressed. Minor: sleep 5 runs after the last failed retry attempt. |
| docs/security.md | Corrects the Backups section from an inaccurate claim (Railway auto-backups) to accurate manual-backup guidance; restore command and gitignore note are correct. |
| .gitignore | Adds root-anchored /backups/ entry with an explanatory comment; prevents dump files containing user data from being committed. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([backup.sh start]) --> B{RAILWAY_PROJECT_ID set?}
    B -- yes --> D
    B -- no --> C[railway status --json]
    C --> D{PROJECT_ID resolved?}
    D -- no --> ERR1([exit 1])
    D -- yes --> E[Read TOKEN from ~/.railway/config.json]
    E --> F{TOKEN present?}
    F -- no --> ERR2([exit 1])
    F -- yes --> G[GraphQL: resolve ENV_ID + SVC_ID]
    G --> H{IDs found?}
    H -- no --> ERR3([exit 1])
    H -- yes --> I[GraphQL: fetch DATABASE_URL, extract PW + DBN]
    I --> J[GraphQL: tcpProxyCreate, get DOMAIN + PORT]
    J --> K{PROXY_ID set?}
    K -- no --> ERR4([exit 1])
    K -- yes --> L[retry loop up to 6x, PGPASSWORD pg_dump -Fc]
    L -- success --> M[echo OK + restore hint]
    L -- all failed --> N[echo pg_dump failed, cat ERRFILE]
    M --> TRAP
    N --> TRAP
    ERR1 --> TRAP
    ERR2 --> TRAP
    ERR3 --> TRAP
    ERR4 --> TRAP
    TRAP([EXIT trap: tcpProxyDelete + rm ERRFILE])
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
scripts/db/backup.sh:70-71
`sleep 5` runs even after the 6th (final) failed attempt, adding a needless 5-second wait before the failure is reported. On a complete proxy-warm-up timeout the script takes 30 s instead of 25 s before printing the error.

```suggestion
  if PGPASSWORD="$PW" "$PG_DUMP" "$URL" --no-owner --no-privileges -Fc -f "$OUT" 2>"$ERRFILE"; then ok=1; break; fi
  [ "$i" -lt 6 ] && { echo "  (proxy warming up, retry $i)..."; sleep 5; }
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: harden backup script credential h..."](https://github.com/caitlon/become/commit/a1271d57573db03c25849eaf23b711033de73558) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34750380)</sub>

<!-- /greptile_comment -->