### PR TITLE
fix: read backup db password from PGPASSWORD var

### DIFF
--- a/scripts/db/backup.sh
+++ b/scripts/db/backup.sh
@@ -27,32 +27,40 @@ PROJECT_ID="${RAILWAY_PROJECT_ID:-$(railway status --json 2>/dev/null | jq -r '.
 [ -z "$PROJECT_ID" ] && { echo "Set RAILWAY_PROJECT_ID, or run 'railway link' in this repo first"; exit 1; }
 TOKEN=$(python3 -c "import json,os;print(json.load(open(os.path.expanduser('~/.railway/config.json')))['user']['accessToken'])" 2>/dev/null)
 [ -z "$TOKEN" ] && { echo "No Railway token -- run 'railway login' (or 'railway whoami' to refresh)"; exit 1; }
-gql() { curl -s -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" https://backboard.railway.com/graphql/v2 -d "$1"; }
+
+# GraphQL helper. The query is passed to jq as DATA (--arg), never embedded in the jq
+# program, so the braces/`$vars` in the query can't be mis-parsed by any jq version.
+api() {  # $1 = query/mutation string; $2 = variables JSON object (default {})
+  local vars="${2:-}"; [ -z "$vars" ] && vars='{}'
+  curl -s -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    https://backboard.railway.com/graphql/v2 \
+    -d "$(jq -n --arg q "$1" --argjson v "$vars" '{query:$q,variables:$v}')"
+}
 
 # Always clean up: remove the temporary proxy (if opened) and the stderr scratch file.
 ERRFILE=$(mktemp)
 PROXY_ID=""
 cleanup() {
-  [ -n "$PROXY_ID" ] && gql "$(jq -n --arg id "$PROXY_ID" '{query:"mutation($id:String!){tcpProxyDelete(id:$id)}",variables:{id:$id}}')" >/dev/null && echo "temporary proxy removed"
+  [ -n "$PROXY_ID" ] && api 'mutation($id:String!){tcpProxyDelete(id:$id)}' "$(jq -n --arg id "$PROXY_ID" '{id:$id}')" >/dev/null && echo "temporary proxy removed"
   rm -f "$ERRFILE"
 }
 trap cleanup EXIT
 
 # Resolve environment + service ids by name.
-META=$(gql "$(jq -n --arg id "$PROJECT_ID" '{query:"query($id:String!){project(id:$id){environments{edges{node{id name}}}services{edges{node{id name}}}}}",variables:{id:$id}}')")
+META=$(api 'query($id:String!){project(id:$id){environments{edges{node{id name}}}services{edges{node{id name}}}}}' "$(jq -n --arg id "$PROJECT_ID" '{id:$id}')")
 ENV_ID=$(printf '%s' "$META" | jq -r --arg n "$RW_ENV" '.data.project.environments.edges[].node | select(.name==$n) | .id')
 SVC_ID=$(printf '%s' "$META" | jq -r --arg n "$DB_SVC" '.data.project.services.edges[].node | select(.name==$n) | .id')
 { [ -z "$ENV_ID" ] || [ -z "$SVC_ID" ]; } && { echo "could not resolve $RW_ENV / $DB_SVC"; exit 1; }
 
 # Password + database name from the service's canonical Postgres variables.
-VARS=$(gql "$(jq -n --arg p "$PROJECT_ID" --arg e "$ENV_ID" --arg s "$SVC_ID" '{query:"query($p:String!,$e:String!,$s:String!){variables(projectId:$p,environmentId:$e,serviceId:$s)}",variables:{p:$p,e:$e,s:$s}}')")
+VARS=$(api 'query($p:String!,$e:String!,$s:String!){variables(projectId:$p,environmentId:$e,serviceId:$s)}' "$(jq -n --arg p "$PROJECT_ID" --arg e "$ENV_ID" --arg s "$SVC_ID" '{p:$p,e:$e,s:$s}')")
 printf '%s' "$VARS" | jq -e '.errors' >/dev/null 2>&1 && { echo "Railway API error: $(printf '%s' "$VARS" | jq -c '.errors')"; exit 1; }
 PW=$(printf '%s' "$VARS" | jq -r '.data.variables.PGPASSWORD // .data.variables.POSTGRES_PASSWORD // empty')
 DBN=$(printf '%s' "$VARS" | jq -r '.data.variables.PGDATABASE // .data.variables.POSTGRES_DB // "railway"')
 [ -z "$PW" ] && { echo "could not read DB password for $DB_SVC (got vars: $(printf '%s' "$VARS" | jq -r '.data.variables|keys|join(",")' 2>/dev/null))"; exit 1; }
 
 # Open a temporary public proxy (torn down by the trap above).
-CR=$(gql "$(jq -n --arg e "$ENV_ID" --arg s "$SVC_ID" '{query:"mutation($i:TCPProxyCreateInput!){tcpProxyCreate(input:$i){id domain proxyPort}}",variables:{i:{environmentId:$e,serviceId:$s,applicationPort:5432}}}')")
+CR=$(api 'mutation($i:TCPProxyCreateInput!){tcpProxyCreate(input:$i){id domain proxyPort}}' "$(jq -n --arg e "$ENV_ID" --arg s "$SVC_ID" '{i:{environmentId:$e,serviceId:$s,applicationPort:5432}}')")
 PROXY_ID=$(printf '%s' "$CR" | jq -r '.data.tcpProxyCreate.id // empty')
 DOMAIN=$(printf '%s' "$CR" | jq -r '.data.tcpProxyCreate.domain // empty')
 PORT=$(printf '%s' "$CR" | jq -r '.data.tcpProxyCreate.proxyPort // empty')

--- a/scripts/db/backup.sh
+++ b/scripts/db/backup.sh
@@ -44,11 +44,12 @@ ENV_ID=$(printf '%s' "$META" | jq -r --arg n "$RW_ENV" '.data.project.environmen
 SVC_ID=$(printf '%s' "$META" | jq -r --arg n "$DB_SVC" '.data.project.services.edges[].node | select(.name==$n) | .id')
 { [ -z "$ENV_ID" ] || [ -z "$SVC_ID" ]; } && { echo "could not resolve $RW_ENV / $DB_SVC"; exit 1; }
 
-# Password + database name from the internal DATABASE_URL (password is shared with the proxy).
-INTURL=$(gql "$(jq -n --arg p "$PROJECT_ID" --arg e "$ENV_ID" --arg s "$SVC_ID" '{query:"query($p:String!,$e:String!,$s:String!){variables(projectId:$p,environmentId:$e,serviceId:$s)}",variables:{p:$p,e:$e,s:$s}}')" | jq -r '.data.variables.DATABASE_URL // empty')
-[ -z "$INTURL" ] && { echo "no DATABASE_URL for $DB_SVC"; exit 1; }
-PW=$(printf '%s' "$INTURL" | sed -E 's#^postgres(ql)?://[^:]+:([^@]+)@.*#\2#')
-DBN=$(printf '%s' "$INTURL" | sed -E 's#.*/([^/?]+)(\?.*)?$#\1#')
+# Password + database name from the service's canonical Postgres variables.
+VARS=$(gql "$(jq -n --arg p "$PROJECT_ID" --arg e "$ENV_ID" --arg s "$SVC_ID" '{query:"query($p:String!,$e:String!,$s:String!){variables(projectId:$p,environmentId:$e,serviceId:$s)}",variables:{p:$p,e:$e,s:$s}}')")
+printf '%s' "$VARS" | jq -e '.errors' >/dev/null 2>&1 && { echo "Railway API error: $(printf '%s' "$VARS" | jq -c '.errors')"; exit 1; }
+PW=$(printf '%s' "$VARS" | jq -r '.data.variables.PGPASSWORD // .data.variables.POSTGRES_PASSWORD // empty')
+DBN=$(printf '%s' "$VARS" | jq -r '.data.variables.PGDATABASE // .data.variables.POSTGRES_DB // "railway"')
+[ -z "$PW" ] && { echo "could not read DB password for $DB_SVC (got vars: $(printf '%s' "$VARS" | jq -r '.data.variables|keys|join(",")' 2>/dev/null))"; exit 1; }
 
 # Open a temporary public proxy (torn down by the trap above).
 CR=$(gql "$(jq -n --arg e "$ENV_ID" --arg s "$SVC_ID" '{query:"mutation($i:TCPProxyCreateInput!){tcpProxyCreate(input:$i){id domain proxyPort}}",variables:{i:{environmentId:$e,serviceId:$s,applicationPort:5432}}}')")


### PR DESCRIPTION
backup.sh failed with "no DATABASE_URL for prod-db" when the variables fetch returned no DATABASE_URL. It now reads the password from the canonical PGPASSWORD variable (always present on a Railway Postgres) with a POSTGRES_PASSWORD fallback, surfaces Railway API errors instead of masking them as a missing var, and lists the available variable names on failure for debugging. No behaviour change on the happy path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a `backup.sh` crash ("no DATABASE_URL for prod-db") by replacing `DATABASE_URL` URL-parsing with direct lookups of the canonical Railway Postgres environment variables (`PGPASSWORD`/`POSTGRES_PASSWORD` and `PGDATABASE`/`POSTGRES_DB`). It also refactors the raw `gql` curl helper into a cleaner `api()` function that passes the query as a `--arg` rather than embedding it in jq, and adds an explicit `.errors` check on the variables API response.

- **Password resolution**: Reads `PGPASSWORD` (with `POSTGRES_PASSWORD` fallback) directly from Railway service variables instead of parsing `DATABASE_URL` with sed; when no password is found, prints available variable names for debugging.
- **`api()` helper**: Accepts the query string and a variables JSON object as separate arguments, avoiding jq-parsing ambiguity from embedded GraphQL braces.
- **Error surfacing**: The variables API response is now checked for a `.errors` field before proceeding, so Railway-side errors produce a meaningful message instead of a confusing "no DATABASE_URL" failure.

<h3>Confidence Score: 5/5</h3>

The change is narrowly scoped to credential resolution — the happy path is unaffected and the new code adds a safety net rather than removing one.

No new bugs were introduced beyond the two issues already raised in prior review threads. The api() helper correctly isolates query strings from jq parsing, and the PGPASSWORD env-var injection into pg_dump avoids credentials in the process list.

scripts/db/backup.sh — the two items flagged in prior review threads (jq -e behaviour on an empty errors array, and the silent railway database-name fallback) remain open.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/db/backup.sh | Switches password+db-name resolution from DATABASE_URL parsing to individual Postgres env vars; adds GraphQL error surfacing for the variables query; refactors gql() into api(). Two issues flagged in previous review threads remain unresolved in this diff. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Op as Operator
    participant SH as backup.sh
    participant RW as Railway GraphQL API
    participant PG as Postgres (via TCP Proxy)

    Op->>SH: "./backup.sh [prod|test|dev]"
    SH->>SH: "resolve PROJECT_ID & TOKEN"
    SH->>RW: api: project(id) environments + services
    RW-->>SH: ENV_ID, SVC_ID
    SH->>RW: api: variables(project, env, service)
    RW-->>SH: PGPASSWORD / POSTGRES_PASSWORD, PGDATABASE / POSTGRES_DB
    SH->>SH: check .errors in response
    SH->>SH: "PW = PGPASSWORD fallback POSTGRES_PASSWORD"
    SH->>SH: "DBN = PGDATABASE fallback POSTGRES_DB fallback railway"
    SH->>RW: api: tcpProxyCreate(env, svc, port 5432)
    RW-->>SH: PROXY_ID, DOMAIN, PORT
    loop up to 6 retries
        SH->>PG: pg_dump via PGPASSWORD env var
        PG-->>SH: dump data or error
    end
    SH->>RW: api: tcpProxyDelete(PROXY_ID) EXIT trap
    SH-->>Op: backups/env-timestamp.dump
```

<sub>Reviews (2): Last reviewed commit: ["fix: build backup graphql request via jq..."](https://github.com/caitlon/become/commit/5294ab35d7dc2023c9bdbfe49c9a04dc18170c84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34778321)</sub>

<!-- /greptile_comment -->