### PR TITLE
feat: add GDPR data export endpoint

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -83,6 +83,7 @@ api/
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | `/api/v1/users/me` | Get profile |
+| GET | `/api/v1/users/me/export` | Export all personal data as JSON (GDPR Art. 20) |
 | PUT | `/api/v1/users/me` | Update profile |
 | PUT | `/api/v1/users/me/password` | Change password |
 | POST | `/api/v1/users/me/photo` | Upload photo |

--- a/api/auth/logging.py
+++ b/api/auth/logging.py
@@ -138,3 +138,20 @@ def log_account_deletion(user_id: UUID, email: str, request: "Request | None" = 
             "ip": ip,
         },
     )
+
+
+def log_data_export(user_id: UUID, request: "Request | None" = None) -> None:
+    """Log a GDPR data export download (Article 20).
+
+    :param user_id: ID of the user who exported their data
+    :param request: FastAPI request (for IP extraction)
+    """
+    ip = get_client_ip(request)
+    logger.info(
+        "Data export downloaded",
+        extra={
+            "event": "data_export",
+            "user_id": str(user_id),
+            "ip": ip,
+        },
+    )

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -17,6 +17,7 @@ from api.config import get_settings
 from api.db.models import Project
 from api.db.session import get_session
 from api.services.calculation_service import CalculationService
+from api.services.data_export_service import DataExportService
 from api.services.email.base import EmailSender
 from api.services.email.console_email_sender import ConsoleEmailSender
 from api.services.email.resend_email_sender import ResendEmailSender
@@ -83,6 +84,13 @@ def get_calculation_service(
 ) -> CalculationService:
     """Create CalculationService instance."""
     return CalculationService(session)
+
+
+def get_data_export_service(
+    session: Annotated[Session, Depends(get_session)],
+) -> DataExportService:
+    """Create DataExportService instance."""
+    return DataExportService(session)
 
 
 def get_invitation_service(session: Annotated[Session, Depends(get_session)]) -> InvitationService:

--- a/api/routes/users.py
+++ b/api/routes/users.py
@@ -7,10 +7,18 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, File, HTTPException, Request, Response, UploadFile, status
 
 from api.auth.dependencies import CurrentUser
-from api.auth.logging import log_account_deletion, log_password_change
-from api.dependencies import get_storage_service, get_user_service
-from api.middleware.rate_limit import LIMIT_PHOTO, LIMIT_PWD_RESET, LIMIT_UPLOAD, limiter
+from api.auth.logging import log_account_deletion, log_data_export, log_password_change
+from api.dependencies import get_data_export_service, get_storage_service, get_user_service
+from api.middleware.rate_limit import (
+    LIMIT_PHOTO,
+    LIMIT_PWD_RESET,
+    LIMIT_STANDARD,
+    LIMIT_UPLOAD,
+    limiter,
+)
 from api.schemas.auth import ChangePasswordRequest, UpdateUserRequest, UserResponse
+from api.schemas.data_export import DataExportResponse
+from api.services.data_export_service import DataExportService
 from api.services.storage import validation
 from api.services.storage.base import StorageService
 from api.services.storage.exceptions import StorageDeleteError, StorageUploadError
@@ -27,6 +35,32 @@ def get_current_user_profile(current_user: CurrentUser) -> UserResponse:
     :return: User profile data
     """
     return UserResponse.from_user(current_user)
+
+
+@router.get(
+    "/me/export",
+    summary="Export current user's personal data (GDPR Article 20)",
+)
+@limiter.limit(LIMIT_STANDARD)
+def export_current_user_data(
+    request: Request,
+    current_user: CurrentUser,
+    service: Annotated[DataExportService, Depends(get_data_export_service)],
+) -> DataExportResponse:
+    """Return all of the authenticated user's data in machine-readable form.
+
+    Serves the GDPR Article 20 right to data portability: profile, owned
+    projects with results, memberships, submitted opinions, and pending
+    invitations. Password material is never included.
+
+    :param request: FastAPI request (for rate limiting and audit logging)
+    :param current_user: User from JWT token
+    :param service: Data export service
+    :return: The user's full data export
+    """
+    export = service.build_export(current_user)
+    log_data_export(current_user.id, request)
+    return export
 
 
 @router.put("/me", summary="Update current user profile")

--- a/api/schemas/data_export.py
+++ b/api/schemas/data_export.py
@@ -31,6 +31,17 @@ EXPORT_DESCRIPTION = (
 )
 
 
+def _centroid(lower: float, peak: float, upper: float) -> float:
+    """Compute the centroid of a triangular fuzzy number from its three vertices.
+
+    :param lower: Lower bound (pessimistic estimate).
+    :param peak: Peak value (most likely).
+    :param upper: Upper bound (optimistic estimate).
+    :return: The centroid, i.e. the mean of the triangle's three vertices.
+    """
+    return (lower + peak + upper) / 3
+
+
 def _fuzzy(lower: float, peak: float, upper: float) -> FuzzyNumberOutput:
     """Build a fuzzy-number output with a centroid from raw bounds.
 
@@ -43,7 +54,7 @@ def _fuzzy(lower: float, peak: float, upper: float) -> FuzzyNumberOutput:
         lower=lower,
         peak=peak,
         upper=upper,
-        centroid=(lower + peak + upper) / 3,
+        centroid=_centroid(lower, peak, upper),
     )
 
 
@@ -217,7 +228,7 @@ class ExportOpinion(BaseModel):
             lower_bound=opinion.lower_bound,
             peak=opinion.peak,
             upper_bound=opinion.upper_bound,
-            centroid=(opinion.lower_bound + opinion.peak + opinion.upper_bound) / 3,
+            centroid=_centroid(opinion.lower_bound, opinion.peak, opinion.upper_bound),
             created_at=opinion.created_at,
             updated_at=opinion.updated_at,
         )

