### PR TITLE
feat: add password reset flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,18 @@ DATABASE_URL=sqlite:///./become.db
 # BUCKET_ACCESS_KEY_ID=...
 # BUCKET_SECRET_ACCESS_KEY=...
 
+# Email (transactional password reset). When unset the provider is "console":
+# the reset link is logged, not sent, so the flow works offline in dev/CI/tests.
+# Set EMAIL_PROVIDER=http plus EMAIL_API_KEY to send for real via Resend.
+# FRONTEND_BASE_URL is the frontend origin used to build the reset link target.
+# EMAIL_PROVIDER=console
+# EMAIL_FROM=no-reply@become.app
+# EMAIL_FROM_NAME=BeCoMe
+# FRONTEND_BASE_URL=http://localhost:5173
+# PASSWORD_RESET_TOKEN_TTL_MINUTES=60
+# EMAIL_API_KEY=
+# EMAIL_API_URL=https://api.resend.com/emails
+
 # Logging
 # LOG_LEVEL sets verbosity (DEBUG/INFO/WARNING/ERROR/CRITICAL, case-insensitive);
 # default INFO. An unsupported value is rejected when settings load.

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -16,3 +16,11 @@ API_PUBLIC_URL=https://api.becomify.app
 
 # Railway injects bucket credentials when a bucket is attached to the service:
 # BUCKET_NAME / BUCKET_ENDPOINT / BUCKET_ACCESS_KEY_ID / BUCKET_SECRET_ACCESS_KEY
+
+# Email: send real password-reset mail via Resend. EMAIL_FROM must be on a domain
+# verified in Resend; FRONTEND_BASE_URL is the deployed frontend origin.
+EMAIL_PROVIDER=http
+EMAIL_API_KEY=
+EMAIL_FROM=no-reply@your-domain.example
+EMAIL_FROM_NAME=BeCoMe
+FRONTEND_BASE_URL=https://your-frontend.example

--- a/api/README.md
+++ b/api/README.md
@@ -74,6 +74,8 @@ api/
 | POST | `/api/v1/auth/login` | Login, get tokens |
 | POST | `/api/v1/auth/logout` | Revoke refresh token |
 | POST | `/api/v1/auth/refresh` | Refresh access token |
+| POST | `/api/v1/auth/forgot-password` | Request a password reset email |
+| POST | `/api/v1/auth/reset-password` | Reset password using a token |
 | GET | `/api/v1/auth/me` | Get current user profile |
 
 ### Users

--- a/api/auth/logging.py
+++ b/api/auth/logging.py
@@ -87,6 +87,40 @@ def log_password_change(user_id: UUID, request: "Request | None" = None) -> None
     )
 
 
+def log_password_reset_requested(email: str, request: "Request | None" = None) -> None:
+    """Log a password reset request (forgot-password).
+
+    :param email: Email address from the request
+    :param request: FastAPI request (for IP extraction)
+    """
+    ip = get_client_ip(request)
+    logger.info(
+        "Password reset requested",
+        extra={
+            "event": "password_reset_requested",
+            "email": email,
+            "ip": ip,
+        },
+    )
+
+
+def log_password_reset_completed(user_id: UUID, request: "Request | None" = None) -> None:
+    """Log a completed password reset.
+
+    :param user_id: User's ID
+    :param request: FastAPI request (for IP extraction)
+    """
+    ip = get_client_ip(request)
+    logger.info(
+        "Password reset completed",
+        extra={
+            "event": "password_reset_completed",
+            "user_id": str(user_id),
+            "ip": ip,
+        },
+    )
+
+
 def log_account_deletion(user_id: UUID, email: str, request: "Request | None" = None) -> None:
     """Log account deletion event.
 

--- a/api/config.py
+++ b/api/config.py
@@ -138,6 +138,19 @@ class Settings(BaseSettings):
     bucket_secret_access_key: str | None = None
     bucket_region: str = "auto"
 
+    # Email (transactional password reset). When the provider is "console" or the
+    # selected provider's credentials are unset, the reset link is logged rather
+    # than sent, so the flow still works offline in dev/CI/tests.
+    email_provider: Literal["console", "http"] = "console"
+    email_from: str = "no-reply@become.app"
+    email_from_name: str = "BeCoMe"
+    # Public base URL of the FRONTEND, used to build the reset link in emails.
+    frontend_base_url: str = "http://localhost:5173"
+    password_reset_token_ttl_minutes: int = 60
+    # HTTP transactional provider (Resend-style API).
+    email_api_key: str | None = None
+    email_api_url: str = "https://api.resend.com/emails"
+
     def __init__(self, **kwargs: Any) -> None:
         """Load ``.env`` then ``.env.<APP_ENV>`` and inject the resolved profile.
 
@@ -163,6 +176,19 @@ class Settings(BaseSettings):
             and self.bucket_access_key_id
             and self.bucket_secret_access_key
         )
+
+    @property
+    def email_enabled(self) -> bool:
+        """Check if a real email provider is fully configured.
+
+        The console provider always returns False: it logs reset links instead
+        of sending them, so it never counts as a real send.
+
+        :return: True when the HTTP provider is selected and its API key is set.
+        """
+        if self.email_provider == "http":
+            return bool(self.email_api_key)
+        return False
 
     @model_validator(mode="after")
     def _validate_production_invariants(self) -> "Settings":

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -17,8 +17,12 @@ from api.config import get_settings
 from api.db.models import Project
 from api.db.session import get_session
 from api.services.calculation_service import CalculationService
+from api.services.email.base import EmailSender
+from api.services.email.console_email_sender import ConsoleEmailSender
+from api.services.email.resend_email_sender import ResendEmailSender
 from api.services.invitation_service import InvitationService
 from api.services.opinion_service import OpinionService
+from api.services.password_reset_service import PasswordResetService
 from api.services.project_membership_service import ProjectMembershipService
 from api.services.project_query_service import ProjectQueryService
 from api.services.project_service import ProjectService
