### PR TITLE
chore: move flaky dependency audits out of lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,6 @@ jobs:
       - name: Install Python dependencies
         run: uv sync --locked --extra dev --extra api
 
-      # Security: dependency audit
-      - name: Audit Python dependencies
-        run: uv run pip-audit
-
       # Python linting
       - name: Check code formatting
         run: uv run ruff format --check .
@@ -56,14 +52,63 @@ jobs:
         working-directory: frontend
         run: npm ci
 
-      - name: Audit npm dependencies
-        working-directory: frontend
-        run: npm audit --omit=dev --audit-level=moderate
-
       # TypeScript linting
       - name: Run ESLint
         working-directory: frontend
         run: npm run lint
+
+  dependency-audit:
+    name: Dependency Audit
+    runs-on: ubuntu-24.04
+    # Network-bound audits (pip-audit -> pypi.org, npm audit -> npm registry) live here,
+    # not in the required "Code Quality Checks" job, so a transient registry timeout cannot
+    # fail the required lint check or skip the test jobs that depend on it. Retries absorb
+    # flaky network; a real vulnerability still fails the job after all attempts.
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.13.7
+
+      - name: Install Python dependencies
+        run: uv sync --locked --extra dev --extra api
+
+      - name: Audit Python dependencies (pip-audit)
+        run: |
+          for attempt in 1 2 3; do
+            uv run pip-audit --timeout 30 && exit 0
+            echo "::warning::pip-audit attempt $attempt failed (network?); retrying in 15s"
+            sleep 15
+          done
+          echo "::error::pip-audit failed after 3 attempts"
+          exit 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Audit npm dependencies
+        working-directory: frontend
+        run: |
+          for attempt in 1 2 3; do
+            npm audit --omit=dev --audit-level=moderate && exit 0
+            echo "::warning::npm audit attempt $attempt failed (network?); retrying in 15s"
+            sleep 15
+          done
+          echo "::error::npm audit failed after 3 attempts"
+          exit 1
 
   python-tests:
     name: Python Tests


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the `pip-audit` and `npm audit` steps from the required `lint` job into a new standalone `dependency-audit` job, and wraps each audit command in a 3-attempt retry loop to absorb transient registry timeouts. The intent is to prevent a flaky network call from blocking the lint gate and therefore the downstream test jobs.

- The new `dependency-audit` job is correctly decoupled from `lint` and from all test jobs, so a registry outage can no longer cascade into a CI blockage.
- The retry logic does not differentiate between a transient network error and an actual vulnerability finding — both cause a non-zero exit — so a real CVE triggers two unnecessary retries and ultimately surfaces under the misleading \"failed after 3 attempts (network?)\" banner rather than the audit tool's own report.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change correctly isolates flaky network calls from the required lint gate, and the overall CI flow remains sound.

The restructuring is straightforward and achieves its goal. The retry loops treat a real vulnerability finding the same as a network error, causing redundant retries and a misleading failure message, but the job still fails correctly when a CVE is present.

The retry logic in the dependency-audit job steps (lines 82-111) is worth a second look regarding how failures are surfaced to the team.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Moves pip-audit and npm audit from the lint job into a new independent dependency-audit job with 3-attempt retry loops; the retry logic does not distinguish transient network failures from genuine vulnerability findings, which can produce misleading output but does not affect overall correctness. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/ci.yml:102-111
**Retry loop can't distinguish network errors from vulnerability findings**

Both `npm audit` and `pip-audit` exit non-zero for *two* distinct reasons: a transient network error and an actual vulnerability finding. The retry loop treats both identically, so when a real CVE is detected the job will silently retry it twice more (burning ~30 s) before finally failing with the misleading banner `npm audit failed after 3 attempts` instead of the audit's own vulnerability report. The `(network?)` hint in the warning will actively mislead anyone trying to diagnose a real security hit.

The same logic applies to the `pip-audit` retry block above (lines 82-89).

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: move flaky dependency audits out of ..."](https://github.com/caitlon/become/commit/41952a4e856c7b6663817f41b384967c81337086) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36010275)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->