--- a/api/schemas/data_export.py
+++ b/api/schemas/data_export.py
@@ -1,0 +1,263 @@
+"""GDPR data export schemas (Article 20 - data portability).
+
+These schemas describe the machine-readable document returned by
+``GET /users/me/export``. They deliberately mirror only the data a user
+contributed (profile, owned projects, memberships, opinions, invitations) and
+never expose password material.
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+from api.schemas.calculation import FuzzyNumberOutput
+from api.utils.photo_links import build_photo_url
+
+if TYPE_CHECKING:
+    from api.db.models import (
+        CalculationResult,
+        ExpertOpinion,
+        Invitation,
+        Project,
+        ProjectMember,
+        User,
+    )
+
+EXPORT_FORMAT_VERSION = "1.0"
+EXPORT_DESCRIPTION = (
+    "Personal data export under GDPR Article 20 (right to data portability). "
+    "Contains all data associated with your BeCoMe account."
+)
+
+
+def _fuzzy(lower: float, peak: float, upper: float) -> FuzzyNumberOutput:
+    """Build a fuzzy-number output with a centroid from raw bounds.
+
+    :param lower: Lower bound (pessimistic estimate).
+    :param peak: Peak value (most likely).
+    :param upper: Upper bound (optimistic estimate).
+    :return: FuzzyNumberOutput with the computed centroid.
+    """
+    return FuzzyNumberOutput(
+        lower=lower,
+        peak=peak,
+        upper=upper,
+        centroid=(lower + peak + upper) / 3,
+    )
+
+
+class ExportMetadata(BaseModel):
+    """Metadata describing the export document itself."""
+
+    format_version: str
+    generated_at: datetime
+    description: str
+
+
+class ExportProfile(BaseModel):
+    """The account holder's own profile (no password material)."""
+
+    id: str
+    email: str
+    first_name: str
+    last_name: str
+    photo_url: str | None = None
+    created_at: datetime
+
+    @classmethod
+    def from_user(cls, user: "User") -> "ExportProfile":
+        """Build the profile section from a user model.
+
+        :param user: User database model.
+        :return: ExportProfile with the public photo URL, never a password hash.
+        """
+        return cls(
+            id=str(user.id),
+            email=user.email,
+            first_name=user.first_name,
+            last_name=user.last_name,
+            photo_url=build_photo_url(user.id, user.photo_url),
+            created_at=user.created_at,
+        )
+
+
+class ExportResult(BaseModel):
+    """BeCoMe calculation result attached to an owned project."""
+
+    best_compromise: FuzzyNumberOutput
+    arithmetic_mean: FuzzyNumberOutput
+    median: FuzzyNumberOutput
+    max_error: float
+    num_experts: int
+    likert_value: int | None = None
+    likert_decision: str | None = None
+    calculated_at: datetime
+
+    @classmethod
+    def from_model(cls, result: "CalculationResult") -> "ExportResult":
+        """Build the result section from a calculation result model.
+
+        :param result: CalculationResult database model.
+        :return: ExportResult with grouped fuzzy components.
+        """
+        return cls(
+            best_compromise=_fuzzy(
+                result.best_compromise_lower,
+                result.best_compromise_peak,
+                result.best_compromise_upper,
+            ),
+            arithmetic_mean=_fuzzy(
+                result.arithmetic_mean_lower,
+                result.arithmetic_mean_peak,
+                result.arithmetic_mean_upper,
+            ),
+            median=_fuzzy(
+                result.median_lower,
+                result.median_peak,
+                result.median_upper,
+            ),
+            max_error=result.max_error,
+            num_experts=result.num_experts,
+            likert_value=result.likert_value,
+            likert_decision=result.likert_decision,
+            calculated_at=result.calculated_at,
+        )
+
+
+class ExportOwnedProject(BaseModel):
+    """A project the account holder administers."""
+
+    id: str
+    name: str
+    description: str | None = None
+    scale_min: float
+    scale_max: float
+    scale_unit: str
+    created_at: datetime
+    result: ExportResult | None = None
+
+    @classmethod
+    def from_model(
+        cls, project: "Project", result: "CalculationResult | None"
+    ) -> "ExportOwnedProject":
+        """Build an owned-project section from a project model.
+
+        The cached result is passed explicitly (loaded via an outer join) so the
+        export assembles in a fixed number of queries instead of lazy-loading per
+        project.
+
+        :param project: Project database model.
+        :param result: Cached calculation result, or None when not computed yet.
+        :return: ExportOwnedProject including the cached result when present.
+        """
+        return cls(
+            id=str(project.id),
+            name=project.name,
+            description=project.description,
+            scale_min=project.scale_min,
+            scale_max=project.scale_max,
+            scale_unit=project.scale_unit,
+            created_at=project.created_at,
+            result=ExportResult.from_model(result) if result else None,
+        )
+
+
+class ExportMembership(BaseModel):
+    """A project the account holder participates in."""
+
+    project_id: str
+    project_name: str
+    role: str
+    joined_at: datetime
+
+    @classmethod
+    def from_model(cls, member: "ProjectMember", project: "Project") -> "ExportMembership":
+        """Build a membership section from a membership model.
+
+        :param member: ProjectMember database model.
+        :param project: The project joined to the membership.
+        :return: ExportMembership with the project name and the user's role.
+        """
+        return cls(
+            project_id=str(member.project_id),
+            project_name=project.name,
+            role=member.role.value,
+            joined_at=member.joined_at,
+        )
+
+
+class ExportOpinion(BaseModel):
+    """An expert opinion the account holder submitted."""
+
+    id: str
+    project_id: str
+    project_name: str
+    position: str
+    lower_bound: float
+    peak: float
+    upper_bound: float
+    centroid: float
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def from_model(cls, opinion: "ExpertOpinion", project: "Project") -> "ExportOpinion":
+        """Build an opinion section from an opinion model.
+
+        :param opinion: ExpertOpinion database model.
+        :param project: The project the opinion belongs to.
+        :return: ExportOpinion with the fuzzy triangular values and project name.
+        """
+        return cls(
+            id=str(opinion.id),
+            project_id=str(opinion.project_id),
+            project_name=project.name,
+            position=opinion.position,
+            lower_bound=opinion.lower_bound,
+            peak=opinion.peak,
+            upper_bound=opinion.upper_bound,
+            centroid=(opinion.lower_bound + opinion.peak + opinion.upper_bound) / 3,
+            created_at=opinion.created_at,
+            updated_at=opinion.updated_at,
+        )
+
+
+class ExportReceivedInvitation(BaseModel):
+    """A pending invitation addressed to the account holder."""
+
+    id: str
+    project_id: str
+    project_name: str
+    inviter_email: str
+    invited_at: datetime
+
+    @classmethod
+    def from_model(
+        cls, invitation: "Invitation", project: "Project", inviter: "User"
+    ) -> "ExportReceivedInvitation":
+        """Build an invitation section from an invitation model.
+
+        :param invitation: Invitation database model.
+        :param project: The project the invitation is for.
+        :param inviter: The user who sent the invitation.
+        :return: ExportReceivedInvitation with project name and inviter email.
+        """
+        return cls(
+            id=str(invitation.id),
+            project_id=str(invitation.project_id),
+            project_name=project.name,
+            inviter_email=inviter.email,
+            invited_at=invitation.created_at,
+        )
+
+
+class DataExportResponse(BaseModel):
+    """Full GDPR data export for a single user account."""
+
+    export_metadata: ExportMetadata
+    profile: ExportProfile
+    owned_projects: list[ExportOwnedProject]
+    memberships: list[ExportMembership]
+    opinions: list[ExportOpinion]
+    received_invitations: list[ExportReceivedInvitation]