@@ -84,6 +88,29 @@ def get_calculation_service(
 def get_invitation_service(session: Annotated[Session, Depends(get_session)]) -> InvitationService:
     """Create InvitationService instance."""
     return InvitationService(session)
+
+
+def get_password_reset_service(
+    session: Annotated[Session, Depends(get_session)],
+) -> PasswordResetService:
+    """Create PasswordResetService instance."""
+    return PasswordResetService(session)
+
+
+def get_email_service() -> EmailSender:
+    """Create the email sender for the configured provider.
+
+    Always returns a usable sender: when the HTTP provider is selected and
+    configured it sends for real; otherwise it falls back to the console sender
+    that logs the link. The forgot-password flow must never 503 (that would leak
+    account existence), so there is no None / unconfigured branch here.
+
+    :return: An EmailSender implementation.
+    """
+    settings = get_settings()
+    if settings.email_provider == "http" and settings.email_enabled:
+        return ResendEmailSender(settings)
+    return ConsoleEmailSender(settings)
 
 
 def get_storage_service() -> StorageService | None:

--- a/api/exceptions.py
+++ b/api/exceptions.py
@@ -85,3 +85,12 @@ class ValuesOutOfRangeError(ValidationError):
 
 class ScaleRangeError(ValidationError):
     """Raised when scale_min >= scale_max."""
+
+
+# Password-reset exceptions
+class InvalidResetTokenError(ValidationError):
+    """Raised when a password reset token is unknown or already used."""
+
+
+class ResetTokenExpiredError(ValidationError):
+    """Raised when a password reset token has expired."""

--- a/api/middleware/exception_handlers.py
+++ b/api/middleware/exception_handlers.py
@@ -14,6 +14,7 @@ from api.auth.logging import log_login_failure
 from api.exceptions import (
     BeCoMeAPIError,
     InvalidCredentialsError,
+    InvalidResetTokenError,
     InvitationAlreadyUsedError,
     InvitationExpiredError,
     InvitationNotFoundError,
@@ -21,6 +22,7 @@ from api.exceptions import (
     NotFoundError,
     OpinionNotFoundError,
     ProjectNotFoundError,
+    ResetTokenExpiredError,
     ScaleRangeError,
     UserAlreadyMemberError,
     UserExistsError,
@@ -51,6 +53,9 @@ EXCEPTION_MAP: dict[type[BeCoMeAPIError], tuple[int, str | None]] = {
         status.HTTP_400_BAD_REQUEST,
         "Invitation has already been used",
     ),
+    # Same opaque message for invalid and expired so neither can be distinguished.
+    InvalidResetTokenError: (status.HTTP_400_BAD_REQUEST, "Invalid or expired reset token"),
+    ResetTokenExpiredError: (status.HTTP_400_BAD_REQUEST, "Invalid or expired reset token"),
     # 401 Unauthorized
     InvalidCredentialsError: (
         status.HTTP_401_UNAUTHORIZED,

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -192,9 +192,8 @@ async def forgot_password(
     :param email_service: Email sender
     :return: A fixed acknowledgement message
     """
-    raw_token = service.create_reset_token(data.email)
-    if raw_token is not None:
-        reset_url = f"{get_settings().frontend_base_url}/reset-password?token={raw_token}"
+    reset_url = service.create_reset_token(data.email)
+    if reset_url is not None:
         try:
             await email_service.send_password_reset(to_email=data.email, reset_url=reset_url)
         except EmailSendError:

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -4,6 +4,7 @@ Exception handling follows OCP: all exceptions are handled
 by centralized middleware, routes focus on business logic only.
 """
 
+import logging
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -18,14 +19,31 @@ from api.auth.jwt import (
     decode_refresh_token,
     revoke_token,
 )
-from api.auth.logging import log_login_success, log_registration
+from api.auth.logging import (
+    log_login_success,
+    log_password_reset_completed,
+    log_password_reset_requested,
+    log_registration,
+)
 from api.config import get_settings
-from api.dependencies import get_user_service
-from api.middleware.rate_limit import LIMIT_AUTH_ENDPOINTS, limiter
-from api.schemas.auth import RefreshTokenRequest, RegisterRequest, TokenResponse, UserResponse
+from api.dependencies import get_email_service, get_password_reset_service, get_user_service
+from api.middleware.rate_limit import LIMIT_AUTH_ENDPOINTS, LIMIT_PWD_RESET, limiter
+from api.schemas.auth import (
+    ForgotPasswordRequest,
+    RefreshTokenRequest,
+    RegisterRequest,
+    ResetPasswordRequest,
+    TokenResponse,
+    UserResponse,
+)
+from api.services.email.base import EmailSender
+from api.services.email.exceptions import EmailSendError
+from api.services.password_reset_service import PasswordResetService
 from api.services.user_service import UserService
 
 router = APIRouter(prefix="/api/v1/auth", tags=["auth"])
+
+logger = logging.getLogger("api.route.auth")
 
 
 @router.post(
@@ -147,6 +165,70 @@ def logout(
     :param token_payload: Current token payload from JWT
     """
     revoke_token(token_payload.jti)
+
+
+@router.post(
+    "/forgot-password",
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Request a password reset email",
+)
+@limiter.limit(LIMIT_PWD_RESET)
+async def forgot_password(
+    request: Request,
+    data: ForgotPasswordRequest,
+    service: Annotated[PasswordResetService, Depends(get_password_reset_service)],
+    email_service: Annotated[EmailSender, Depends(get_email_service)],
+) -> dict[str, str]:
+    """Start the password reset flow for the given email.
+
+    Always returns the same 202 response whether or not the email is registered,
+    so the endpoint cannot reveal which addresses have accounts. When a user
+    exists a reset link is emailed; send failures are swallowed for the same
+    reason. Rate limited to slow abuse.
+
+    :param request: FastAPI request (for rate limiting and logging)
+    :param data: Email to send the reset link to
+    :param service: Password reset service
+    :param email_service: Email sender
+    :return: A fixed acknowledgement message
+    """
+    raw_token = service.create_reset_token(data.email)
+    if raw_token is not None:
+        reset_url = f"{get_settings().frontend_base_url}/reset-password?token={raw_token}"
+        try:
+            await email_service.send_password_reset(to_email=data.email, reset_url=reset_url)
+        except EmailSendError:
+            logger.warning(
+                "Failed to send password reset email",
+                extra={"event": "password_reset_email_failed"},
+            )
+
+    log_password_reset_requested(data.email, request)
+    return {"detail": "If that email is registered, a reset link has been sent."}
+
+
+@router.post(
+    "/reset-password",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Reset password using a token",
+)
+@limiter.limit(LIMIT_PWD_RESET)
+def reset_password(
+    request: Request,
+    data: ResetPasswordRequest,
+    service: Annotated[PasswordResetService, Depends(get_password_reset_service)],
+) -> None:
+    """Set a new password using a valid reset token.
+
+    InvalidResetTokenError and ResetTokenExpiredError are handled by centralized
+    middleware and both map to 400 with the same opaque message. Rate limited.
+
+    :param request: FastAPI request (for rate limiting and logging)
+    :param data: Reset token and new password
+    :param service: Password reset service
+    """
+    user = service.reset_password(data.token, data.new_password)
+    log_password_reset_completed(user.id, request)
 
 
 @router.get("/me", summary="Get current user profile")

--- a/api/schemas/auth.py
+++ b/api/schemas/auth.py
@@ -155,3 +155,30 @@ class ChangePasswordRequest(BaseModel):
     def password_strength(cls, v: str) -> str:
         """Validate password strength."""
         return validate_password_strength(v)
+
+
+class ForgotPasswordRequest(BaseModel):
+    """Password reset request by email."""
+
+    email: EmailStr = Field(..., max_length=255, description="Email address")
+
+    @field_validator("email")
+    @classmethod
+    def email_ascii_only(cls, v: str) -> str:
+        """Validate email contains only ASCII characters."""
+        if not v.isascii():
+            raise ValueError("Email must contain only ASCII characters")
+        return v
+
+
+class ResetPasswordRequest(BaseModel):
+    """Password reset confirmation with a token and the new password."""
+
+    token: str = Field(..., min_length=1, max_length=512, description="Reset token")
+    new_password: str = Field(..., min_length=12, max_length=128, description="New password")
+
+    @field_validator("new_password")
+    @classmethod
+    def password_strength(cls, v: str) -> str:
+        """Validate password strength."""
+        return validate_password_strength(v)

--- a/api/services/email/__init__.py
+++ b/api/services/email/__init__.py
@@ -1,0 +1,1 @@
+"""Email services for transactional mail."""

--- a/api/services/email/base.py
+++ b/api/services/email/base.py
@@ -1,0 +1,22 @@
+"""Abstract email-sender interface for transactional mail."""
+
+from abc import ABC, abstractmethod
+
+
+class EmailSender(ABC):
+    """Transactional email backend.
+
+    Implementations either send a real message (production) or log its contents
+    (development). The interface stays minimal -- one method per transactional
+    message the app needs -- so concrete senders implement only what is used.
+    """
+
+    @abstractmethod
+    async def send_password_reset(self, *, to_email: str, reset_url: str) -> None:
+        """Send (or log) a password-reset message.
+
+        :param to_email: Recipient email address.
+        :param reset_url: Full frontend link the user clicks to reset; it already
+            carries the raw reset token as a query parameter.
+        :raises EmailSendError: If a real send fails.
+        """

--- a/api/services/email/console_email_sender.py
+++ b/api/services/email/console_email_sender.py
@@ -1,0 +1,42 @@
+"""Development email sender that logs the message instead of sending it."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from api.services.email.base import EmailSender
+
+if TYPE_CHECKING:
+    from api.config import Settings
+
+logger = logging.getLogger("api.service.email")
+
+
+class ConsoleEmailSender(EmailSender):
+    """Log the password-reset link instead of sending an email.
+
+    Used in development, CI, and tests: the flow works offline and the reset
+    link is read straight from the application log. Never selected in
+    production, so the link (and its token) only ever reaches a
+    developer-visible log.
+
+    :param settings: Application settings (kept for a uniform sender signature).
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        """Store settings for signature parity with real senders."""
+        self._settings = settings
+
+    async def send_password_reset(self, *, to_email: str, reset_url: str) -> None:
+        """Log the reset link; perform no network call.
+
+        :param to_email: Recipient email address.
+        :param reset_url: Full frontend reset link (carries the raw token).
+        """
+        logger.info(
+            "Password reset link (console sender) for %s: %s",
+            to_email,
+            reset_url,
+            extra={"event": "password_reset_email", "to_email": to_email},
+        )

--- a/api/services/email/exceptions.py
+++ b/api/services/email/exceptions.py
@@ -1,0 +1,11 @@
+"""Email-specific exception hierarchy."""
+
+from api.exceptions import BeCoMeAPIError
+
+
+class EmailError(BeCoMeAPIError):
+    """Base exception for email operations."""
+
+
+class EmailSendError(EmailError):
+    """Raised when sending an email fails."""

--- a/api/services/email/resend_email_sender.py
+++ b/api/services/email/resend_email_sender.py
@@ -13,6 +13,19 @@ if TYPE_CHECKING:
     from api.config import Settings
 
 _TIMEOUT_SECONDS = 10.0
+_MINUTES_PER_HOUR = 60
+
+
+def _format_ttl_window(minutes: int) -> str:
+    """Render a token TTL in minutes as a human-friendly expiry window.
+
+    :param minutes: Token lifetime in minutes.
+    :return: ``"1 hour"`` / ``"N hours"`` for whole hours, else ``"N minutes"``.
+    """
+    if minutes % _MINUTES_PER_HOUR == 0:
+        hours = minutes // _MINUTES_PER_HOUR
+        return "1 hour" if hours == 1 else f"{hours} hours"
+    return f"{minutes} minutes"
 
 
 class ResendEmailSender(EmailSender):
@@ -49,18 +62,18 @@ class ResendEmailSender(EmailSender):
         except httpx.HTTPError as exc:
             raise EmailSendError(f"Failed to send password reset email: {exc}") from exc
 
-    @staticmethod
-    def _build_html(reset_url: str) -> str:
+    def _build_html(self, reset_url: str) -> str:
         """Render the reset-email HTML body.
 
         :param reset_url: Full frontend reset link.
-        :return: HTML message body.
+        :return: HTML message body, with the expiry window matching the config.
         """
+        window = _format_ttl_window(self._settings.password_reset_token_ttl_minutes)
         return (
             "<p>We received a request to reset your BeCoMe password.</p>"
             f'<p><a href="{reset_url}">Reset your password</a></p>'
             "<p>If you did not request this you can ignore this email. "
-            "The link expires in one hour.</p>"
+            f"The link expires in {window}.</p>"
         )
 
     async def _post(self, payload: dict[str, object], headers: dict[str, str]) -> httpx.Response:

--- a/api/services/email/resend_email_sender.py
+++ b/api/services/email/resend_email_sender.py
@@ -1,0 +1,78 @@
+"""Production email sender using the Resend HTTP API."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+
+from api.services.email.base import EmailSender
+from api.services.email.exceptions import EmailSendError
+
+if TYPE_CHECKING:
+    from api.config import Settings
+
+_TIMEOUT_SECONDS = 10.0
+
+
+class ResendEmailSender(EmailSender):
+    """Send transactional email through the Resend HTTP API.
+
+    :param settings: Application settings carrying the API key, URL, and sender
+        identity.
+    :param client: Preconfigured async HTTP client; a fresh one is created per
+        request when omitted (injected directly in tests).
+    """
+
+    def __init__(self, settings: Settings, *, client: httpx.AsyncClient | None = None) -> None:
+        """Store settings and an optional injected HTTP client."""
+        self._settings = settings
+        self._client = client
+
+    async def send_password_reset(self, *, to_email: str, reset_url: str) -> None:
+        """Send a password-reset email via Resend.
+
+        :param to_email: Recipient email address.
+        :param reset_url: Full frontend reset link.
+        :raises EmailSendError: If the API rejects the request or transport fails.
+        """
+        payload: dict[str, object] = {
+            "from": f"{self._settings.email_from_name} <{self._settings.email_from}>",
+            "to": [to_email],
+            "subject": "Reset your BeCoMe password",
+            "html": self._build_html(reset_url),
+        }
+        headers = {"Authorization": f"Bearer {self._settings.email_api_key}"}
+        try:
+            response = await self._post(payload, headers)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise EmailSendError(f"Failed to send password reset email: {exc}") from exc
+
+    @staticmethod
+    def _build_html(reset_url: str) -> str:
+        """Render the reset-email HTML body.
+
+        :param reset_url: Full frontend reset link.
+        :return: HTML message body.
+        """
+        return (
+            "<p>We received a request to reset your BeCoMe password.</p>"
+            f'<p><a href="{reset_url}">Reset your password</a></p>'
+            "<p>If you did not request this you can ignore this email. "
+            "The link expires in one hour.</p>"
+        )
+
+    async def _post(self, payload: dict[str, object], headers: dict[str, str]) -> httpx.Response:
+        """POST the payload using the injected client or a fresh one.
+
+        :param payload: JSON request body.
+        :param headers: Request headers.
+        :return: The HTTP response.
+        """
+        if self._client is not None:
+            return await self._client.post(
+                self._settings.email_api_url, json=payload, headers=headers
+            )
+        async with httpx.AsyncClient(timeout=_TIMEOUT_SECONDS) as client:
+            return await client.post(self._settings.email_api_url, json=payload, headers=headers)

--- a/api/services/password_reset_service.py
+++ b/api/services/password_reset_service.py
@@ -1,0 +1,142 @@
+"""Password reset business logic service."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import secrets
+from datetime import timedelta
+
+from sqlmodel import col, select
+
+from api.auth.password import hash_password
+from api.config import get_settings
+from api.db.models import PasswordResetToken, User
+from api.db.utils import ensure_utc, utc_now
+from api.exceptions import InvalidResetTokenError, ResetTokenExpiredError
+from api.services.base import BaseService
+
+logger = logging.getLogger("api.service.password_reset")
+
+# Entropy for the raw reset token; token_urlsafe(32) yields a ~43-character string.
+_TOKEN_BYTES = 32
+
+# One opaque message for unknown, used, and expired tokens so a caller cannot
+# tell them apart (avoids a token-state oracle).
+_INVALID_MESSAGE = "Invalid or expired reset token"
+
+
+def _hash_token(raw_token: str) -> str:
+    """Return the SHA-256 hex digest of a raw reset token.
+
+    :param raw_token: The raw, high-entropy token sent to the user.
+    :return: 64-character hex digest stored in the database.
+    """
+    return hashlib.sha256(raw_token.encode()).hexdigest()
+
+
+class PasswordResetService(BaseService):
+    """Issue and redeem single-use, expiring password-reset tokens.
+
+    Only the SHA-256 hash of each token is stored; the raw token lives only long
+    enough to be emailed. Redeeming a token does not revoke the user's existing
+    access tokens (the JTI blacklist has no per-user revoke); this is acceptable
+    given the short access-token lifetime.
+    """
+
+    def create_reset_token(self, email: str) -> str | None:
+        """Issue a reset token for the given email, if a matching user exists.
+
+        Any outstanding tokens for the user are invalidated first, so only the
+        newest link works. The raw token is returned for delivery and never
+        persisted.
+
+        :param email: Email address from the forgot-password request.
+        :return: The raw reset token, or None when no user has that email. The
+            caller must respond identically either way to avoid user enumeration.
+        """
+        user = self._get_user_by_email(email)
+        if user is None:
+            logger.info(
+                "Password reset requested for unknown email",
+                extra={"event": "password_reset_unknown_email"},
+            )
+            return None
+
+        self._invalidate_outstanding(user)
+
+        raw_token = secrets.token_urlsafe(_TOKEN_BYTES)
+        ttl = timedelta(minutes=get_settings().password_reset_token_ttl_minutes)
+        token = PasswordResetToken(
+            user_id=user.id,
+            token_hash=_hash_token(raw_token),
+            expires_at=utc_now() + ttl,
+        )
+        # Commits the invalidations queued above together with the new token.
+        self._save_and_refresh(token)
+        logger.info(
+            "Password reset token created",
+            extra={"event": "password_reset_token_created", "user_id": str(user.id)},
+        )
+        return raw_token
+
+    def reset_password(self, token: str, new_password: str) -> User:
+        """Consume a reset token and set the user's new password.
+
+        :param token: The raw reset token from the reset link.
+        :param new_password: The new plaintext password (already strength-checked).
+        :return: The updated user.
+        :raises InvalidResetTokenError: If the token is unknown or already used.
+        :raises ResetTokenExpiredError: If the token has expired.
+        """
+        record = self._session.exec(
+            select(PasswordResetToken).where(PasswordResetToken.token_hash == _hash_token(token))
+        ).first()
+
+        if record is None or record.used_at is not None:
+            raise InvalidResetTokenError(_INVALID_MESSAGE)
+        if ensure_utc(record.expires_at) < utc_now():
+            raise ResetTokenExpiredError(_INVALID_MESSAGE)
+
+        user = self._session.get(User, record.user_id)
+        if user is None:
+            raise InvalidResetTokenError(_INVALID_MESSAGE)
+
+        user.hashed_password = hash_password(new_password)
+        record.used_at = utc_now()
+        self._session.add(user)
+        self._session.add(record)
+        self._session.commit()
+        self._session.refresh(user)
+
+        logger.info(
+            "Password reset completed",
+            extra={"event": "password_reset_completed", "user_id": str(user.id)},
+        )
+        return user
+
+    def _get_user_by_email(self, email: str) -> User | None:
+        """Find a user by normalized email.
+
+        :param email: Email address (case-insensitive).
+        :return: The user, or None when not found.
+        """
+        statement = select(User).where(User.email == email.lower())
+        return self._session.exec(statement).first()
+
+    def _invalidate_outstanding(self, user: User) -> None:
+        """Queue all of the user's not-yet-used tokens to be marked used.
+
+        The change is flushed by the caller's commit, keeping invalidation and
+        new-token creation in a single transaction.
+
+        :param user: The user whose outstanding tokens should be invalidated.
+        """
+        statement = select(PasswordResetToken).where(
+            PasswordResetToken.user_id == user.id,
+            col(PasswordResetToken.used_at).is_(None),
+        )
+        now = utc_now()
+        for token in self._session.exec(statement).all():
+            token.used_at = now
+            self._session.add(token)

--- a/api/services/password_reset_service.py
+++ b/api/services/password_reset_service.py
@@ -48,12 +48,13 @@ class PasswordResetService(BaseService):
         """Issue a reset token for the given email, if a matching user exists.
 
         Any outstanding tokens for the user are invalidated first, so only the
-        newest link works. The raw token is returned for delivery and never
-        persisted.
+        newest link works. Only the token hash is persisted; the raw token lives
+        only inside the returned URL.
 
         :param email: Email address from the forgot-password request.
-        :return: The raw reset token, or None when no user has that email. The
-            caller must respond identically either way to avoid user enumeration.
+        :return: The full password-reset URL to email, or None when no user has
+            that email. The caller must respond identically either way to avoid
+            user enumeration.
         """
         user = self._get_user_by_email(email)
         if user is None:
@@ -65,8 +66,9 @@ class PasswordResetService(BaseService):
 
         self._invalidate_outstanding(user)
 
+        settings = get_settings()
         raw_token = secrets.token_urlsafe(_TOKEN_BYTES)
-        ttl = timedelta(minutes=get_settings().password_reset_token_ttl_minutes)
+        ttl = timedelta(minutes=settings.password_reset_token_ttl_minutes)
         token = PasswordResetToken(
             user_id=user.id,
             token_hash=_hash_token(raw_token),
@@ -78,7 +80,7 @@ class PasswordResetService(BaseService):
             "Password reset token created",
             extra={"event": "password_reset_token_created", "user_id": str(user.id)},
         )
-        return raw_token
+        return f"{settings.frontend_base_url}/reset-password?token={raw_token}"
 
     def reset_password(self, token: str, new_password: str) -> User:
         """Consume a reset token and set the user's new password.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,8 @@ import { Loader2 } from "lucide-react";
 const Landing = lazy(() => import("./pages/Landing"));
 const Login = lazy(() => import("./pages/Login"));
 const Register = lazy(() => import("./pages/Register"));
+const ForgotPassword = lazy(() => import("./pages/ForgotPassword"));
+const ResetPassword = lazy(() => import("./pages/ResetPassword"));
 const Projects = lazy(() => import("./pages/Projects"));
 const ProjectDetail = lazy(() => import("./pages/ProjectDetail"));
 const Profile = lazy(() => import("./pages/Profile"));
@@ -58,6 +60,8 @@ const App = () => (
                 <Route path="/case-study/:id" element={<CaseStudy />} />
                 <Route path="/login" element={<Login />} />
                 <Route path="/register" element={<Register />} />
+                <Route path="/forgot-password" element={<ForgotPassword />} />
+                <Route path="/reset-password" element={<ResetPassword />} />
                 <Route path="/projects" element={
                   <ProtectedRoute>
                     <Projects />

--- a/frontend/src/i18n/locales/cs/auth.json
+++ b/frontend/src/i18n/locales/cs/auth.json
@@ -36,6 +36,32 @@
     "errorTitle": "Registrace se nezdařila",
     "errorMessage": "Nepodařilo se vytvořit účet"
   },
+  "forgotPassword": {
+    "title": "Obnovení hesla",
+    "description": "Zadejte svůj e-mail a my vám pošleme odkaz pro obnovení.",
+    "email": "E-mail",
+    "emailPlaceholder": "vas@email.cz",
+    "submit": "Odeslat odkaz",
+    "submitting": "Odesílání...",
+    "successTitle": "Zkontrolujte schránku",
+    "successMessage": "Pokud je tento e-mail registrován, odkaz pro obnovení je na cestě.",
+    "backToLogin": "Zpět na přihlášení"
+  },
+  "resetPassword": {
+    "title": "Zvolte nové heslo",
+    "password": "Nové heslo",
+    "passwordPlaceholder": "Min. 12 znaků",
+    "confirmPassword": "Potvrzení nového hesla",
+    "confirmPasswordPlaceholder": "Potvrďte heslo",
+    "submit": "Obnovit heslo",
+    "submitting": "Obnovování...",
+    "successTitle": "Heslo aktualizováno",
+    "successMessage": "Nyní se můžete přihlásit novým heslem.",
+    "errorTitle": "Obnovení se nezdařilo",
+    "errorInvalidToken": "Tento odkaz pro obnovení je neplatný nebo vypršel.",
+    "missingToken": "Tento odkaz pro obnovení je neplatný. Požádejte o nový.",
+    "requestNewLink": "Požádat o nový odkaz"
+  },
   "validation": {
     "emailRequired": "E-mail je povinný",
     "emailInvalid": "Neplatná e-mailová adresa",

--- a/frontend/src/i18n/locales/cs/common.json
+++ b/frontend/src/i18n/locales/cs/common.json
@@ -129,6 +129,8 @@
     "about": "O metodě",
     "login": "Přihlášení",
     "register": "Vytvoření účtu",
+    "forgotPassword": "Obnovení hesla",
+    "resetPassword": "Nové heslo",
     "projects": "Projekty",
     "projectDetail": "Projekt: {{name}}",
     "profile": "Profil",

--- a/frontend/src/i18n/locales/en/auth.json
+++ b/frontend/src/i18n/locales/en/auth.json
@@ -36,6 +36,32 @@
     "errorTitle": "Registration failed",
     "errorMessage": "Failed to create account"
   },
+  "forgotPassword": {
+    "title": "Reset your password",
+    "description": "Enter your email and we'll send you a reset link.",
+    "email": "Email",
+    "emailPlaceholder": "you@example.com",
+    "submit": "Send reset link",
+    "submitting": "Sending...",
+    "successTitle": "Check your inbox",
+    "successMessage": "If that email is registered, a reset link is on its way.",
+    "backToLogin": "Back to sign in"
+  },
+  "resetPassword": {
+    "title": "Choose a new password",
+    "password": "New password",
+    "passwordPlaceholder": "Min. 12 characters",
+    "confirmPassword": "Confirm new password",
+    "confirmPasswordPlaceholder": "Confirm your password",
+    "submit": "Reset password",
+    "submitting": "Resetting...",
+    "successTitle": "Password updated",
+    "successMessage": "You can now sign in with your new password.",
+    "errorTitle": "Reset failed",
+    "errorInvalidToken": "This reset link is invalid or has expired.",
+    "missingToken": "This reset link is invalid. Request a new one.",
+    "requestNewLink": "Request a new link"
+  },
   "validation": {
     "emailRequired": "Email is required",
     "emailInvalid": "Invalid email address",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -129,6 +129,8 @@
     "about": "About the Method",
     "login": "Sign In",
     "register": "Create Account",
+    "forgotPassword": "Reset Password",
+    "resetPassword": "New Password",
     "projects": "Projects",
     "projectDetail": "Project: {{name}}",
     "profile": "Profile",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -136,6 +136,20 @@ class ApiClient {
     this.setToken(null);
   }
 
+  async forgotPassword(email: string): Promise<void> {
+    return this.request<void>('/auth/forgot-password', {
+      method: 'POST',
+      body: JSON.stringify({ email }),
+    });
+  }
+
+  async resetPassword(token: string, newPassword: string): Promise<void> {
+    return this.request<void>('/auth/reset-password', {
+      method: 'POST',
+      body: JSON.stringify({ token, new_password: newPassword }),
+    });
+  }
+
   // Users
   async getCurrentUser(): Promise<User> {
     return this.request<User>('/users/me');

--- a/frontend/src/pages/ForgotPassword.tsx
+++ b/frontend/src/pages/ForgotPassword.tsx
@@ -1,0 +1,102 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useTranslation } from "react-i18next";
+
+import { FormField, SubmitButton } from "@/components/forms";
+import { AuthLayout } from "@/components/layout/AuthLayout";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { api } from "@/lib/api";
+
+type ForgotPasswordFormData = {
+  email: string;
+};
+
+const ForgotPassword = () => {
+  const { t } = useTranslation("auth");
+  const { t: tCommon } = useTranslation();
+  useDocumentTitle(tCommon("pageTitle.forgotPassword"));
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const schema = useMemo(
+    () =>
+      z.object({
+        email: z.email(t("validation.emailInvalid")),
+      }),
+    [t]
+  );
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ForgotPasswordFormData>({
+    resolver: zodResolver(schema),
+    mode: "onTouched",
+  });
+
+  const onSubmit = async (data: ForgotPasswordFormData) => {
+    setIsLoading(true);
+    try {
+      await api.forgotPassword(data.email);
+    } catch {
+      // Swallow errors: the screen must look identical whether or not the email
+      // exists, mirroring the backend's anti-enumeration response.
+    } finally {
+      setIsLoading(false);
+      setSubmitted(true);
+    }
+  };
+
+  if (submitted) {
+    return (
+      <AuthLayout title={t("forgotPassword.successTitle")}>
+        <p className="text-center text-sm text-muted-foreground">
+          {t("forgotPassword.successMessage")}
+        </p>
+        <p className="text-center text-sm text-muted-foreground mt-6">
+          <Link to="/login" className="text-foreground hover:underline">
+            {t("forgotPassword.backToLogin")}
+          </Link>
+        </p>
+      </AuthLayout>
+    );
+  }
+
+  return (
+    <AuthLayout title={t("forgotPassword.title")}>
+      <p className="text-sm text-muted-foreground mb-4">
+        {t("forgotPassword.description")}
+      </p>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          label={t("forgotPassword.email")}
+          type="email"
+          placeholder={t("forgotPassword.emailPlaceholder")}
+          error={errors.email}
+          {...register("email")}
+        />
+
+        <SubmitButton
+          className="w-full"
+          isLoading={isLoading}
+          loadingText={t("forgotPassword.submitting")}
+        >
+          {t("forgotPassword.submit")}
+        </SubmitButton>
+      </form>
+
+      <p className="text-center text-sm text-muted-foreground mt-6">
+        <Link to="/login" className="text-foreground hover:underline">
+          {t("forgotPassword.backToLogin")}
+        </Link>
+      </p>
+    </AuthLayout>
+  );
+};
+
+export default ForgotPassword;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -68,6 +68,15 @@ const Login = () => {
           {...register("password")}
         />
 
+        <div className="text-right -mt-2">
+          <Link
+            to="/forgot-password"
+            className="text-sm text-muted-foreground hover:underline"
+          >
+            {t("login.forgotPassword")}
+          </Link>
+        </div>
+
         <SubmitButton
           className="w-full"
           isLoading={isLoading}

--- a/frontend/src/pages/ResetPassword.tsx
+++ b/frontend/src/pages/ResetPassword.tsx
@@ -1,0 +1,147 @@
+import { useMemo, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { useForm, useWatch } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useTranslation } from "react-i18next";
+
+import {
+  FormField,
+  PasswordInput,
+  SubmitButton,
+  ValidationChecklist,
+} from "@/components/forms";
+import { AuthLayout } from "@/components/layout/AuthLayout";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { useToast } from "@/hooks/use-toast";
+import { api } from "@/lib/api";
+import { SPECIAL_CHAR_REGEX, getPasswordRequirements } from "@/lib/validation";
+
+type ResetPasswordFormData = {
+  password: string;
+  confirmPassword: string;
+};
+
+const ResetPassword = () => {
+  const { t } = useTranslation("auth");
+  const { t: tCommon } = useTranslation();
+  useDocumentTitle(tCommon("pageTitle.resetPassword"));
+
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token");
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const schema = useMemo(
+    () =>
+      z
+        .object({
+          password: z
+            .string()
+            .min(12, t("passwordRequirements.minLength"))
+            .max(128, t("validation.passwordMaxLength"))
+            .regex(/[A-Z]/, t("passwordRequirements.uppercase"))
+            .regex(/[a-z]/, t("passwordRequirements.lowercase"))
+            .regex(/\d/, t("passwordRequirements.number"))
+            .regex(SPECIAL_CHAR_REGEX, t("passwordRequirements.specialChar")),
+          confirmPassword: z.string().min(1, t("validation.passwordRequired")),
+        })
+        .refine((data) => data.password === data.confirmPassword, {
+          error: t("validation.passwordsMatch"),
+          path: ["confirmPassword"],
+        }),
+    [t]
+  );
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    formState: { errors, isValid },
+  } = useForm<ResetPasswordFormData>({
+    resolver: zodResolver(schema),
+    mode: "onTouched",
+  });
+
+  const password = useWatch({ control, name: "password", defaultValue: "" });
+  const passwordRequirements = getPasswordRequirements(password, t);
+
+  const onSubmit = async (data: ResetPasswordFormData) => {
+    if (!token) return;
+    setIsLoading(true);
+    try {
+      await api.resetPassword(token, data.password);
+      toast({
+        title: t("resetPassword.successTitle"),
+        description: t("resetPassword.successMessage"),
+      });
+      navigate("/login");
+    } catch {
+      toast({
+        title: t("resetPassword.errorTitle"),
+        description: t("resetPassword.errorInvalidToken"),
+        variant: "destructive",
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (!token) {
+    return (
+      <AuthLayout title={t("resetPassword.title")}>
+        <p className="text-center text-sm text-muted-foreground">
+          {t("resetPassword.missingToken")}
+        </p>
+        <p className="text-center text-sm text-muted-foreground mt-6">
+          <Link
+            to="/forgot-password"
+            className="text-foreground hover:underline"
+          >
+            {t("resetPassword.requestNewLink")}
+          </Link>
+        </p>
+      </AuthLayout>
+    );
+  }
+
+  return (
+    <AuthLayout title={t("resetPassword.title")}>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <div>
+          <PasswordInput
+            label={t("resetPassword.password")}
+            placeholder={t("resetPassword.passwordPlaceholder")}
+            error={errors.password}
+            {...register("password")}
+          />
+          <ValidationChecklist
+            title={t("passwordRequirements.title")}
+            requirements={passwordRequirements}
+            show={!!password}
+          />
+        </div>
+
+        <FormField
+          label={t("resetPassword.confirmPassword")}
+          type="password"
+          placeholder={t("resetPassword.confirmPasswordPlaceholder")}
+          error={errors.confirmPassword}
+          {...register("confirmPassword")}
+        />
+
+        <SubmitButton
+          className="w-full"
+          isLoading={isLoading}
+          loadingText={t("resetPassword.submitting")}
+          disabled={!isValid}
+        >
+          {t("resetPassword.submit")}
+        </SubmitButton>
+      </form>
+    </AuthLayout>
+  );
+};
+
+export default ResetPassword;

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -21,10 +21,16 @@ vi.mock('react-router-dom', async (importOriginal) => {
   };
 });
 
-// 2. Mock all 13 lazy-loaded pages as synchronous stubs
+// 2. Mock all 15 lazy-loaded pages as synchronous stubs
 vi.mock('@/pages/Landing', () => ({ default: () => <div data-testid="landing" /> }));
 vi.mock('@/pages/Login', () => ({ default: () => <div data-testid="login" /> }));
 vi.mock('@/pages/Register', () => ({ default: () => <div data-testid="register" /> }));
+vi.mock('@/pages/ForgotPassword', () => ({
+  default: () => <div data-testid="forgot-password" />,
+}));
+vi.mock('@/pages/ResetPassword', () => ({
+  default: () => <div data-testid="reset-password" />,
+}));
 vi.mock('@/pages/Projects', () => ({ default: () => <div data-testid="projects" /> }));
 vi.mock('@/pages/ProjectDetail', () => ({ default: () => <div data-testid="project-detail" /> }));
 vi.mock('@/pages/Profile', () => ({ default: () => <div data-testid="profile" /> }));
@@ -132,6 +138,24 @@ describe('App - public routes', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('register')).toBeInTheDocument();
+    });
+  });
+
+  it('renders ForgotPassword page at /forgot-password', async () => {
+    routeRef.value = '/forgot-password';
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('forgot-password')).toBeInTheDocument();
+    });
+  });
+
+  it('renders ResetPassword page at /reset-password', async () => {
+    routeRef.value = '/reset-password';
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reset-password')).toBeInTheDocument();
     });
   });
 

--- a/frontend/tests/pages/ForgotPassword.test.tsx
+++ b/frontend/tests/pages/ForgotPassword.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '@tests/utils';
+import ForgotPassword from '@/pages/ForgotPassword';
+
+// Mock the API client (the page calls api.forgotPassword directly)
+const mockForgotPassword = vi.fn();
+vi.mock('@/lib/api', () => ({
+  api: {
+    forgotPassword: (email: string) => mockForgotPassword(email),
+  },
+}));
+
+// AuthLayout renders Navbar, which calls useAuth -> mock it (as Login/Register tests do)
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: null,
+    isLoading: false,
+    isAuthenticated: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshUser: vi.fn(),
+  }),
+}));
+
+describe('ForgotPassword', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const getEmailInput = () => screen.getByPlaceholderText('you@example.com');
+  const getSubmitButton = () => screen.getByRole('button', { name: /send reset link/i });
+
+  it('renders the email field and submit button', () => {
+    render(<ForgotPassword />);
+
+    expect(getEmailInput()).toBeInTheDocument();
+    expect(getSubmitButton()).toBeInTheDocument();
+  });
+
+  it('shows a validation error for an invalid email', async () => {
+    const user = userEvent.setup();
+    render(<ForgotPassword />);
+
+    await user.type(getEmailInput(), 'not-an-email');
+    await user.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid.*email/i)).toBeInTheDocument();
+    });
+  });
+
+  it('calls api.forgotPassword and shows a generic success message', async () => {
+    const user = userEvent.setup();
+    mockForgotPassword.mockResolvedValueOnce(undefined);
+    render(<ForgotPassword />);
+
+    await user.type(getEmailInput(), 'user@example.com');
+    await user.click(getSubmitButton());
+
+    await waitFor(() => {
+      expect(mockForgotPassword).toHaveBeenCalledWith('user@example.com');
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/if that email is registered/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows the same success message even when the request fails (anti-enumeration)', async () => {
+    const user = userEvent.setup();
+    mockForgotPassword.mockRejectedValueOnce(new Error('boom'));
+    render(<ForgotPassword />);
+
+    await user.type(getEmailInput(), 'user@example.com');
+    await user.click(getSubmitButton());
+
+    await waitFor(() => {
+      expect(screen.getByText(/if that email is registered/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows a loading state during submission', async () => {
+    const user = userEvent.setup();
+    mockForgotPassword.mockImplementation(() => new Promise(() => {}));
+    render(<ForgotPassword />);
+
+    await user.type(getEmailInput(), 'user@example.com');
+    await user.click(getSubmitButton());
+
+    await waitFor(() => {
+      expect(screen.getByText(/sending/i)).toBeInTheDocument();
+    });
+  });
+
+  it('has a link back to login', () => {
+    render(<ForgotPassword />);
+
+    const loginLink = screen.getByRole('link', { name: /back to sign in/i });
+    expect(loginLink).toHaveAttribute('href', '/login');
+  });
+});

--- a/frontend/tests/pages/ResetPassword.test.tsx
+++ b/frontend/tests/pages/ResetPassword.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '@tests/utils';
+import ResetPassword from '@/pages/ResetPassword';
+
+// Mock the API client (the page calls api.resetPassword directly)
+const mockResetPassword = vi.fn();
+vi.mock('@/lib/api', () => ({
+  api: {
+    resetPassword: (token: string, password: string) => mockResetPassword(token, password),
+  },
+}));
+
+// Mock navigation and the reset token read from the URL query string
+const mockNavigate = vi.fn();
+const routeState: { token: string | null } = { token: 'valid-reset-token' };
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useSearchParams: () => [{ get: () => routeState.token }, vi.fn()],
+  };
+});
+
+// Mock useToast
+const mockToast = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+// AuthLayout renders Navbar, which calls useAuth -> mock it (as Login/Register tests do)
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: null,
+    isLoading: false,
+    isAuthenticated: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshUser: vi.fn(),
+  }),
+}));
+
+describe('ResetPassword', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    routeState.token = 'valid-reset-token';
+  });
+
+  const getPasswordInput = () => screen.getByPlaceholderText('Min. 12 characters');
+  const getConfirmInput = () => screen.getByPlaceholderText('Confirm your password');
+  const getSubmitButton = () => screen.getByRole('button', { name: /reset password/i });
+
+  it('renders the password and confirm fields when a token is present', () => {
+    render(<ResetPassword />);
+
+    expect(getPasswordInput()).toBeInTheDocument();
+    expect(getConfirmInput()).toBeInTheDocument();
+    expect(getSubmitButton()).toBeInTheDocument();
+  });
+
+  it('shows an invalid-link message when the token is missing', () => {
+    routeState.token = null;
+    render(<ResetPassword />);
+
+    expect(screen.getByText(/this reset link is invalid/i)).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /request a new link/i });
+    expect(link).toHaveAttribute('href', '/forgot-password');
+  });
+
+  it('shows the password requirements checklist when typing', async () => {
+    const user = userEvent.setup();
+    render(<ResetPassword />);
+
+    await user.type(getPasswordInput(), 'test');
+
+    await waitFor(() => {
+      expect(screen.getByText(/at least 12 characters/i)).toBeInTheDocument();
+      expect(screen.getByText(/an uppercase letter/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error when passwords do not match', async () => {
+    const user = userEvent.setup();
+    render(<ResetPassword />);
+
+    await user.type(getPasswordInput(), 'TestPass123!@#');
+    await user.type(getConfirmInput(), 'Different123!@#');
+    await user.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText(/passwords must match/i)).toBeInTheDocument();
+    });
+  });
+
+  it('disables submit until the form is valid', () => {
+    render(<ResetPassword />);
+
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  it('resets the password, shows success, and navigates to login', async () => {
+    const user = userEvent.setup();
+    mockResetPassword.mockResolvedValueOnce(undefined);
+    render(<ResetPassword />);
+
+    await user.type(getPasswordInput(), 'BrandNewPass456!');
+    await user.type(getConfirmInput(), 'BrandNewPass456!');
+    await waitFor(() => expect(getSubmitButton()).not.toBeDisabled());
+    await user.click(getSubmitButton());
+
+    await waitFor(() => {
+      expect(mockResetPassword).toHaveBeenCalledWith('valid-reset-token', 'BrandNewPass456!');
+    });
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
+    });
+  });
+
+  it('shows an error toast when the reset fails', async () => {
+    const user = userEvent.setup();
+    mockResetPassword.mockRejectedValueOnce(new Error('Invalid or expired reset token'));
+    render(<ResetPassword />);
+
+    await user.type(getPasswordInput(), 'BrandNewPass456!');
+    await user.type(getConfirmInput(), 'BrandNewPass456!');
+    await waitFor(() => expect(getSubmitButton()).not.toBeDisabled());
+    await user.click(getSubmitButton());
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: 'destructive' })
+      );
+    });
+  });
+});