--- a/api/services/data_export_service.py
+++ b/api/services/data_export_service.py
@@ -1,0 +1,134 @@
+"""GDPR data export business logic service (Article 20 - data portability)."""
+
+import logging
+from uuid import UUID
+
+from sqlmodel import col, select
+
+from api.db.models import (
+    CalculationResult,
+    ExpertOpinion,
+    Invitation,
+    Project,
+    ProjectMember,
+    User,
+)
+from api.db.utils import utc_now
+from api.schemas.data_export import (
+    EXPORT_DESCRIPTION,
+    EXPORT_FORMAT_VERSION,
+    DataExportResponse,
+    ExportMembership,
+    ExportMetadata,
+    ExportOpinion,
+    ExportOwnedProject,
+    ExportProfile,
+    ExportReceivedInvitation,
+)
+from api.services.base import BaseService
+
+logger = logging.getLogger("api.service.data_export")
+
+
+class DataExportService(BaseService):
+    """Assemble a full GDPR data export for a single user account.
+
+    Each related collection is loaded with an explicit join so the whole export
+    runs in a fixed number of queries rather than lazy-loading relationships per
+    row (no N+1 access).
+    """
+
+    def build_export(self, user: User) -> DataExportResponse:
+        """Collect every piece of data tied to a user into one document.
+
+        :param user: The authenticated account holder.
+        :return: DataExportResponse with profile, owned projects, memberships,
+            opinions, and received invitations.
+        """
+        response = DataExportResponse(
+            export_metadata=ExportMetadata(
+                format_version=EXPORT_FORMAT_VERSION,
+                generated_at=utc_now(),
+                description=EXPORT_DESCRIPTION,
+            ),
+            profile=ExportProfile.from_user(user),
+            owned_projects=self._owned_projects(user.id),
+            memberships=self._memberships(user.id),
+            opinions=self._opinions(user.id),
+            received_invitations=self._received_invitations(user.id),
+        )
+        logger.info(
+            "Data export generated",
+            extra={
+                "event": "data_export_generated",
+                "user_id": str(user.id),
+                "owned_projects": len(response.owned_projects),
+                "memberships": len(response.memberships),
+                "opinions": len(response.opinions),
+            },
+        )
+        return response
+
+    def _owned_projects(self, user_id: UUID) -> list[ExportOwnedProject]:
+        """Load projects the user administers with their cached results.
+
+        :param user_id: The account holder's ID.
+        :return: Owned projects ordered by creation date, each with its result.
+        """
+        statement = (
+            select(Project, CalculationResult)
+            .join(CalculationResult, col(CalculationResult.project_id) == Project.id, isouter=True)
+            .where(Project.admin_id == user_id)
+            .order_by(col(Project.created_at))
+        )
+        rows = self._session.exec(statement).all()
+        return [ExportOwnedProject.from_model(project, result) for project, result in rows]
+
+    def _memberships(self, user_id: UUID) -> list[ExportMembership]:
+        """Load the user's project memberships with their projects.
+
+        :param user_id: The account holder's ID.
+        :return: Memberships ordered by join date.
+        """
+        statement = (
+            select(ProjectMember, Project)
+            .join(Project, col(ProjectMember.project_id) == Project.id)
+            .where(ProjectMember.user_id == user_id)
+            .order_by(col(ProjectMember.joined_at))
+        )
+        rows = self._session.exec(statement).all()
+        return [ExportMembership.from_model(member, project) for member, project in rows]
+
+    def _opinions(self, user_id: UUID) -> list[ExportOpinion]:
+        """Load the opinions the user submitted with their projects.
+
+        :param user_id: The account holder's ID.
+        :return: Opinions ordered by creation date.
+        """
+        statement = (
+            select(ExpertOpinion, Project)
+            .join(Project, col(ExpertOpinion.project_id) == Project.id)
+            .where(ExpertOpinion.user_id == user_id)
+            .order_by(col(ExpertOpinion.created_at))
+        )
+        rows = self._session.exec(statement).all()
+        return [ExportOpinion.from_model(opinion, project) for opinion, project in rows]
+
+    def _received_invitations(self, user_id: UUID) -> list[ExportReceivedInvitation]:
+        """Load pending invitations addressed to the user with project and inviter.
+
+        :param user_id: The account holder's ID.
+        :return: Received invitations ordered by creation date.
+        """
+        statement = (
+            select(Invitation, Project, User)
+            .join(Project, col(Invitation.project_id) == Project.id)
+            .join(User, col(Invitation.inviter_id) == User.id)
+            .where(Invitation.invitee_id == user_id)
+            .order_by(col(Invitation.created_at))
+        )
+        rows = self._session.exec(statement).all()
+        return [
+            ExportReceivedInvitation.from_model(invitation, project, inviter)
+            for invitation, project, inviter in rows
+        ]

--- a/frontend/src/i18n/locales/cs/profile.json
+++ b/frontend/src/i18n/locales/cs/profile.json
@@ -12,6 +12,14 @@
     "confirmPassword": "Potvrdit nové heslo",
     "update": "Aktualizovat heslo"
   },
+  "dataExport": {
+    "title": "Stáhnout vaše data",
+    "description": "Exportujte všechna svá osobní data (profil, projekty, názory a pozvánky) do strojově čitelného souboru JSON.",
+    "button": "Stáhnout data",
+    "downloading": "Příprava stahování...",
+    "success": "Vaše data byla stažena",
+    "error": "Nepodařilo se exportovat vaše data"
+  },
   "dangerZone": {
     "title": "Nebezpečná zóna",
     "warning": "Po smazání účtu již není cesty zpět. Buďte si prosím jisti.",

--- a/frontend/src/i18n/locales/en/profile.json
+++ b/frontend/src/i18n/locales/en/profile.json
@@ -12,6 +12,14 @@
     "confirmPassword": "Confirm New Password",
     "update": "Update Password"
   },
+  "dataExport": {
+    "title": "Download Your Data",
+    "description": "Export all your personal data (profile, projects, opinions, and invitations) in a machine-readable JSON file.",
+    "button": "Download Data",
+    "downloading": "Preparing download...",
+    "success": "Your data has been downloaded",
+    "error": "Failed to export your data"
+  },
   "dangerZone": {
     "title": "Danger Zone",
     "warning": "Once you delete your account, there is no going back. Please be certain.",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -155,6 +155,13 @@ class ApiClient {
     return this.request<User>('/users/me');
   }
 
+  // Returns the user's full GDPR data export. The payload is only downloaded as
+  // a file (never rendered), so it stays an opaque record instead of mirroring
+  // the backend schema and risking drift.
+  async exportData(): Promise<Record<string, unknown>> {
+    return this.request<Record<string, unknown>>('/users/me/export');
+  }
+
   async updateCurrentUser(data: UpdateUserInput): Promise<User> {
     return this.request<User>('/users/me', {
       method: 'PUT',

--- a/frontend/src/lib/download.ts
+++ b/frontend/src/lib/download.ts
@@ -1,0 +1,27 @@
+/**
+ * Trigger a browser download of a JSON-serializable value as a file.
+ *
+ * Builds a Blob from the data and clicks a temporary anchor, then revokes the
+ * object URL. The fetch + Blob approach is required because the API authorizes
+ * with a Bearer header, so a plain `<a href download>` cannot reach the
+ * endpoint. Used for the GDPR data export download.
+ *
+ * @param data - Any JSON-serializable value.
+ * @param filename - Suggested file name for the download.
+ */
+export function downloadJson(data: unknown, filename: string): void {
+  const blob = new Blob([JSON.stringify(data, null, 2)], {
+    type: 'application/json',
+  });
+  const url = URL.createObjectURL(blob);
+  try {
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -2,7 +2,7 @@ import { useRef, useState } from "react";
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
-import { Loader2, AlertTriangle, Camera, Trash2 } from "lucide-react";
+import { Loader2, AlertTriangle, Camera, Trash2, Download } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -14,6 +14,7 @@ import { DeleteConfirmModal } from "@/components/modals/DeleteConfirmModal";
 import { ValidationChecklist } from "@/components/forms";
 import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
+import { downloadJson } from "@/lib/download";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
@@ -69,6 +70,9 @@ const Profile = () => {
 
   // Delete account
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+
+  // Data export (GDPR Article 20)
+  const [isExporting, setIsExporting] = useState(false);
 
   // Photo upload
   const [isUploadingPhoto, setIsUploadingPhoto] = useState(false);
@@ -191,6 +195,25 @@ const Profile = () => {
       });
     } finally {
       setIsChangingPassword(false);
+    }
+  };
+
+  const handleExportData = async () => {
+    setIsExporting(true);
+    try {
+      const data = await api.exportData();
+      const today = new Date().toISOString().slice(0, 10);
+      downloadJson(data, `become-data-export-${today}.json`);
+      toast({ title: t("dataExport.success") });
+    } catch (error) {
+      toast({
+        title: t("toast.error"),
+        description:
+          error instanceof Error ? error.message : t("dataExport.error"),
+        variant: "destructive",
+      });
+    } finally {
+      setIsExporting(false);
     }
   };
 
@@ -393,6 +416,35 @@ const Profile = () => {
                   <Loader2 className="h-4 w-4 animate-spin" />
                 ) : (
                   t("changePassword.update")
+                )}
+              </Button>
+            </CardContent>
+          </Card>
+
+          {/* Data Export (GDPR Article 20) */}
+          <Card>
+            <CardHeader>
+              <CardTitle>{t("dataExport.title")}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground mb-4">
+                {t("dataExport.description")}
+              </p>
+              <Button
+                variant="outline"
+                onClick={handleExportData}
+                disabled={isExporting}
+              >
+                {isExporting ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    {t("dataExport.downloading")}
+                  </>
+                ) : (
+                  <>
+                    <Download className="mr-2 h-4 w-4" />
+                    {t("dataExport.button")}
+                  </>
                 )}
               </Button>
             </CardContent>

--- a/frontend/tests/lib/download.test.ts
+++ b/frontend/tests/lib/download.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { downloadJson } from '@/lib/download';
+
+describe('downloadJson', () => {
+  let createObjectURL: ReturnType<typeof vi.fn>;
+  let revokeObjectURL: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    createObjectURL = vi.fn(() => 'blob:mock-url');
+    revokeObjectURL = vi.fn();
+    URL.createObjectURL = createObjectURL as unknown as typeof URL.createObjectURL;
+    URL.revokeObjectURL = revokeObjectURL as unknown as typeof URL.revokeObjectURL;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds a JSON blob and revokes the object URL afterwards', () => {
+    downloadJson({ hello: 'world' }, 'data.json');
+
+    expect(createObjectURL).toHaveBeenCalledOnce();
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    expect(blob.type).toBe('application/json');
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+
+  it('clicks an anchor carrying the requested filename', () => {
+    const click = vi.fn();
+    const anchor = document.createElement('a');
+    anchor.click = click;
+    const createElement = vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+
+    downloadJson({ a: 1 }, 'become-export.json');
+
+    expect(anchor.download).toBe('become-export.json');
+    expect(anchor.href).toBe('blob:mock-url');
+    expect(click).toHaveBeenCalledOnce();
+
+    createElement.mockRestore();
+  });
+
+  it('revokes the URL even when the click throws', () => {
+    const anchor = document.createElement('a');
+    anchor.click = vi.fn(() => {
+      throw new Error('click failed');
+    });
+    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+
+    expect(() => downloadJson({ a: 1 }, 'x.json')).toThrow('click failed');
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+});

--- a/frontend/tests/pages/Profile.test.tsx
+++ b/frontend/tests/pages/Profile.test.tsx
@@ -22,6 +22,7 @@ const mockApi = {
   deleteAccount: vi.fn(),
   uploadPhoto: vi.fn(),
   deletePhoto: vi.fn(),
+  exportData: vi.fn(),
 };
 vi.mock('@/lib/api', () => ({
   api: {
@@ -30,7 +31,14 @@ vi.mock('@/lib/api', () => ({
     deleteAccount: () => mockApi.deleteAccount(),
     uploadPhoto: (file: File) => mockApi.uploadPhoto(file),
     deletePhoto: () => mockApi.deletePhoto(),
+    exportData: () => mockApi.exportData(),
   },
+}));
+
+// Mock the file-download helper so no real Blob/anchor is exercised here
+const mockDownloadJson = vi.fn();
+vi.mock('@/lib/download', () => ({
+  downloadJson: (data: unknown, filename: string) => mockDownloadJson(data, filename),
 }));
 
 // Mock useToast
@@ -707,6 +715,79 @@ describe('Profile - Profile Update Error', () => {
         expect.objectContaining({
           title: 'Error',
           description: 'Failed to update profile',
+          variant: 'destructive',
+        })
+      );
+    });
+  });
+});
+
+describe('Profile - Data Export', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders Data Export section', () => {
+    render(<Profile />);
+
+    expect(screen.getByText('Download Your Data')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /download data/i })).toBeInTheDocument();
+  });
+
+  it('exports data and triggers a dated download with a success toast', async () => {
+    const user = userEvent.setup();
+    const payload = { profile: { email: 'john@example.com' } };
+    mockApi.exportData.mockResolvedValueOnce(payload);
+
+    render(<Profile />);
+
+    await user.click(screen.getByRole('button', { name: /download data/i }));
+
+    await waitFor(() => {
+      expect(mockApi.exportData).toHaveBeenCalled();
+      expect(mockDownloadJson).toHaveBeenCalledWith(
+        payload,
+        expect.stringMatching(/^become-data-export-\d{4}-\d{2}-\d{2}\.json$/)
+      );
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Your data has been downloaded' })
+      );
+    });
+  });
+
+  it('shows error toast and skips download when export fails with Error', async () => {
+    const user = userEvent.setup();
+    mockApi.exportData.mockRejectedValueOnce(new Error('Export boom'));
+
+    render(<Profile />);
+
+    await user.click(screen.getByRole('button', { name: /download data/i }));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Error',
+          description: 'Export boom',
+          variant: 'destructive',
+        })
+      );
+    });
+    expect(mockDownloadJson).not.toHaveBeenCalled();
+  });
+
+  it('shows fallback error toast when export throws non-Error', async () => {
+    const user = userEvent.setup();
+    mockApi.exportData.mockRejectedValueOnce('unknown');
+
+    render(<Profile />);
+
+    await user.click(screen.getByRole('button', { name: /download data/i }));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Error',
+          description: 'Failed to export your data',
           variant: 'destructive',
         })
       );