--- a/tests/e2e/test_password_reset.py
+++ b/tests/e2e/test_password_reset.py
@@ -1,0 +1,60 @@
+"""E2E tests for the password reset endpoints.
+
+Black-box only: the real server uses the console email sender, so the raw reset
+token never appears in an HTTP response. The token round-trip is covered at the
+integration layer; here we assert the publicly observable behaviors.
+"""
+
+import pytest
+
+from tests.e2e.conftest import register_user, unique_email
+
+NEW_PASSWORD = "BrandNewPass456!"
+
+
+@pytest.mark.e2e
+class TestForgotPassword:
+    """E2E tests for POST /auth/forgot-password."""
+
+    def test_known_and_unknown_email_responses_are_identical(self, http_client):
+        """Known and unknown emails both return 202 with the same body."""
+        # GIVEN — one registered email and one that was never registered
+        email = unique_email("reset-known")
+        register_user(http_client, email)
+
+        # WHEN
+        known = http_client.post("/auth/forgot-password", json={"email": email})
+        unknown = http_client.post(
+            "/auth/forgot-password", json={"email": unique_email("reset-ghost")}
+        )
+
+        # THEN — indistinguishable (anti-enumeration)
+        assert known.status_code == unknown.status_code == 202
+        assert known.json() == unknown.json()
+
+
+@pytest.mark.e2e
+class TestResetPassword:
+    """E2E tests for POST /auth/reset-password."""
+
+    def test_invalid_token_returns_400(self, http_client):
+        """An unknown token is rejected with 400."""
+        # WHEN
+        response = http_client.post(
+            "/auth/reset-password",
+            json={"token": "definitely-not-a-real-token", "new_password": NEW_PASSWORD},
+        )
+
+        # THEN
+        assert response.status_code == 400
+
+    def test_weak_password_returns_422(self, http_client):
+        """A weak new password is rejected by validation before any token check."""
+        # WHEN
+        response = http_client.post(
+            "/auth/reset-password",
+            json={"token": "any-token", "new_password": "weak"},
+        )
+
+        # THEN
+        assert response.status_code == 422