--- a/tests/e2e/test_gdpr_compliance.py
+++ b/tests/e2e/test_gdpr_compliance.py
@@ -48,23 +48,45 @@ class TestRightOfAccess:
         # Cleanup
         http_client.delete("/users/me", headers=auth_headers(token))
 
-    def test_data_export_endpoint_not_implemented(self, http_client):
-        """No data export endpoint exists yet (GDPR Article 20 gap)."""
-        # GIVEN — registered user
+    def test_user_can_export_their_data(self, http_client):
+        """GET /users/me/export returns the user's data (GDPR Article 20)."""
+        # GIVEN — user with an owned project and a submitted opinion
         email = unique_email("gdpr-export")
-        token = register_user(http_client, email)
+        token = register_user_with_name(http_client, email, "Export", "Tester")
+        project = create_project(http_client, token, "Export Project")
+        project_id = project["id"]
+        submit_opinion(http_client, token, project_id, 20.0, 50.0, 80.0)
 
-        # WHEN — user attempts to export their data
+        # WHEN — user exports their data
         response = http_client.get(
             "/users/me/export",
             headers=auth_headers(token),
         )
 
-        # THEN — endpoint does not exist
-        assert response.status_code in (404, 405)
+        # THEN — the export carries the profile, the project, and the opinion
+        assert response.status_code == 200
+        data = response.json()
+        assert "export_metadata" in data
+        assert data["profile"]["email"] == email
+        assert data["profile"]["first_name"] == "Export"
+        assert any(p["name"] == "Export Project" for p in data["owned_projects"])
+        assert any(o["project_id"] == project_id for o in data["opinions"])
+
+        # AND — password material is never exported
+        assert "hashed_password" not in response.text
+        assert "hashed_password" not in data["profile"]
 
         # Cleanup
+        http_client.delete(f"/projects/{project_id}", headers=auth_headers(token))
         http_client.delete("/users/me", headers=auth_headers(token))
+
+    def test_data_export_requires_authentication(self, http_client):
+        """The export endpoint rejects unauthenticated requests."""
+        # WHEN — the export is requested without a token
+        response = http_client.get("/users/me/export")
+
+        # THEN — access is denied
+        assert response.status_code == 401
 
 
 @pytest.mark.e2e

--- a/tests/integration/api/routes/test_data_export.py
+++ b/tests/integration/api/routes/test_data_export.py
@@ -1,0 +1,112 @@
+"""Tests for GET /api/v1/users/me/export endpoint (GDPR Article 20)."""
+
+from fastapi import status
+
+from tests.integration.api.conftest import (
+    auth_header,
+    create_project,
+    register_and_login,
+    submit_opinion,
+)
+
+_EXPORT_URL = "/api/v1/users/me/export"
+
+
+class TestDataExport:
+    """Tests for the GDPR data export endpoint."""
+
+    def test_export_returns_profile(self, client):
+        """The export carries the authenticated user's profile and metadata."""
+        # GIVEN
+        token = register_and_login(client, "export@example.com")
+
+        # WHEN
+        response = client.get(_EXPORT_URL, headers=auth_header(token))
+
+        # THEN
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["profile"]["email"] == "export@example.com"
+        assert "created_at" in data["profile"]
+        assert data["export_metadata"]["format_version"]
+
+    def test_export_includes_owned_project_and_opinion(self, client):
+        """Owned projects and submitted opinions appear in the export."""
+        # GIVEN - a user who owns a project and submitted an opinion
+        token = register_and_login(client, "owner@example.com")
+        project = create_project(client, token, "My Project")
+        project_id = project["id"]
+        submit_opinion(client, token, project_id, 20.0, 50.0, 80.0, "Lead")
+
+        # WHEN
+        response = client.get(_EXPORT_URL, headers=auth_header(token))
+
+        # THEN
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert any(p["name"] == "My Project" for p in data["owned_projects"])
+        opinions = data["opinions"]
+        assert len(opinions) == 1
+        assert opinions[0]["project_id"] == project_id
+        assert opinions[0]["position"] == "Lead"
+        assert opinions[0]["peak"] == 50.0
+
+    def test_export_includes_membership(self, client):
+        """A project the user joined as an expert shows up under memberships."""
+        # GIVEN - owner invites an expert who accepts
+        owner = register_and_login(client, "m-owner@example.com")
+        expert = register_and_login(client, "m-expert@example.com")
+        project = create_project(client, owner, "Shared Project")
+        project_id = project["id"]
+        client.post(
+            f"/api/v1/projects/{project_id}/invite",
+            json={"email": "m-expert@example.com"},
+            headers=auth_header(owner),
+        )
+        invitations = client.get("/api/v1/invitations", headers=auth_header(expert)).json()
+        client.post(
+            f"/api/v1/invitations/{invitations[0]['id']}/accept",
+            headers=auth_header(expert),
+        )
+
+        # WHEN - the expert exports their data
+        data = client.get(_EXPORT_URL, headers=auth_header(expert)).json()
+
+        # THEN
+        memberships = data["memberships"]
+        assert any(m["project_name"] == "Shared Project" for m in memberships)
+        assert memberships[0]["role"] == "expert"
+
+    def test_export_excludes_password_hash(self, client):
+        """The export never exposes password material."""
+        # GIVEN
+        token = register_and_login(client, "secure@example.com")
+
+        # WHEN
+        response = client.get(_EXPORT_URL, headers=auth_header(token))
+
+        # THEN
+        assert "hashed_password" not in response.text
+        assert "hashed_password" not in response.json()["profile"]
+
+    def test_export_empty_account_has_empty_collections(self, client):
+        """A fresh account exports empty lists, never null."""
+        # GIVEN
+        token = register_and_login(client, "fresh@example.com")
+
+        # WHEN
+        data = client.get(_EXPORT_URL, headers=auth_header(token)).json()
+
+        # THEN
+        assert data["owned_projects"] == []
+        assert data["memberships"] == []
+        assert data["opinions"] == []
+        assert data["received_invitations"] == []
+
+    def test_export_requires_authentication(self, client):
+        """Unauthenticated requests are rejected."""
+        # WHEN
+        response = client.get(_EXPORT_URL)
+
+        # THEN
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/unit/api/services/test_data_export.py
+++ b/tests/unit/api/services/test_data_export.py
@@ -1,0 +1,248 @@
+"""Unit tests for DataExportService."""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from api.db.models import (
+    CalculationResult,
+    ExpertOpinion,
+    Invitation,
+    MemberRole,
+    Project,
+    ProjectMember,
+    User,
+)
+from api.schemas.data_export import EXPORT_FORMAT_VERSION
+from api.services.data_export_service import DataExportService
+
+
+@pytest.fixture
+def user() -> User:
+    """An account holder with a password hash that must never be exported."""
+    return User(
+        id=uuid4(),
+        email="alice@example.com",
+        hashed_password="super-secret-hash",
+        first_name="Alice",
+        last_name="Smith",
+    )
+
+
+@pytest.fixture
+def project(user: User) -> Project:
+    """A project owned by the account holder."""
+    return Project(
+        id=uuid4(),
+        name="Budget 2026",
+        admin_id=user.id,
+        scale_min=0.0,
+        scale_max=100.0,
+        scale_unit="%",
+    )
+
+
+@pytest.fixture
+def result(project: Project) -> CalculationResult:
+    """A cached calculation result for the owned project."""
+    return CalculationResult(
+        id=uuid4(),
+        project_id=project.id,
+        best_compromise_lower=10.0,
+        best_compromise_peak=20.0,
+        best_compromise_upper=30.0,
+        arithmetic_mean_lower=10.0,
+        arithmetic_mean_peak=20.0,
+        arithmetic_mean_upper=30.0,
+        median_lower=10.0,
+        median_peak=20.0,
+        median_upper=30.0,
+        max_error=1.5,
+        num_experts=5,
+    )
+
+
+@pytest.fixture
+def membership(user: User, project: Project) -> ProjectMember:
+    """The account holder's membership in the project."""
+    return ProjectMember(
+        id=uuid4(),
+        project_id=project.id,
+        user_id=user.id,
+        role=MemberRole.EXPERT,
+    )
+
+
+@pytest.fixture
+def opinion(user: User, project: Project) -> ExpertOpinion:
+    """An opinion the account holder submitted to the project."""
+    return ExpertOpinion(
+        id=uuid4(),
+        project_id=project.id,
+        user_id=user.id,
+        position="Analyst",
+        lower_bound=10.0,
+        peak=20.0,
+        upper_bound=30.0,
+    )
+
+
+@pytest.fixture
+def inviter() -> User:
+    """A different user who invited the account holder."""
+    return User(
+        id=uuid4(),
+        email="bob@example.com",
+        hashed_password="another-hash",
+        first_name="Bob",
+        last_name="Jones",
+    )
+
+
+@pytest.fixture
+def invitation(user: User, project: Project, inviter: User) -> Invitation:
+    """A pending invitation addressed to the account holder."""
+    return Invitation(
+        id=uuid4(),
+        project_id=project.id,
+        invitee_id=user.id,
+        inviter_id=inviter.id,
+    )
+
+
+def _exec_returning(rows: list[object]) -> MagicMock:
+    """Build a mock matching ``session.exec(...).all()`` for one query.
+
+    :param rows: The rows the query should yield.
+    :return: A mock whose ``.all()`` returns the given rows.
+    """
+    mock = MagicMock()
+    mock.all.return_value = rows
+    return mock
+
+
+class TestDataExportServiceBuildExport:
+    """Tests for DataExportService.build_export."""
+
+    def test_assembles_all_sections(
+        self,
+        user: User,
+        project: Project,
+        result: CalculationResult,
+        membership: ProjectMember,
+        opinion: ExpertOpinion,
+        invitation: Invitation,
+        inviter: User,
+    ):
+        """Every category of user data lands in the export document."""
+        # GIVEN - the four collection queries each return one row
+        session = MagicMock()
+        session.exec.side_effect = [
+            _exec_returning([(project, result)]),
+            _exec_returning([(membership, project)]),
+            _exec_returning([(opinion, project)]),
+            _exec_returning([(invitation, project, inviter)]),
+        ]
+        service = DataExportService(session)
+
+        # WHEN
+        export = service.build_export(user)
+
+        # THEN
+        assert export.export_metadata.format_version == EXPORT_FORMAT_VERSION
+        assert export.profile.email == "alice@example.com"
+
+        assert len(export.owned_projects) == 1
+        assert export.owned_projects[0].name == "Budget 2026"
+        assert export.owned_projects[0].result is not None
+        assert export.owned_projects[0].result.num_experts == 5
+
+        assert len(export.memberships) == 1
+        assert export.memberships[0].project_name == "Budget 2026"
+        assert export.memberships[0].role == "expert"
+
+        assert len(export.opinions) == 1
+        assert export.opinions[0].position == "Analyst"
+        assert export.opinions[0].project_name == "Budget 2026"
+
+        assert len(export.received_invitations) == 1
+        assert export.received_invitations[0].inviter_email == "bob@example.com"
+
+    def test_owned_project_without_result_is_none(self, user: User, project: Project):
+        """A project with no cached result exports a null result, not an error."""
+        # GIVEN - the outer join yields the project with a None result
+        session = MagicMock()
+        session.exec.side_effect = [
+            _exec_returning([(project, None)]),
+            _exec_returning([]),
+            _exec_returning([]),
+            _exec_returning([]),
+        ]
+        service = DataExportService(session)
+
+        # WHEN
+        export = service.build_export(user)
+
+        # THEN
+        assert export.owned_projects[0].result is None
+
+    def test_export_never_contains_password_material(self, user: User):
+        """The serialized export leaks neither the hash value nor its field name."""
+        # GIVEN - a user with no related data
+        session = MagicMock()
+        session.exec.side_effect = [
+            _exec_returning([]),
+            _exec_returning([]),
+            _exec_returning([]),
+            _exec_returning([]),
+        ]
+        service = DataExportService(session)
+
+        # WHEN
+        dumped = service.build_export(user).model_dump_json()
+
+        # THEN
+        assert "super-secret-hash" not in dumped
+        assert "hashed_password" not in dumped
+
+    def test_empty_account_has_empty_collections(self, user: User):
+        """A user with no projects/opinions exports empty lists, never None."""
+        # GIVEN
+        session = MagicMock()
+        session.exec.side_effect = [
+            _exec_returning([]),
+            _exec_returning([]),
+            _exec_returning([]),
+            _exec_returning([]),
+        ]
+        service = DataExportService(session)
+
+        # WHEN
+        export = service.build_export(user)
+
+        # THEN
+        assert export.owned_projects == []
+        assert export.memberships == []
+        assert export.opinions == []
+        assert export.received_invitations == []
+        assert export.profile.email == user.email
+
+    def test_logs_generation_event(self, user: User):
+        """A business log records that an export was generated, tagged with its event."""
+        # GIVEN
+        session = MagicMock()
+        session.exec.side_effect = [
+            _exec_returning([]),
+            _exec_returning([]),
+            _exec_returning([]),
+            _exec_returning([]),
+        ]
+        service = DataExportService(session)
+
+        # WHEN
+        with patch("api.services.data_export_service.logger") as mock_logger:
+            service.build_export(user)
+
+        # THEN
+        assert mock_logger.info.call_args[1]["extra"]["event"] == "data_export_generated"


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements GDPR Article 20 data portability by adding `GET /api/v1/users/me/export`, a new `DataExportService` that assembles the user's full data in a fixed number of queries, matching Pydantic schemas, an audit log entry, and a frontend Download button on the Profile page.