--- a/tests/integration/api/auth/test_password_reset.py
+++ b/tests/integration/api/auth/test_password_reset.py
@@ -1,0 +1,198 @@
+"""Integration tests for the password reset endpoints.
+
+Uses shared fixtures from conftest.py (client, client_with_session). A fake email
+sender captures the raw reset token, which the API never returns in a response.
+"""
+
+import hashlib
+from datetime import timedelta
+
+import pytest
+from sqlmodel import select
+
+from api.db.models import PasswordResetToken, User
+from api.db.utils import utc_now
+from api.dependencies import get_email_service
+from tests.shared.helpers import DEFAULT_TEST_PASSWORD
+
+NEW_PASSWORD = "BrandNewPass456!"
+
+
+class FakeEmailSender:
+    """Record password-reset sends so a test can read back the raw token."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, str]] = []
+
+    async def send_password_reset(self, *, to_email: str, reset_url: str) -> None:
+        """Capture the call instead of sending an email."""
+        self.calls.append({"to_email": to_email, "reset_url": reset_url})
+
+
+@pytest.fixture
+def fake_email(client):
+    """Install a fake email sender on the app and return it."""
+    sender = FakeEmailSender()
+    client.app.dependency_overrides[get_email_service] = lambda: sender
+    return sender
+
+
+def _register(client, email: str = "user@example.com") -> None:
+    """Register a user with the default test password."""
+    client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": email,
+            "password": DEFAULT_TEST_PASSWORD,
+            "first_name": "Test",
+            "last_name": "User",
+        },
+    )
+
+
+def _captured_token(sender: FakeEmailSender) -> str:
+    """Extract the raw reset token from the last captured reset URL."""
+    reset_url = sender.calls[-1]["reset_url"]
+    return reset_url.split("token=")[1]
+
+
+class TestForgotPassword:
+    """Tests for POST /api/v1/auth/forgot-password."""
+
+    def test_returns_202_and_sends_for_existing_user(self, client, fake_email):
+        """A known email gets a 202 and triggers exactly one send."""
+        # GIVEN
+        _register(client, "user@example.com")
+
+        # WHEN
+        response = client.post("/api/v1/auth/forgot-password", json={"email": "user@example.com"})
+
+        # THEN
+        assert response.status_code == 202
+        assert len(fake_email.calls) == 1
+        assert fake_email.calls[0]["to_email"] == "user@example.com"
+
+    def test_returns_202_without_sending_for_unknown_email(self, client, fake_email):
+        """An unknown email gets a 202 but triggers no send (anti-enumeration)."""
+        # WHEN
+        response = client.post("/api/v1/auth/forgot-password", json={"email": "nobody@example.com"})
+
+        # THEN
+        assert response.status_code == 202
+        assert fake_email.calls == []
+
+    def test_response_identical_for_known_and_unknown(self, client, fake_email):
+        """Status and body are identical whether or not the email exists."""
+        # GIVEN
+        _register(client, "known@example.com")
+
+        # WHEN
+        known = client.post("/api/v1/auth/forgot-password", json={"email": "known@example.com"})
+        unknown = client.post("/api/v1/auth/forgot-password", json={"email": "ghost@example.com"})
+
+        # THEN
+        assert known.status_code == unknown.status_code == 202
+        assert known.json() == unknown.json()
+
+
+class TestResetPassword:
+    """Tests for POST /api/v1/auth/reset-password."""
+
+    def test_full_round_trip(self, client, fake_email):
+        """Reset swaps the password: the old one fails and the new one logs in."""
+        # GIVEN
+        _register(client, "user@example.com")
+        client.post("/api/v1/auth/forgot-password", json={"email": "user@example.com"})
+        token = _captured_token(fake_email)
+
+        # WHEN
+        reset = client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": token, "new_password": NEW_PASSWORD},
+        )
+
+        # THEN
+        assert reset.status_code == 204
+        old_login = client.post(
+            "/api/v1/auth/login",
+            data={"username": "user@example.com", "password": DEFAULT_TEST_PASSWORD},
+        )
+        assert old_login.status_code == 401
+        new_login = client.post(
+            "/api/v1/auth/login",
+            data={"username": "user@example.com", "password": NEW_PASSWORD},
+        )
+        assert new_login.status_code == 200
+
+    def test_rejects_unknown_token(self, client):
+        """An unknown token is rejected with 400."""
+        # WHEN
+        response = client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": "garbage-token", "new_password": NEW_PASSWORD},
+        )
+
+        # THEN
+        assert response.status_code == 400
+
+    def test_rejects_reused_token(self, client, fake_email):
+        """A token cannot be redeemed twice."""
+        # GIVEN
+        _register(client, "user@example.com")
+        client.post("/api/v1/auth/forgot-password", json={"email": "user@example.com"})
+        token = _captured_token(fake_email)
+        first = client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": token, "new_password": NEW_PASSWORD},
+        )
+        assert first.status_code == 204
+
+        # WHEN
+        second = client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": token, "new_password": "EvenNewerPass789!"},
+        )
+
+        # THEN
+        assert second.status_code == 400
+
+    def test_rejects_weak_password(self, client, fake_email):
+        """A weak new password is rejected by schema validation with 422."""
+        # GIVEN
+        _register(client, "user@example.com")
+        client.post("/api/v1/auth/forgot-password", json={"email": "user@example.com"})
+        token = _captured_token(fake_email)
+
+        # WHEN
+        response = client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": token, "new_password": "weak"},
+        )
+
+        # THEN
+        assert response.status_code == 422
+
+    def test_rejects_expired_token(self, client_with_session):
+        """An expired token is rejected with 400."""
+        # GIVEN
+        client, session = client_with_session
+        _register(client, "user@example.com")
+        user = session.exec(select(User).where(User.email == "user@example.com")).first()
+        raw = "expired-integration-token"
+        session.add(
+            PasswordResetToken(
+                user_id=user.id,
+                token_hash=hashlib.sha256(raw.encode()).hexdigest(),
+                expires_at=utc_now() - timedelta(minutes=1),
+            )
+        )
+        session.commit()
+
+        # WHEN
+        response = client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": raw, "new_password": NEW_PASSWORD},
+        )
+
+        # THEN
+        assert response.status_code == 400

--- a/tests/integration/api/auth/test_password_reset.py
+++ b/tests/integration/api/auth/test_password_reset.py
@@ -13,6 +13,7 @@ from sqlmodel import select
 from api.db.models import PasswordResetToken, User
 from api.db.utils import utc_now
 from api.dependencies import get_email_service
+from api.services.email.exceptions import EmailSendError
 from tests.shared.helpers import DEFAULT_TEST_PASSWORD
 
 NEW_PASSWORD = "BrandNewPass456!"
@@ -93,6 +94,23 @@ class TestForgotPassword:
         # THEN
         assert known.status_code == unknown.status_code == 202
         assert known.json() == unknown.json()
+
+    def test_returns_202_even_when_email_send_fails(self, client):
+        """A provider send failure is swallowed; the response is still 202."""
+
+        # GIVEN — an email sender that raises on send
+        class FailingEmailSender:
+            async def send_password_reset(self, **_kwargs: object) -> None:
+                raise EmailSendError("send failed")
+
+        client.app.dependency_overrides[get_email_service] = lambda: FailingEmailSender()
+        _register(client, "user@example.com")
+
+        # WHEN
+        response = client.post("/api/v1/auth/forgot-password", json={"email": "user@example.com"})
+
+        # THEN
+        assert response.status_code == 202
 
 
 class TestResetPassword:

--- a/tests/unit/api/services/test_email.py
+++ b/tests/unit/api/services/test_email.py
@@ -124,3 +124,34 @@ class TestResendEmailSender:
                     reset_url="https://app.example/reset",
                 )
             )
+
+    def test_creates_own_client_when_none_injected(self):
+        """
+        GIVEN a Resend sender with no injected client
+        WHEN a password reset email is sent
+        THEN it opens its own AsyncClient and posts through it
+        """
+        # GIVEN
+        sender = ResendEmailSender(_settings())
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        own_client = MagicMock()
+        own_client.post = AsyncMock(return_value=response)
+        async_cm = MagicMock()
+        async_cm.__aenter__ = AsyncMock(return_value=own_client)
+        async_cm.__aexit__ = AsyncMock(return_value=None)
+
+        # WHEN
+        with patch(
+            "api.services.email.resend_email_sender.httpx.AsyncClient",
+            return_value=async_cm,
+        ):
+            asyncio.run(
+                sender.send_password_reset(
+                    to_email="user@example.com",
+                    reset_url="https://app.example/reset",
+                )
+            )
+
+        # THEN
+        own_client.post.assert_awaited_once()

--- a/tests/unit/api/services/test_email.py
+++ b/tests/unit/api/services/test_email.py
@@ -18,6 +18,7 @@ def _settings(**overrides: object) -> MagicMock:
     settings.email_from_name = "BeCoMe"
     settings.email_api_key = "re_test_key"
     settings.email_api_url = "https://api.resend.com/emails"
+    settings.password_reset_token_ttl_minutes = 60
     for key, value in overrides.items():
         setattr(settings, key, value)
     return settings
@@ -80,6 +81,32 @@ class TestResendEmailSender:
         assert call.kwargs["headers"]["Authorization"] == "Bearer re_test_key"
         assert call.kwargs["json"]["to"] == ["user@example.com"]
         assert "https://app.example/reset-password?token=abc" in call.kwargs["json"]["html"]
+
+    def test_email_body_reflects_configured_ttl(self):
+        """
+        GIVEN a Resend sender whose token TTL is 30 minutes
+        WHEN a password reset email is sent
+        THEN the email body states the matching expiry window, not a hardcoded one
+        """
+        # GIVEN
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        client = MagicMock()
+        client.post = AsyncMock(return_value=response)
+        sender = ResendEmailSender(_settings(password_reset_token_ttl_minutes=30), client=client)
+
+        # WHEN
+        asyncio.run(
+            sender.send_password_reset(
+                to_email="user@example.com",
+                reset_url="https://app.example/reset",
+            )
+        )
+
+        # THEN
+        html = client.post.call_args.kwargs["json"]["html"]
+        assert "30 minutes" in html
+        assert "one hour" not in html
 
     def test_raises_send_error_on_http_status_error(self):
         """

--- a/tests/unit/api/services/test_email.py
+++ b/tests/unit/api/services/test_email.py
@@ -1,0 +1,126 @@
+"""Unit tests for the email sender implementations."""
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from api.services.email.console_email_sender import ConsoleEmailSender
+from api.services.email.exceptions import EmailSendError
+from api.services.email.resend_email_sender import ResendEmailSender
+
+
+def _settings(**overrides: object) -> MagicMock:
+    """Build a settings stub with valid email configuration."""
+    settings = MagicMock()
+    settings.email_from = "no-reply@become.app"
+    settings.email_from_name = "BeCoMe"
+    settings.email_api_key = "re_test_key"
+    settings.email_api_url = "https://api.resend.com/emails"
+    for key, value in overrides.items():
+        setattr(settings, key, value)
+    return settings
+
+
+class TestConsoleEmailSender:
+    """Tests for the development console email sender."""
+
+    def test_logs_reset_link_without_network(self, caplog):
+        """
+        GIVEN a console email sender
+        WHEN a password reset email is sent
+        THEN the reset link is logged and no network call is made
+        """
+        # GIVEN
+        sender = ConsoleEmailSender(_settings())
+
+        # WHEN
+        with caplog.at_level(logging.INFO, logger="api.service.email"):
+            asyncio.run(
+                sender.send_password_reset(
+                    to_email="user@example.com",
+                    reset_url="https://app.example/reset-password?token=abc123",
+                )
+            )
+
+        # THEN
+        assert "https://app.example/reset-password?token=abc123" in caplog.text
+
+
+class TestResendEmailSender:
+    """Tests for the production Resend HTTP email sender."""
+
+    def test_posts_to_api_with_bearer_and_payload(self):
+        """
+        GIVEN a Resend sender with an injected client
+        WHEN a password reset email is sent
+        THEN it POSTs to the API URL with a bearer header and the reset link
+        """
+        # GIVEN
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        client = MagicMock()
+        client.post = AsyncMock(return_value=response)
+        sender = ResendEmailSender(_settings(), client=client)
+
+        # WHEN
+        asyncio.run(
+            sender.send_password_reset(
+                to_email="user@example.com",
+                reset_url="https://app.example/reset-password?token=abc",
+            )
+        )
+
+        # THEN
+        client.post.assert_awaited_once()
+        call = client.post.call_args
+        assert call.args[0] == "https://api.resend.com/emails"
+        assert call.kwargs["headers"]["Authorization"] == "Bearer re_test_key"
+        assert call.kwargs["json"]["to"] == ["user@example.com"]
+        assert "https://app.example/reset-password?token=abc" in call.kwargs["json"]["html"]
+
+    def test_raises_send_error_on_http_status_error(self):
+        """
+        GIVEN a Resend sender whose response is a non-2xx status
+        WHEN a password reset email is sent
+        THEN EmailSendError is raised
+        """
+        # GIVEN
+        response = MagicMock()
+        response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError("400", request=MagicMock(), response=MagicMock())
+        )
+        client = MagicMock()
+        client.post = AsyncMock(return_value=response)
+        sender = ResendEmailSender(_settings(), client=client)
+
+        # WHEN / THEN
+        with pytest.raises(EmailSendError):
+            asyncio.run(
+                sender.send_password_reset(
+                    to_email="user@example.com",
+                    reset_url="https://app.example/reset",
+                )
+            )
+
+    def test_raises_send_error_on_transport_error(self):
+        """
+        GIVEN a Resend sender whose client fails to connect
+        WHEN a password reset email is sent
+        THEN EmailSendError is raised
+        """
+        # GIVEN
+        client = MagicMock()
+        client.post = AsyncMock(side_effect=httpx.ConnectError("boom"))
+        sender = ResendEmailSender(_settings(), client=client)
+
+        # WHEN / THEN
+        with pytest.raises(EmailSendError):
+            asyncio.run(
+                sender.send_password_reset(
+                    to_email="user@example.com",
+                    reset_url="https://app.example/reset",
+                )
+            )