- **Backend**: `DataExportService` uses explicit joins (owned projects + results, memberships, opinions, received invitations) avoiding N+1 queries; the route is thin, rate-limited with `LIMIT_STANDARD`, and logs after a successful export.
- **Frontend**: `downloadJson` utility triggers a Bearer-authenticated Blob download; the Profile component adds an export card with loading/error states and i18n keys mirrored across both `en` and `cs` locales.
- **Tests**: Unit tests mock the session, integration tests cover the full HTTP path including empty accounts and auth rejection, and the existing e2e stub is replaced with a real round-trip test.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the two minor issues; no data-loss or auth risks introduced.

The implementation is solid end-to-end. Two small issues were found: the centroid denominator `3` is a bare literal in aggregation math (appears in both `_fuzzy()` and `ExportOpinion.from_model`), and the `_received_invitations` docstring describes the result as 'pending' while the query returns all statuses — which may or may not match the intended behavior depending on whether Invitation rows are deleted on acceptance.

`api/schemas/data_export.py` for the magic-number centroid denominator, and `api/services/data_export_service.py` for the pending-vs-all ambiguity in `_received_invitations`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| api/schemas/data_export.py | New GDPR export schemas with well-structured from_model factories; bare literal `3` appears in the centroid formula in both `_fuzzy()` and `ExportOpinion.from_model`, violating the no-magic-numbers rule. |
| api/services/data_export_service.py | Clean fixed-query service with no N+1 issues; `_received_invitations` docstring claims 'pending' invitations but the query returns all statuses. |
| api/routes/users.py | Thin endpoint delegating entirely to DataExportService via Depends injection; rate-limited with LIMIT_STANDARD and audit-logged after success. |
| frontend/src/lib/download.ts | Clean Blob/anchor download utility with `try/finally` ensuring URL revocation even when `click` throws; well-tested. |
| tests/unit/api/services/test_data_export.py | Properly isolated unit tests using a mocked Session; GIVEN/WHEN/THEN structure throughout; covers password-material exclusion and logging. |
| tests/integration/api/routes/test_data_export.py | Good integration coverage across empty account, owned project, membership, and auth rejection cases. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant Profile.tsx
    participant ApiClient
    participant ExportEndpoint as GET /users/me/export
    participant DataExportService
    participant DB

    Browser->>Profile.tsx: click "Download Data"
    Profile.tsx->>ApiClient: exportData()
    ApiClient->>ExportEndpoint: GET /api/v1/users/me/export (Bearer)
    ExportEndpoint->>ExportEndpoint: rate-limit check (LIMIT_STANDARD)
    ExportEndpoint->>DataExportService: build_export(current_user)
    DataExportService->>DB: SELECT Project + CalculationResult (outer join, admin_id)
    DataExportService->>DB: SELECT ProjectMember + Project (user_id)
    DataExportService->>DB: SELECT ExpertOpinion + Project (user_id)
    DataExportService->>DB: SELECT Invitation + Project + User (invitee_id)
    DataExportService-->>ExportEndpoint: DataExportResponse
    ExportEndpoint->>ExportEndpoint: log_data_export(user_id, request)
    ExportEndpoint-->>ApiClient: 200 JSON
    ApiClient-->>Profile.tsx: "Record<string, unknown>"
    Profile.tsx->>Browser: downloadJson(data, "become-data-export-YYYY-MM-DD.json")
    Profile.tsx->>Browser: toast("Your data has been downloaded")
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant Profile.tsx
    participant ApiClient
    participant ExportEndpoint as GET /users/me/export
    participant DataExportService
    participant DB

    Browser->>Profile.tsx: click "Download Data"
    Profile.tsx->>ApiClient: exportData()
    ApiClient->>ExportEndpoint: GET /api/v1/users/me/export (Bearer)
    ExportEndpoint->>ExportEndpoint: rate-limit check (LIMIT_STANDARD)
    ExportEndpoint->>DataExportService: build_export(current_user)
    DataExportService->>DB: SELECT Project + CalculationResult (outer join, admin_id)
    DataExportService->>DB: SELECT ProjectMember + Project (user_id)
    DataExportService->>DB: SELECT ExpertOpinion + Project (user_id)
    DataExportService->>DB: SELECT Invitation + Project + User (invitee_id)
    DataExportService-->>ExportEndpoint: DataExportResponse
    ExportEndpoint->>ExportEndpoint: log_data_export(user_id, request)
    ExportEndpoint-->>ApiClient: 200 JSON
    ApiClient-->>Profile.tsx: "Record<string, unknown>"
    Profile.tsx->>Browser: downloadJson(data, "become-data-export-YYYY-MM-DD.json")
    Profile.tsx->>Browser: toast("Your data has been downloaded")