--- a/tests/unit/api/services/test_email.py
+++ b/tests/unit/api/services/test_email.py
@@ -1,8 +1,7 @@
 """Unit tests for the email sender implementations."""
 
 import asyncio
-import logging
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -27,7 +26,7 @@ def _settings(**overrides: object) -> MagicMock:
 class TestConsoleEmailSender:
     """Tests for the development console email sender."""
 
-    def test_logs_reset_link_without_network(self, caplog):
+    def test_logs_reset_link_without_network(self):
         """
         GIVEN a console email sender
         WHEN a password reset email is sent
@@ -37,7 +36,7 @@ class TestConsoleEmailSender:
         sender = ConsoleEmailSender(_settings())
 
         # WHEN
-        with caplog.at_level(logging.INFO, logger="api.service.email"):
+        with patch("api.services.email.console_email_sender.logger") as mock_logger:
             asyncio.run(
                 sender.send_password_reset(
                     to_email="user@example.com",
@@ -46,7 +45,8 @@ class TestConsoleEmailSender:
             )
 
         # THEN
-        assert "https://app.example/reset-password?token=abc123" in caplog.text
+        mock_logger.info.assert_called_once()
+        assert "https://app.example/reset-password?token=abc123" in str(mock_logger.info.call_args)
 
 
 class TestResendEmailSender:

--- a/tests/unit/api/services/test_password_reset.py
+++ b/tests/unit/api/services/test_password_reset.py
@@ -1,0 +1,186 @@
+"""Unit tests for PasswordResetService."""
+
+import hashlib
+from datetime import timedelta
+
+import pytest
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine, select
+
+from api.auth.password import verify_password
+from api.db.models import PasswordResetToken, User
+from api.db.utils import utc_now
+from api.exceptions import InvalidResetTokenError, ResetTokenExpiredError
+from api.services.password_reset_service import PasswordResetService
+
+
+def _hash(raw: str) -> str:
+    """Hash a raw token the same way the service stores it."""
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+@pytest.fixture
+def session():
+    """In-memory SQLite session with all tables created."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as db_session:
+        yield db_session
+    engine.dispose()
+
+
+def _make_user(session: Session, email: str = "user@example.com") -> User:
+    """Persist and return a user."""
+    user = User(
+        email=email,
+        hashed_password="old-hash",
+        first_name="Test",
+        last_name="User",
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+class TestCreateResetToken:
+    """Tests for issuing reset tokens."""
+
+    def test_returns_raw_token_and_stores_only_hash(self, session):
+        """
+        GIVEN an existing user
+        WHEN a reset token is created
+        THEN a raw token is returned and only its SHA-256 hash is stored
+        """
+        # GIVEN
+        user = _make_user(session)
+        service = PasswordResetService(session)
+
+        # WHEN
+        raw = service.create_reset_token(user.email)
+
+        # THEN
+        assert raw
+        stored = session.exec(select(PasswordResetToken)).all()
+        assert len(stored) == 1
+        assert stored[0].token_hash == _hash(raw)
+        assert raw != stored[0].token_hash
+
+    def test_returns_none_for_unknown_email(self, session):
+        """
+        GIVEN no user with the requested email
+        WHEN a reset token is requested
+        THEN None is returned and no token row is written
+        """
+        # GIVEN
+        service = PasswordResetService(session)
+
+        # WHEN
+        raw = service.create_reset_token("nobody@example.com")
+
+        # THEN
+        assert raw is None
+        assert session.exec(select(PasswordResetToken)).all() == []
+
+    def test_invalidates_previous_tokens(self, session):
+        """
+        GIVEN a user with an outstanding reset token
+        WHEN a second token is requested
+        THEN the first token is marked used
+        """
+        # GIVEN
+        user = _make_user(session)
+        service = PasswordResetService(session)
+        first_raw = service.create_reset_token(user.email)
+
+        # WHEN
+        service.create_reset_token(user.email)
+
+        # THEN
+        first = session.exec(
+            select(PasswordResetToken).where(PasswordResetToken.token_hash == _hash(first_raw))
+        ).first()
+        assert first is not None
+        assert first.used_at is not None
+
+
+class TestResetPassword:
+    """Tests for redeeming reset tokens."""
+
+    def test_sets_new_password_and_marks_token_used(self, session):
+        """
+        GIVEN a valid reset token
+        WHEN the password is reset
+        THEN the new password verifies and the token is marked used
+        """
+        # GIVEN
+        user = _make_user(session)
+        service = PasswordResetService(session)
+        raw = service.create_reset_token(user.email)
+
+        # WHEN
+        updated = service.reset_password(raw, "NewSecurePass123!")
+
+        # THEN
+        assert verify_password("NewSecurePass123!", updated.hashed_password)
+        record = session.exec(
+            select(PasswordResetToken).where(PasswordResetToken.token_hash == _hash(raw))
+        ).first()
+        assert record is not None
+        assert record.used_at is not None
+
+    def test_raises_for_unknown_token(self, session):
+        """
+        GIVEN a token that does not exist
+        WHEN the password reset is attempted
+        THEN InvalidResetTokenError is raised
+        """
+        # GIVEN
+        service = PasswordResetService(session)
+
+        # WHEN / THEN
+        with pytest.raises(InvalidResetTokenError):
+            service.reset_password("garbage-token", "NewSecurePass123!")
+
+    def test_raises_for_already_used_token(self, session):
+        """
+        GIVEN a token that has already been redeemed
+        WHEN the password reset is attempted again
+        THEN InvalidResetTokenError is raised
+        """
+        # GIVEN
+        user = _make_user(session)
+        service = PasswordResetService(session)
+        raw = service.create_reset_token(user.email)
+        service.reset_password(raw, "NewSecurePass123!")
+
+        # WHEN / THEN
+        with pytest.raises(InvalidResetTokenError):
+            service.reset_password(raw, "AnotherPass123!")
+
+    def test_raises_for_expired_token(self, session):
+        """
+        GIVEN a token whose expiry is in the past
+        WHEN the password reset is attempted
+        THEN ResetTokenExpiredError is raised
+        """
+        # GIVEN
+        user = _make_user(session)
+        raw = "expired-raw-token-value"
+        session.add(
+            PasswordResetToken(
+                user_id=user.id,
+                token_hash=_hash(raw),
+                expires_at=utc_now() - timedelta(hours=1),
+            )
+        )
+        session.commit()
+        service = PasswordResetService(session)
+
+        # WHEN / THEN
+        with pytest.raises(ResetTokenExpiredError):
+            service.reset_password(raw, "NewSecurePass123!")

--- a/tests/unit/api/services/test_password_reset.py
+++ b/tests/unit/api/services/test_password_reset.py
@@ -2,6 +2,7 @@
 
 import hashlib
 from datetime import timedelta
+from uuid import uuid4
 
 import pytest
 from sqlalchemy.pool import StaticPool
@@ -183,4 +184,26 @@ class TestResetPassword:
 
         # WHEN / THEN
         with pytest.raises(ResetTokenExpiredError):
+            service.reset_password(raw, "NewSecurePass123!")
+
+    def test_raises_when_user_missing_for_valid_token(self, session):
+        """
+        GIVEN a non-expired token whose user no longer exists
+        WHEN the password reset is attempted
+        THEN InvalidResetTokenError is raised
+        """
+        # GIVEN — a token row pointing at a user id that was never created
+        raw = "orphan-token-value"
+        session.add(
+            PasswordResetToken(
+                user_id=uuid4(),
+                token_hash=_hash(raw),
+                expires_at=utc_now() + timedelta(hours=1),
+            )
+        )
+        session.commit()
+        service = PasswordResetService(session)
+
+        # WHEN / THEN
+        with pytest.raises(InvalidResetTokenError):
             service.reset_password(raw, "NewSecurePass123!")

--- a/tests/unit/api/services/test_password_reset.py
+++ b/tests/unit/api/services/test_password_reset.py
@@ -20,6 +20,11 @@ def _hash(raw: str) -> str:
     return hashlib.sha256(raw.encode()).hexdigest()
 
 
+def _token_from_url(url: str) -> str:
+    """Extract the raw token from a reset URL (the part after ``token=``)."""
+    return url.split("token=")[1]
+
+
 @pytest.fixture
 def session():
     """In-memory SQLite session with all tables created."""
@@ -51,25 +56,27 @@ def _make_user(session: Session, email: str = "user@example.com") -> User:
 class TestCreateResetToken:
     """Tests for issuing reset tokens."""
 
-    def test_returns_raw_token_and_stores_only_hash(self, session):
+    def test_returns_reset_url_and_stores_only_hash(self, session):
         """
         GIVEN an existing user
         WHEN a reset token is created
-        THEN a raw token is returned and only its SHA-256 hash is stored
+        THEN a reset URL is returned and only the token's SHA-256 hash is stored
         """
         # GIVEN
         user = _make_user(session)
         service = PasswordResetService(session)
 
         # WHEN
-        raw = service.create_reset_token(user.email)
+        url = service.create_reset_token(user.email)
 
         # THEN
-        assert raw
+        assert url
+        assert "/reset-password?token=" in url
+        token = _token_from_url(url)
         stored = session.exec(select(PasswordResetToken)).all()
         assert len(stored) == 1
-        assert stored[0].token_hash == _hash(raw)
-        assert raw != stored[0].token_hash
+        assert stored[0].token_hash == _hash(token)
+        assert token != stored[0].token_hash
 
     def test_returns_none_for_unknown_email(self, session):
         """
@@ -96,14 +103,16 @@ class TestCreateResetToken:
         # GIVEN
         user = _make_user(session)
         service = PasswordResetService(session)
-        first_raw = service.create_reset_token(user.email)
+        first_url = service.create_reset_token(user.email)
 
         # WHEN
         service.create_reset_token(user.email)
 
         # THEN
         first = session.exec(
-            select(PasswordResetToken).where(PasswordResetToken.token_hash == _hash(first_raw))
+            select(PasswordResetToken).where(
+                PasswordResetToken.token_hash == _hash(_token_from_url(first_url))
+            )
         ).first()
         assert first is not None
         assert first.used_at is not None
@@ -121,15 +130,15 @@ class TestResetPassword:
         # GIVEN
         user = _make_user(session)
         service = PasswordResetService(session)
-        raw = service.create_reset_token(user.email)
+        token = _token_from_url(service.create_reset_token(user.email))
 
         # WHEN
-        updated = service.reset_password(raw, "NewSecurePass123!")
+        updated = service.reset_password(token, "NewSecurePass123!")
 
         # THEN
         assert verify_password("NewSecurePass123!", updated.hashed_password)
         record = session.exec(
-            select(PasswordResetToken).where(PasswordResetToken.token_hash == _hash(raw))
+            select(PasswordResetToken).where(PasswordResetToken.token_hash == _hash(token))
         ).first()
         assert record is not None
         assert record.used_at is not None
@@ -156,12 +165,12 @@ class TestResetPassword:
         # GIVEN
         user = _make_user(session)
         service = PasswordResetService(session)
-        raw = service.create_reset_token(user.email)
-        service.reset_password(raw, "NewSecurePass123!")
+        token = _token_from_url(service.create_reset_token(user.email))
+        service.reset_password(token, "NewSecurePass123!")
 
         # WHEN / THEN
         with pytest.raises(InvalidResetTokenError):
-            service.reset_password(raw, "AnotherPass123!")
+            service.reset_password(token, "AnotherPass123!")
 
     def test_raises_for_expired_token(self, session):
         """

--- a/tests/unit/api/test_config.py
+++ b/tests/unit/api/test_config.py
@@ -77,6 +77,24 @@ class TestStorageEnabled:
 class TestEmailEnabled:
     """Tests for email settings defaults and the email_enabled property."""
 
+    @pytest.fixture(autouse=True)
+    def _isolate_email_env(self, monkeypatch, tmp_path):
+        """Isolate from the local .env file and any EMAIL_* process variables.
+
+        Without this, a developer's local .env (which may set EMAIL_PROVIDER and
+        EMAIL_API_KEY for real sending) leaks into these default-value tests and
+        breaks them, even though CI -- with no .env -- stays green.
+        """
+        monkeypatch.chdir(tmp_path)
+        for var in (
+            "EMAIL_PROVIDER",
+            "EMAIL_API_KEY",
+            "EMAIL_FROM",
+            "EMAIL_FROM_NAME",
+            "FRONTEND_BASE_URL",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
     def test_email_provider_defaults_to_console(self):
         """
         GIVEN Settings without an explicit email provider

--- a/tests/unit/api/test_config.py
+++ b/tests/unit/api/test_config.py
@@ -74,6 +74,74 @@ class TestStorageEnabled:
         assert settings.storage_enabled is False
 
 
+class TestEmailEnabled:
+    """Tests for email settings defaults and the email_enabled property."""
+
+    def test_email_provider_defaults_to_console(self):
+        """
+        GIVEN Settings without an explicit email provider
+        WHEN constructed
+        THEN email_provider defaults to "console"
+        """
+        # GIVEN / WHEN
+        settings = Settings(secret_key="test-secret-key")
+
+        # THEN
+        assert settings.email_provider == "console"
+
+    def test_token_ttl_defaults_to_60_minutes(self):
+        """
+        GIVEN Settings without an explicit reset-token TTL
+        WHEN constructed
+        THEN password_reset_token_ttl_minutes defaults to 60
+        """
+        # GIVEN / WHEN
+        settings = Settings(secret_key="test-secret-key")
+
+        # THEN
+        assert settings.password_reset_token_ttl_minutes == 60
+
+    def test_returns_false_for_console_provider(self):
+        """
+        GIVEN the default console email provider
+        WHEN email_enabled is accessed
+        THEN it returns False (console never counts as a real send)
+        """
+        # GIVEN
+        settings = Settings(secret_key="test-secret-key")
+
+        # WHEN / THEN
+        assert settings.email_enabled is False
+
+    def test_returns_false_for_http_without_api_key(self):
+        """
+        GIVEN the http email provider but no API key
+        WHEN email_enabled is accessed
+        THEN it returns False
+        """
+        # GIVEN
+        settings = Settings(secret_key="test-secret-key", email_provider="http")
+
+        # WHEN / THEN
+        assert settings.email_enabled is False
+
+    def test_returns_true_for_http_with_api_key(self):
+        """
+        GIVEN the http email provider with an API key set
+        WHEN email_enabled is accessed
+        THEN it returns True
+        """
+        # GIVEN
+        settings = Settings(
+            secret_key="test-secret-key",
+            email_provider="http",
+            email_api_key="re_test_key",
+        )
+
+        # WHEN / THEN
+        assert settings.email_enabled is True
+
+
 class TestEnvironmentResolution:
     """Tests for APP_ENV profile resolution."""
 

--- a/tests/unit/api/test_dependencies.py
+++ b/tests/unit/api/test_dependencies.py
@@ -3,7 +3,14 @@
 from unittest.mock import MagicMock, patch
 
 from api.config import Settings
-from api.dependencies import get_storage_service
+from api.dependencies import (
+    get_email_service,
+    get_password_reset_service,
+    get_storage_service,
+)
+from api.services.email.console_email_sender import ConsoleEmailSender
+from api.services.email.resend_email_sender import ResendEmailSender
+from api.services.password_reset_service import PasswordResetService
 from api.services.storage.exceptions import StorageConfigurationError
 from api.services.storage.railway_bucket_storage_service import RailwayBucketStorageService
 
@@ -74,3 +81,81 @@ class TestGetStorageService:
 
         # THEN
         assert result is None
+
+
+class TestGetEmailService:
+    """Tests for the get_email_service factory function."""
+
+    def test_returns_console_sender_for_console_provider(self):
+        """
+        GIVEN the console email provider
+        WHEN get_email_service is called
+        THEN it returns a ConsoleEmailSender
+        """
+        # GIVEN
+        mock_settings = MagicMock(spec=Settings)
+        mock_settings.email_provider = "console"
+        mock_settings.email_enabled = False
+
+        # WHEN
+        with patch("api.dependencies.get_settings", return_value=mock_settings):
+            result = get_email_service()
+
+        # THEN
+        assert isinstance(result, ConsoleEmailSender)
+
+    def test_returns_resend_sender_for_configured_http_provider(self):
+        """
+        GIVEN the http email provider with credentials set
+        WHEN get_email_service is called
+        THEN it returns a ResendEmailSender
+        """
+        # GIVEN
+        mock_settings = MagicMock(spec=Settings)
+        mock_settings.email_provider = "http"
+        mock_settings.email_enabled = True
+
+        # WHEN
+        with patch("api.dependencies.get_settings", return_value=mock_settings):
+            result = get_email_service()
+
+        # THEN
+        assert isinstance(result, ResendEmailSender)
+
+    def test_falls_back_to_console_when_http_unconfigured(self):
+        """
+        GIVEN the http provider selected but no credentials
+        WHEN get_email_service is called
+        THEN it falls back to a ConsoleEmailSender (no crash, preserves anti-enumeration)
+        """
+        # GIVEN
+        mock_settings = MagicMock(spec=Settings)
+        mock_settings.email_provider = "http"
+        mock_settings.email_enabled = False
+
+        # WHEN
+        with patch("api.dependencies.get_settings", return_value=mock_settings):
+            result = get_email_service()
+
+        # THEN
+        assert isinstance(result, ConsoleEmailSender)
+
+
+class TestGetPasswordResetService:
+    """Tests for the get_password_reset_service factory function."""
+
+    def test_returns_service_bound_to_session(self):
+        """
+        GIVEN a database session
+        WHEN get_password_reset_service is called
+        THEN it returns a PasswordResetService bound to that session
+        """
+        # GIVEN
+        mock_session = MagicMock()
+
+        # WHEN
+        result = get_password_reset_service(mock_session)
+
+        # THEN
+        assert isinstance(result, PasswordResetService)
+        assert result.session is mock_session


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a full password-reset flow: a `PasswordResetService` that issues and redeems single-use SHA-256-hashed tokens, two new auth endpoints (`/forgot-password` and `/reset-password`), an `EmailSender` abstraction with a Resend HTTP backend and a console fallback, two new frontend pages, and accompanying i18n keys.

- The anti-enumeration design (identical 202 responses, swallowed email failures, same opaque 400 for invalid/expired tokens) is consistently applied across the backend and frontend.
- The email HTML template in `ResendEmailSender._build_html` hardcodes "one hour" as the expiry text, which diverges from the configurable `password_reset_token_ttl_minutes` setting; changing the TTL will send users an incorrect expiry time.
- The `forgot_password` route calls `get_settings()` directly to assemble the reset URL, placing URL-construction logic in the route rather than the service layer.

<h3>Confidence Score: 3/5</h3>

The core reset flow is safe to merge with a fix to the email body before it ships to production users.

The email template hardcodes 'one hour' independent of the configurable TTL — if the TTL is changed in a production deployment the link may already be expired when users click it, making the feature unreliable. Everything else — token hashing, anti-enumeration 202s, the console fallback, frontend i18n parity, and the exception hierarchy — is solid.

api/services/email/resend_email_sender.py (_build_html hardcodes the expiry string) and api/routes/auth.py (reset-URL construction should move into the service).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/services/password_reset_service.py | Core password-reset service: hashes tokens with SHA-256, invalidates outstanding tokens before issuing new ones, and correctly raises distinct domain exceptions for unknown vs. expired tokens. |
| api/services/email/resend_email_sender.py | Production Resend email sender: hardcodes 'one hour' expiry text in _build_html regardless of the configurable password_reset_token_ttl_minutes setting, causing a mismatch whenever the TTL is changed. |
| api/routes/auth.py | Adds forgot-password and reset-password endpoints with anti-enumeration 202 responses and rate limiting; reset-URL construction via get_settings() inside the route is business logic that should live in the service layer. |
| api/dependencies.py | Adds get_password_reset_service and get_email_service factories; get_email_service correctly falls back to ConsoleEmailSender when the HTTP provider is not fully configured. |
| api/config.py | Adds email provider settings with safe console default; email_enabled property correctly requires both http provider and a non-empty API key. |
| api/middleware/exception_handlers.py | Maps both reset-token exceptions to the same opaque 400 message; deliberate conflation documented in an inline comment. |
| frontend/src/pages/ForgotPassword.tsx | Forgot-password form that swallows all errors to preserve anti-enumeration UX; all strings correctly use t() from the auth namespace. |
| frontend/src/pages/ResetPassword.tsx | Reset-password form with password-strength checklist, gracefully handles missing token with a redirect prompt, and navigates to /login on success. |
| frontend/src/lib/api.ts | Adds forgotPassword and resetPassword API calls; both use the existing request() helper with correct HTTP methods and body shapes. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant FE as Frontend
    participant RT as /forgot-password
    participant PRS as PasswordResetService
    participant DB as Database
    participant ES as EmailSender

    U->>FE: Submit email (ForgotPassword page)
    FE->>RT: "POST /api/v1/auth/forgot-password {email}"
    RT->>PRS: create_reset_token(email)
    PRS->>DB: "SELECT user WHERE email=..."
    alt User not found
        PRS-->>RT: None
    else User found
        PRS->>DB: "Mark outstanding tokens used_at=now"
        PRS->>DB: INSERT new PasswordResetToken (SHA-256 hash)
        PRS-->>RT: raw_token
        RT->>RT: Build reset_url (settings.frontend_base_url + token)
        RT->>ES: send_password_reset(to_email, reset_url)
        alt HTTP provider configured
            ES->>ES: POST Resend API
        else Console provider
            ES->>ES: logger.info (link logged)
        end
    end
    RT-->>FE: "202 {detail: If that email is registered...}"
    FE-->>U: Show success screen (same either way)

    U->>FE: Click link, enter new password (ResetPassword page)
    FE->>RT: "POST /api/v1/auth/reset-password {token, new_password}"
    RT->>PRS: reset_password(token, new_password)
    PRS->>DB: "SELECT token WHERE hash=SHA256(token)"
    alt Token unknown or already used
        PRS-->>RT: raise InvalidResetTokenError
    else Token expired
        PRS-->>RT: raise ResetTokenExpiredError
    else Token valid
        PRS->>DB: UPDATE user.hashed_password
        PRS->>DB: "UPDATE token.used_at=now"
        PRS-->>RT: User
        RT-->>FE: 204 No Content
        FE-->>U: Toast success, navigate to /login
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant FE as Frontend
    participant RT as /forgot-password
    participant PRS as PasswordResetService
    participant DB as Database
    participant ES as EmailSender

    U->>FE: Submit email (ForgotPassword page)
    FE->>RT: "POST /api/v1/auth/forgot-password {email}"
    RT->>PRS: create_reset_token(email)
    PRS->>DB: "SELECT user WHERE email=..."
    alt User not found
        PRS-->>RT: None
    else User found
        PRS->>DB: "Mark outstanding tokens used_at=now"
        PRS->>DB: INSERT new PasswordResetToken (SHA-256 hash)
        PRS-->>RT: raw_token
        RT->>RT: Build reset_url (settings.frontend_base_url + token)
        RT->>ES: send_password_reset(to_email, reset_url)
        alt HTTP provider configured
            ES->>ES: POST Resend API
        else Console provider
            ES->>ES: logger.info (link logged)
        end
    end
    RT-->>FE: "202 {detail: If that email is registered...}"
    FE-->>U: Show success screen (same either way)

    U->>FE: Click link, enter new password (ResetPassword page)
    FE->>RT: "POST /api/v1/auth/reset-password {token, new_password}"
    RT->>PRS: reset_password(token, new_password)
    PRS->>DB: "SELECT token WHERE hash=SHA256(token)"
    alt Token unknown or already used
        PRS-->>RT: raise InvalidResetTokenError
    else Token expired
        PRS-->>RT: raise ResetTokenExpiredError
    else Token valid
        PRS->>DB: UPDATE user.hashed_password
        PRS->>DB: "UPDATE token.used_at=now"
        PRS-->>RT: User
        RT-->>FE: 204 No Content
        FE-->>U: Toast success, navigate to /login
    end
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
api/services/email/resend_email_sender.py:59-64
**Hardcoded TTL in email body diverges from configured value**

`_build_html` always tells recipients "The link expires in one hour", but the actual expiry is driven by `password_reset_token_ttl_minutes` (default 60, but freely overridden). An operator who changes the TTL to, say, 30 minutes will send emails that claim an hour of validity, causing users to follow a link that already expired — or to wait unnecessarily before requesting a new one. The settings object is already available via `self._settings`, so the body can be rendered dynamically using `self._settings.password_reset_token_ttl_minutes`.

### Issue 2 of 2
api/routes/auth.py:195-207
**Reset-URL construction is business logic that belongs in the service**

The `forgot_password` route calls `get_settings()` directly to build the reset link. Per the `api-thin-endpoints` rule, business logic — including assembling the target URL from a token and the configured frontend origin — belongs in the service layer, not the route. The route should receive a ready-to-send URL from `PasswordResetService.create_reset_token` and pass it straight to the email sender.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add ForgotPassword and ResetPasswo..."](https://github.com/caitlon/become/commit/87763c0d4ce2487722455e6ed65743a50c5a8183) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39529346)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - Keep endpoints thin. Business logic belongs in ser... ([source](.greptile))

<!-- /greptile_comment -->