```

</a>

<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. `api/services/data_export_service.py`, line 514-531 ([link](https://github.com/caitlon/become/blob/4c3fbcf19f90733e36a15440850a0bb0049716a2/api/services/data_export_service.py#L514-L531)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Docstring says "pending" but query has no status filter**

   The method docstring reads "Load **pending** invitations" and the schema class `ExportReceivedInvitation` is described as "A **pending** invitation", but the WHERE clause only constrains by `invitee_id`. If `Invitation` rows persist after acceptance or decline (which is typical for audit trails), accepted and declined invitations will also appear in the export. For a GDPR Article 20 export, including all historical invitations is defensible, but the docstring and schema class doc should be updated to reflect that — or a status filter should be added if only pending invitations are intended.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: api/services/data_export_service.py
   Line: 514-531

   Comment:
   **Docstring says "pending" but query has no status filter**

   The method docstring reads "Load **pending** invitations" and the schema class `ExportReceivedInvitation` is described as "A **pending** invitation", but the WHERE clause only constrains by `invitee_id`. If `Invitation` rows persist after acceptance or decline (which is typical for audit trails), accepted and declined invitations will also appear in the export. For a GDPR Article 20 export, including all historical invitations is defensible, but the docstring and schema class doc should be updated to reflect that — or a status filter should be added if only pending invitations are intended.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
api/schemas/data_export.py:46
**Magic number in centroid formula**

The bare `3` appears twice in this file — once in `_fuzzy()` (line 46) and again inline in `ExportOpinion.from_model` (line 220). Per the repo's no-magic-numbers rule, aggregation math constants need a named class attribute so each formula is verifiable against the documented BeCoMe method. A module-level constant (e.g. `_TRIANGULAR_BOUNDS = 3  # triangular fuzzy-number centroid denominator`) referenced in both places would make the intent explicit and ensure future changes stay in sync.

### Issue 2 of 2
api/services/data_export_service.py:514-531
**Docstring says "pending" but query has no status filter**

The method docstring reads "Load **pending** invitations" and the schema class `ExportReceivedInvitation` is described as "A **pending** invitation", but the WHERE clause only constrains by `invitee_id`. If `Invitation` rows persist after acceptance or decline (which is typical for audit trails), accepted and declined invitations will also appear in the export. For a GDPR Article 20 export, including all historical invitations is defensible, but the docstring and schema class doc should be updated to reflect that — or a status filter should be added if only pending invitations are intended.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add GDPR data export endpoint"](https://github.com/caitlon/become/commit/4c3fbcf19f90733e36a15440850a0bb0049716a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39679718)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->