### PR TITLE
feat: add project ownership transfer and account-deletion guard

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -88,7 +88,7 @@ api/
 | PUT | `/api/v1/users/me/password` | Change password |
 | POST | `/api/v1/users/me/photo` | Upload photo |
 | DELETE | `/api/v1/users/me/photo` | Delete photo |
-| DELETE | `/api/v1/users/me` | Delete account |
+| DELETE | `/api/v1/users/me` | Delete account (409 while you still admin any project) |
 
 ### Projects
 
@@ -101,6 +101,7 @@ api/
 | DELETE | `/api/v1/projects/{id}` | Delete project |
 | GET | `/api/v1/projects/{id}/members` | List members |
 | DELETE | `/api/v1/projects/{id}/members/{user_id}` | Remove member |
+| POST | `/api/v1/projects/{id}/transfer-ownership` | Transfer ownership to another member |
 | POST | `/api/v1/projects/{id}/invite` | Invite user |
 
 ### Opinions

--- a/api/db/models.py
+++ b/api/db/models.py
@@ -73,7 +73,11 @@ class Project(SQLModel, table=True):
     id: UUID = Field(default_factory=uuid4, primary_key=True)
     name: str = Field(max_length=255)
     description: str | None = Field(default=None)
-    admin_id: UUID = Field(foreign_key=_USERS_FK, ondelete="CASCADE")
+    # RESTRICT (not CASCADE): deleting a user who still admins a project is blocked
+    # at the DB level, so account erasure cannot silently wipe other experts' work.
+    # The API rejects such deletes with 409 first (see delete_current_user); this is
+    # the defense-in-depth backstop. Ownership transfer keeps admin_id in sync.
+    admin_id: UUID = Field(foreign_key=_USERS_FK, ondelete="RESTRICT")
     scale_min: float = Field(default=0.0)
     scale_max: float = Field(default=100.0)
     scale_unit: str = Field(default="", max_length=50)

--- a/api/exceptions.py
+++ b/api/exceptions.py
@@ -40,6 +40,10 @@ class InvalidCredentialsError(BeCoMeAPIError):
         self.reason = reason
 
 
+class AccountHasOwnedProjectsError(BeCoMeAPIError):
+    """Raised when account deletion is blocked because the user still owns projects."""
+
+
 # Project-related exceptions
 class ProjectNotFoundError(NotFoundError):
     """Raised when project is not found."""

--- a/api/middleware/exception_handlers.py
+++ b/api/middleware/exception_handlers.py
@@ -12,6 +12,7 @@ from fastapi.responses import JSONResponse
 
 from api.auth.logging import log_login_failure
 from api.exceptions import (
+    AccountHasOwnedProjectsError,
     BeCoMeAPIError,
     InvalidCredentialsError,
     InvalidResetTokenError,
@@ -62,6 +63,11 @@ EXCEPTION_MAP: dict[type[BeCoMeAPIError], tuple[int, str | None]] = {
         "Incorrect email or password",
     ),
     # 409 Conflict
+    AccountHasOwnedProjectsError: (
+        status.HTTP_409_CONFLICT,
+        "Cannot delete your account while you are the admin of one or more projects. "
+        "Transfer ownership or delete those projects first.",
+    ),
     UserExistsError: (status.HTTP_409_CONFLICT, "Email already registered"),
     UserAlreadyMemberError: (
         status.HTTP_409_CONFLICT,

--- a/api/routes/projects.py
+++ b/api/routes/projects.py
@@ -23,6 +23,7 @@ from api.schemas.project import (
     ProjectResponse,
     ProjectUpdate,
     ProjectWithRoleResponse,
+    TransferOwnershipRequest,
 )
 from api.services.project_membership_service import ProjectMembershipService
 from api.services.project_query_service import ProjectQueryService
@@ -139,6 +140,38 @@ def delete_project(
     :param service: Project service
     """
     service.delete_project(project.id)
+
+
+@router.post(
+    "/{project_id}/transfer-ownership",
+    summary="Transfer project ownership to another member",
+)
+def transfer_ownership(
+    project_id: UUID,
+    project: ProjectAdmin,
+    request: TransferOwnershipRequest,
+    current_user: CurrentUser,
+    service: Annotated[ProjectService, Depends(get_project_service)],
+) -> ProjectResponse:
+    """Transfer project ownership to another member. Only the current admin can do this.
+
+    The new admin must already be a member of the project. MemberNotFoundError
+    (target not a member) is handled by centralized exception middleware as 404.
+
+    :param project: Project (verified admin)
+    :param request: New admin's user ID
+    :param current_user: Authenticated user (the current admin)
+    :param service: Project service
+    :return: Updated project
+    :raises HTTPException: 400 if transferring ownership to self
+    """
+    if request.new_admin_id == current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="You are already the project admin.",
+        )
+    updated = service.transfer_ownership(project, request.new_admin_id)
+    return ProjectResponse.from_model(updated, service.get_member_count(updated.id))
 
 
 @router.get("/{project_id}/members", summary="List project members")

--- a/api/routes/users.py
+++ b/api/routes/users.py
@@ -8,7 +8,13 @@ from fastapi import APIRouter, Depends, File, HTTPException, Request, Response, 
 
 from api.auth.dependencies import CurrentUser
 from api.auth.logging import log_account_deletion, log_data_export, log_password_change
-from api.dependencies import get_data_export_service, get_storage_service, get_user_service
+from api.dependencies import (
+    get_data_export_service,
+    get_project_service,
+    get_storage_service,
+    get_user_service,
+)
+from api.exceptions import AccountHasOwnedProjectsError
 from api.middleware.rate_limit import (
     LIMIT_PHOTO,
     LIMIT_PWD_RESET,
@@ -19,6 +25,7 @@ from api.middleware.rate_limit import (
 from api.schemas.auth import ChangePasswordRequest, UpdateUserRequest, UserResponse
 from api.schemas.data_export import DataExportResponse
 from api.services.data_export_service import DataExportService
+from api.services.project_service import ProjectService
 from api.services.storage import validation
 from api.services.storage.base import StorageService
 from api.services.storage.exceptions import StorageDeleteError, StorageUploadError
@@ -124,13 +131,23 @@ def delete_current_user(
     request: Request,
     current_user: CurrentUser,
     service: Annotated[UserService, Depends(get_user_service)],
+    project_service: Annotated[ProjectService, Depends(get_project_service)],
 ) -> None:
     """Delete the authenticated user's account.
+
+    Rejected with 409 while the user is the admin of any project, so erasure never
+    silently cascades away other experts' contributions; the user must transfer
+    ownership or delete those projects first.
 
     :param request: FastAPI request (for logging)
     :param current_user: User from JWT token
     :param service: User service
+    :param project_service: Project service for the ownership check
+    :raises AccountHasOwnedProjectsError: If the user still admins a project
     """
+    if project_service.get_owned_projects(current_user.id):
+        raise AccountHasOwnedProjectsError("Account still owns one or more projects.")
+
     user_id = current_user.id
     email = current_user.email
 

--- a/api/schemas/project.py
+++ b/api/schemas/project.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 from typing import TYPE_CHECKING, Self
+from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -58,6 +59,12 @@ class ProjectUpdate(BaseModel):
     def sanitize_text_fields(cls, v: str | None) -> str | None:
         """Remove HTML from text fields."""
         return sanitize_text_or_none(v)
+
+
+class TransferOwnershipRequest(BaseModel):
+    """Request to transfer project ownership to another project member."""
+
+    new_admin_id: UUID = Field(..., description="User ID of the member to promote to admin")
 
 
 class ProjectResponse(BaseModel):

--- a/api/services/project_service.py
+++ b/api/services/project_service.py
@@ -165,10 +165,11 @@ class ProjectService(BaseService):
                 f"User {new_admin_id} is not a member of project {project.id}"
             )
 
+        old_admin_id = project.admin_id
         old_admin_membership = self._session.exec(
             select(ProjectMember).where(
                 ProjectMember.project_id == project.id,
-                ProjectMember.user_id == project.admin_id,
+                ProjectMember.user_id == old_admin_id,
             )
         ).first()
 
@@ -186,6 +187,7 @@ class ProjectService(BaseService):
             extra={
                 "event": "ownership_transferred",
                 "project_id": str(project.id),
+                "old_admin_id": str(old_admin_id),
                 "new_admin_id": str(new_admin_id),
             },
         )

--- a/api/services/project_service.py
+++ b/api/services/project_service.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from sqlmodel import func, select
 
 from api.db.models import MemberRole, Project, ProjectMember
-from api.exceptions import ProjectNotFoundError, ScaleRangeError
+from api.exceptions import MemberNotFoundError, ProjectNotFoundError, ScaleRangeError
 from api.schemas.project import ProjectCreate, ProjectUpdate
 from api.services.base import BaseService
 
@@ -132,3 +132,61 @@ class ProjectService(BaseService):
             .where(ProjectMember.project_id == project_id)
         )
         return self._session.exec(statement).one()
+
+    def get_owned_projects(self, user_id: UUID) -> list[Project]:
+        """Get all projects the user owns (is admin of).
+
+        :param user_id: User ID
+        :return: Projects whose admin is the user
+        """
+        statement = select(Project).where(Project.admin_id == user_id)
+        return list(self._session.exec(statement).all())
+
+    def transfer_ownership(self, project: Project, new_admin_id: UUID) -> Project:
+        """Transfer project ownership to another member.
+
+        Keeps both ownership sources in sync atomically: ``Project.admin_id`` and
+        the ``ProjectMember`` role rows -- the new owner becomes admin and the
+        former owner is demoted to expert.
+
+        :param project: Project to transfer (current admin already verified)
+        :param new_admin_id: User ID of the member to promote to admin
+        :return: Updated project
+        :raises MemberNotFoundError: If the target user is not a project member
+        """
+        new_admin_membership = self._session.exec(
+            select(ProjectMember).where(
+                ProjectMember.project_id == project.id,
+                ProjectMember.user_id == new_admin_id,
+            )
+        ).first()
+        if not new_admin_membership:
+            raise MemberNotFoundError(
+                f"User {new_admin_id} is not a member of project {project.id}"
+            )
+
+        old_admin_membership = self._session.exec(
+            select(ProjectMember).where(
+                ProjectMember.project_id == project.id,
+                ProjectMember.user_id == project.admin_id,
+            )
+        ).first()
+
+        project.admin_id = new_admin_id
+        new_admin_membership.role = MemberRole.ADMIN
+        self._session.add(project)
+        self._session.add(new_admin_membership)
+        if old_admin_membership:
+            old_admin_membership.role = MemberRole.EXPERT
+            self._session.add(old_admin_membership)
+        self._session.commit()
+        self._session.refresh(project)
+        logger.info(
+            "Project ownership transferred",
+            extra={
+                "event": "ownership_transferred",
+                "project_id": str(project.id),
+                "new_admin_id": str(new_admin_id),
+            },
+        )
+        return project

--- a/docs/security.md
+++ b/docs/security.md
@@ -59,6 +59,17 @@ read/write auditing would need the `pgaudit` extension, but that requires
 `shared_preload_libraries`, which Railway's image does not expose; `log_statement = 'ddl'` is the
 workable substitute.
 
+## Account deletion and data integrity
+
+Deleting a user must not silently destroy other people's work. Most child rows clear themselves
+through `ON DELETE CASCADE` (memberships, opinions, sent and received invitations, reset tokens),
+but a project a user **admins** is shared data -- it holds other experts' opinions. So
+`projects.admin_id` uses `ON DELETE RESTRICT`: the database refuses to delete a user who still
+owns a project. The API enforces the same rule first and returns `409 Conflict` from
+`DELETE /api/v1/users/me`; the owner must delete those projects or transfer ownership
+(`POST /api/v1/projects/{id}/transfer-ownership`) before erasing their account. This serves the
+GDPR right to erasure without letting one deletion cascade away a whole panel's contributions.
+
 ## Backups
 
 Railway's managed backups require the Pro plan, so on the current (free) plan the Postgres

--- a/frontend/src/i18n/locales/cs/profile.json
+++ b/frontend/src/i18n/locales/cs/profile.json
@@ -23,7 +23,8 @@
   "dangerZone": {
     "title": "Nebezpečná zóna",
     "warning": "Po smazání účtu již není cesty zpět. Buďte si prosím jisti.",
-    "deleteButton": "Smazat účet"
+    "deleteButton": "Smazat účet",
+    "ownsProjects": "Stále spravujete jeden nebo více projektů. Před smazáním účtu předejte vlastnictví nebo je smažte."
   },
   "deleteModal": {
     "title": "Smazat účet?",

--- a/frontend/src/i18n/locales/cs/projects.json
+++ b/frontend/src/i18n/locales/cs/projects.json
@@ -70,7 +70,9 @@
     "deleteFailed": "Nepodařilo se smazat projekt",
     "createFailed": "Nepodařilo se vytvořit projekt",
     "memberRemoved": "Člen odebrán",
-    "removeMemberFailed": "Nepodařilo se odebrat člena"
+    "removeMemberFailed": "Nepodařilo se odebrat člena",
+    "ownershipTransferred": "Vlastnictví předáno",
+    "transferOwnershipFailed": "Předání vlastnictví se nezdařilo"
   },
   "detail": {
     "backToProjects": "Zpět na projekty",
@@ -127,7 +129,13 @@
     "name": "Jméno",
     "email": "E-mail",
     "role": "Role",
-    "joined": "Přidal se"
+    "joined": "Přidal se",
+    "transferOwnershipLabel": "Učinit uživatele {{name}} vlastníkem"
+  },
+  "transferOwnership": {
+    "title": "Předat vlastnictví?",
+    "description": "{{name}} se stane správcem projektu a vy se stanete expertem. Projekt už nebudete moci spravovat.",
+    "confirm": "Předat vlastnictví"
   },
   "memberProfile": {
     "position": "Pozice",

--- a/frontend/src/i18n/locales/en/profile.json
+++ b/frontend/src/i18n/locales/en/profile.json
@@ -23,7 +23,8 @@
   "dangerZone": {
     "title": "Danger Zone",
     "warning": "Once you delete your account, there is no going back. Please be certain.",
-    "deleteButton": "Delete Account"
+    "deleteButton": "Delete Account",
+    "ownsProjects": "You still admin one or more projects. Transfer ownership or delete them before deleting your account."
   },
   "deleteModal": {
     "title": "Delete Account?",

--- a/frontend/src/i18n/locales/en/projects.json
+++ b/frontend/src/i18n/locales/en/projects.json
@@ -70,7 +70,9 @@
     "deleteFailed": "Failed to delete project",
     "createFailed": "Failed to create project",
     "memberRemoved": "Member removed",
-    "removeMemberFailed": "Failed to remove member"
+    "removeMemberFailed": "Failed to remove member",
+    "ownershipTransferred": "Ownership transferred",
+    "transferOwnershipFailed": "Failed to transfer ownership"
   },
   "detail": {
     "backToProjects": "Back to Projects",
@@ -127,7 +129,13 @@
     "name": "Name",
     "email": "Email",
     "role": "Role",
-    "joined": "Joined"
+    "joined": "Joined",
+    "transferOwnershipLabel": "Make {{name}} the owner"
+  },
+  "transferOwnership": {
+    "title": "Transfer ownership?",
+    "description": "{{name}} will become the project admin and you will become an expert. You will no longer be able to manage the project.",
+    "confirm": "Transfer ownership"
   },
   "memberProfile": {
     "position": "Position",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -285,6 +285,13 @@ class ApiClient {
     });
   }
 
+  async transferOwnership(projectId: string, newAdminId: string): Promise<Project> {
+    return this.request<Project>(`/projects/${projectId}/transfer-ownership`, {
+      method: 'POST',
+      body: JSON.stringify({ new_admin_id: newAdminId }),
+    });
+  }
+
   // Opinions
   async getOpinions(projectId: string): Promise<Opinion[]> {
     return this.request<Opinion[]>(`/projects/${projectId}/opinions`);

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -13,7 +13,7 @@ import { Navbar } from "@/components/layout/Navbar";
 import { DeleteConfirmModal } from "@/components/modals/DeleteConfirmModal";
 import { ValidationChecklist } from "@/components/forms";
 import { useAuth } from "@/contexts/AuthContext";
-import { api } from "@/lib/api";
+import { api, HttpError } from "@/lib/api";
 import { downloadJson } from "@/lib/download";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
@@ -224,10 +224,15 @@ const Profile = () => {
       navigate("/");
       toast({ title: t("toast.accountDeleted") });
     } catch (error) {
+      const description =
+        error instanceof HttpError && error.status === 409
+          ? t("dangerZone.ownsProjects")
+          : error instanceof Error
+            ? error.message
+            : t("toast.deleteFailed");
       toast({
         title: t("toast.error"),
-        description:
-          error instanceof Error ? error.message : t("toast.deleteFailed"),
+        description,
         variant: "destructive",
       });
     }

--- a/frontend/src/pages/ProjectDetail.tsx
+++ b/frontend/src/pages/ProjectDetail.tsx
@@ -9,6 +9,7 @@ import {
   Edit,
   UserPlus,
   Trash2,
+  Crown,
   ChevronDown,
   ChevronUp,
   X,
@@ -83,6 +84,7 @@ const ProjectDetail = () => {
   const [lower, setLower] = useState("");
   const [peak, setPeak] = useState("");
   const [upper, setUpper] = useState("");
+  const [transferTarget, setTransferTarget] = useState<Member | null>(null);
   useDocumentTitle(project ? tCommon("pageTitle.projectDetail", { name: project.name }) : tCommon("common.loading"));
 
   const myOpinion = opinions.find((o) => o.user_id === user?.id);
@@ -245,6 +247,23 @@ const ProjectDetail = () => {
       toast({
         title: t("toast.error"),
         description: t("toast.removeMemberFailed"),
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleTransferOwnership = async () => {
+    /* v8 ignore next -- defensive guard: id and target are always set when invoked */
+    if (!id || !transferTarget) return;
+    try {
+      await api.transferOwnership(id, transferTarget.user_id);
+      toast({ title: t("toast.ownershipTransferred") });
+      setTransferTarget(null);
+      fetchData();
+    } catch {
+      toast({
+        title: t("toast.error"),
+        description: t("toast.transferOwnershipFailed"),
         variant: "destructive",
       });
     }
@@ -416,6 +435,7 @@ const ProjectDetail = () => {
                 currentUserId={user?.id}
                 selectedMemberId={profileMember?.user_id}
                 onRemove={handleRemoveMember}
+                onTransfer={(member) => setTransferTarget(member)}
                 onMemberClick={(member) => setProfileMember(member)}
               />
             </TabsContent>
@@ -449,6 +469,7 @@ const ProjectDetail = () => {
                 currentUserId={user?.id}
                 selectedMemberId={profileMember?.user_id}
                 onRemove={handleRemoveMember}
+                onTransfer={(member) => setTransferTarget(member)}
                 onMemberClick={(member) => setProfileMember(member)}
               />
             </CollapsibleContent>
@@ -474,6 +495,19 @@ const ProjectDetail = () => {
           t("deleteModal.details.invitations"),
         ]}
         onConfirm={handleDeleteProject}
+      />
+
+      <DeleteConfirmModal
+        open={!!transferTarget}
+        onOpenChange={(open) => !open && setTransferTarget(null)}
+        title={t("transferOwnership.title")}
+        description={t("transferOwnership.description", {
+          name: transferTarget
+            ? `${transferTarget.first_name} ${transferTarget.last_name ?? ""}`.trim()
+            : "",
+        })}
+        onConfirm={handleTransferOwnership}
+        confirmText={t("transferOwnership.confirm")}
       />
 
       <MemberProfileDialog
@@ -1178,6 +1212,7 @@ interface TeamTableProps {
   currentUserId?: string;
   selectedMemberId?: string;
   onRemove: (userId: string) => void;
+  onTransfer: (member: Member) => void;
   onMemberClick: (member: Member) => void;
 }
 
@@ -1188,6 +1223,7 @@ const TeamTable = ({
   currentUserId,
   selectedMemberId,
   onRemove,
+  onTransfer,
   onMemberClick,
 }: TeamTableProps) => {
   const { t, i18n } = useTranslation("projects");
@@ -1256,18 +1292,32 @@ const TeamTable = ({
                     <TableCell>
                       {member.role !== "admin" &&
                         member.user_id !== currentUserId && (
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-8 w-8 text-destructive hover:text-destructive"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              onRemove(member.user_id);
-                            }}
-                            aria-label={tCommon("a11y.removeTeamMember", { name: fullName })}
-                          >
-                            <X className="h-4 w-4" />
-                          </Button>
+                          <div className="flex items-center justify-end gap-1">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onTransfer(member);
+                              }}
+                              aria-label={t("team.transferOwnershipLabel", { name: fullName })}
+                            >
+                              <Crown className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8 text-destructive hover:text-destructive"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onRemove(member.user_id);
+                              }}
+                              aria-label={tCommon("a11y.removeTeamMember", { name: fullName })}
+                            >
+                              <X className="h-4 w-4" />
+                            </Button>
+                          </div>
                         )}
                     </TableCell>
                   )}

--- a/frontend/tests/lib/api.test.ts
+++ b/frontend/tests/lib/api.test.ts
@@ -640,6 +640,26 @@ describe('ApiClient', () => {
         expect.objectContaining({ method: 'DELETE' })
       );
     });
+
+    it('transferOwnership sends POST to /projects/:id/transfer-ownership', async () => {
+      const project = { id: 'proj-1', admin_id: 'user-1' };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(project),
+      });
+
+      const result = await api.transferOwnership('proj-1', 'user-1');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/projects/proj-1/transfer-ownership'),
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ new_admin_id: 'user-1' }),
+        })
+      );
+      expect(result).toEqual(project);
+    });
   });
 
   describe('Opinion Endpoints', () => {

--- a/frontend/tests/mocks/api.ts
+++ b/frontend/tests/mocks/api.ts
@@ -38,6 +38,7 @@ export function createMockApi(overrides: Record<string, unknown> = {}) {
     // Members
     getMembers: vi.fn().mockResolvedValue([]),
     removeMember: vi.fn().mockResolvedValue(undefined),
+    transferOwnership: vi.fn().mockResolvedValue({}),
 
     // Opinions
     getOpinions: vi.fn().mockResolvedValue([]),

--- a/frontend/tests/pages/Profile.test.tsx
+++ b/frontend/tests/pages/Profile.test.tsx
@@ -3,6 +3,7 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render, framerMotionMock } from '@tests/utils';
 import Profile from '@/pages/Profile';
+import { HttpError } from '@/lib/api';
 import { createUser } from '@tests/factories/user';
 
 // Mock useNavigate
@@ -24,16 +25,20 @@ const mockApi = {
   deletePhoto: vi.fn(),
   exportData: vi.fn(),
 };
-vi.mock('@/lib/api', () => ({
-  api: {
-    updateCurrentUser: (data: unknown) => mockApi.updateCurrentUser(data),
-    changePassword: (data: unknown) => mockApi.changePassword(data),
-    deleteAccount: () => mockApi.deleteAccount(),
-    uploadPhoto: (file: File) => mockApi.uploadPhoto(file),
-    deletePhoto: () => mockApi.deletePhoto(),
-    exportData: () => mockApi.exportData(),
-  },
-}));
+vi.mock('@/lib/api', async (importActual) => {
+  const actual = await importActual<typeof import('@/lib/api')>();
+  return {
+    ...actual,
+    api: {
+      updateCurrentUser: (data: unknown) => mockApi.updateCurrentUser(data),
+      changePassword: (data: unknown) => mockApi.changePassword(data),
+      deleteAccount: () => mockApi.deleteAccount(),
+      uploadPhoto: (file: File) => mockApi.uploadPhoto(file),
+      deletePhoto: () => mockApi.deletePhoto(),
+      exportData: () => mockApi.exportData(),
+    },
+  };
+});
 
 // Mock the file-download helper so no real Blob/anchor is exercised here
 const mockDownloadJson = vi.fn();
@@ -355,6 +360,31 @@ describe('Profile - Delete Account', () => {
         })
       );
     });
+  });
+
+  it('shows ownership warning when deletion is blocked by owned projects (409)', async () => {
+    const user = userEvent.setup();
+    mockApi.deleteAccount.mockRejectedValueOnce(new HttpError('conflict', 409));
+
+    render(<Profile />);
+
+    await user.click(screen.getByRole('button', { name: 'Delete Account' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Delete My Account' }));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: 'destructive',
+          description: expect.stringContaining('still admin'),
+        })
+      );
+    });
+    expect(mockLogout).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/tests/pages/ProjectDetail.test.tsx
+++ b/frontend/tests/pages/ProjectDetail.test.tsx
@@ -18,6 +18,7 @@ const { mockApi, mockToast, mockUser, mockNavigate } = vi.hoisted(() => ({
     deleteOpinion: vi.fn(),
     deleteProject: vi.fn(),
     removeMember: vi.fn(),
+    transferOwnership: vi.fn(),
   },
   mockToast: vi.fn(),
   mockUser: {
@@ -514,6 +515,33 @@ describe('ProjectDetail - Team Section', () => {
       // JD appears in both Navbar avatar and team table avatar (team section open by default)
       const initials = screen.getAllByText('JD');
       expect(initials.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it('transfers ownership to a member after confirmation', async () => {
+    const user = userEvent.setup();
+    const members = [
+      createMember({ user_id: 'user-1', first_name: 'John', last_name: 'Doe', role: 'admin' }),
+      createMember({ user_id: 'user-2', first_name: 'Jane', last_name: 'Smith', role: 'expert' }),
+    ];
+    mockApi.getMembers.mockResolvedValue(members);
+    mockApi.transferOwnership.mockResolvedValue(createProject({ id: 'project-1' }));
+
+    render(<ProjectDetail />);
+
+    // The "make owner" action is shown for non-admin members in the admin view
+    const transferButtons = await screen.findAllByRole('button', {
+      name: /make jane smith the owner/i,
+    });
+    await user.click(transferButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Transfer ownership?')).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: 'Transfer ownership' }));
+
+    await waitFor(() => {
+      expect(mockApi.transferOwnership).toHaveBeenCalledWith('project-1', 'user-2');
     });
   });
 });

--- a/migrations/versions/2026_06_25_1200-b1d9f4a2c7e3_restrict_project_admin_ondelete.py
+++ b/migrations/versions/2026_06_25_1200-b1d9f4a2c7e3_restrict_project_admin_ondelete.py
@@ -1,0 +1,39 @@
+"""restrict project admin ondelete
+
+Revision ID: b1d9f4a2c7e3
+Revises: f3a7c2b9d1e4
+Create Date: 2026-06-25 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b1d9f4a2c7e3"
+down_revision: str | Sequence[str] | None = "f3a7c2b9d1e4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_FK_NAME = "projects_admin_id_fkey"
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Switch ``projects.admin_id`` from ON DELETE CASCADE to ON DELETE RESTRICT so a
+    user who still admins a project cannot be deleted, which would otherwise wipe
+    that project and every other expert's contribution in it. The API rejects such
+    deletes with 409 first (see ``delete_current_user``); this is the DB backstop.
+    """
+    with op.batch_alter_table("projects", schema=None) as batch_op:
+        batch_op.drop_constraint(_FK_NAME, type_="foreignkey")
+        batch_op.create_foreign_key(_FK_NAME, "users", ["admin_id"], ["id"], ondelete="RESTRICT")
+
+
+def downgrade() -> None:
+    """Downgrade schema (restore ON DELETE CASCADE)."""
+    with op.batch_alter_table("projects", schema=None) as batch_op:
+        batch_op.drop_constraint(_FK_NAME, type_="foreignkey")
+        batch_op.create_foreign_key(_FK_NAME, "users", ["admin_id"], ["id"], ondelete="CASCADE")

--- a/tests/e2e/test_gdpr_compliance.py
+++ b/tests/e2e/test_gdpr_compliance.py
@@ -252,6 +252,54 @@ class TestDataErasure:
         # THEN — login is rejected
         assert login_resp.status_code == 401
 
+    def test_owner_cannot_delete_account_while_admin(self, http_client):
+        """An account that still admins a project cannot be deleted (409)."""
+        # GIVEN — a user who owns a project
+        email = unique_email("gdpr-own-block")
+        token = register_user(http_client, email)
+        project = create_project(http_client, token, "Owned Project")
+        project_id = project["id"]
+
+        # WHEN — the owner tries to delete their account
+        response = http_client.delete("/users/me", headers=auth_headers(token))
+
+        # THEN — deletion is blocked
+        assert response.status_code == 409
+
+        # Cleanup
+        http_client.delete(f"/projects/{project_id}", headers=auth_headers(token))
+        http_client.delete("/users/me", headers=auth_headers(token))
+
+    def test_owner_can_delete_after_transferring_ownership(self, http_client):
+        """After transferring ownership, the former owner can delete their account."""
+        # GIVEN — owner with a project and an expert member
+        owner_email = unique_email("gdpr-xfer-own")
+        expert_email = unique_email("gdpr-xfer-exp")
+        owner_token = register_user(http_client, owner_email)
+        expert_token = register_user(http_client, expert_email)
+        project = create_project(http_client, owner_token, "Transferred Project")
+        project_id = project["id"]
+        invite_and_accept(http_client, owner_token, expert_token, expert_email, project_id)
+        expert_id = http_client.get("/users/me", headers=auth_headers(expert_token)).json()["id"]
+
+        # WHEN — owner transfers ownership, then deletes their account
+        transfer = http_client.post(
+            f"/projects/{project_id}/transfer-ownership",
+            json={"new_admin_id": expert_id},
+            headers=auth_headers(owner_token),
+        )
+        assert transfer.status_code == 200
+        assert transfer.json()["admin_id"] == expert_id
+
+        delete_resp = http_client.delete("/users/me", headers=auth_headers(owner_token))
+
+        # THEN — deletion now succeeds
+        assert delete_resp.status_code == 204
+
+        # Cleanup — the new owner removes the project and their own account
+        http_client.delete(f"/projects/{project_id}", headers=auth_headers(expert_token))
+        http_client.delete("/users/me", headers=auth_headers(expert_token))
+
 
 @pytest.mark.e2e
 class TestDeletionAudit:

--- a/tests/integration/api/db/test_cascade.py
+++ b/tests/integration/api/db/test_cascade.py
@@ -193,13 +193,15 @@ class TestProjectCascadeDelete:
 class TestUserCascadeDelete:
     """Tests for user deletion behavior with passive_deletes=True.
 
-    User relationships use passive_deletes=True, which delegates cascade
-    deletion to the database engine. In SQLite (no FK enforcement by default),
-    the ORM simply deletes the user row without touching child records.
-    In PostgreSQL, the database-level ondelete="CASCADE" handles cleanup.
+    User relationships use passive_deletes=True, which delegates referential
+    cleanup to the database. In SQLite (no FK enforcement by default) the ORM
+    just deletes the user row without touching child records, so these tests
+    only assert that the raw delete does not error.
 
-    For actual CASCADE behavior, see PostgreSQL integration tests:
-    test_db_postgres_integration.py::TestCascadeDeleteWithFKEnforcement
+    In PostgreSQL the database enforces the foreign keys: memberships, opinions,
+    and reset tokens are cascade-deleted, while a user who still admins a project
+    is blocked by ON DELETE RESTRICT (the API rejects that with 409 first). For
+    the enforced behavior see test_postgres_integration.py::TestForeignKeyEnforcement.
     """
 
     def test_deleting_user_with_memberships_succeeds_in_sqlite(self, session):
@@ -332,9 +334,11 @@ class TestUserCascadeDelete:
         """
         GIVEN a user who owns projects (is admin)
         WHEN the user is deleted in SQLite
-        THEN deletion succeeds (passive_deletes delegates to DB)
+        THEN the raw delete succeeds because SQLite does not enforce FKs
 
-        In PostgreSQL, Project rows are cascade-deleted by the DB.
+        In PostgreSQL this delete is blocked by ON DELETE RESTRICT on
+        projects.admin_id (see test_postgres_integration.py); the API rejects it
+        with 409 before it reaches the database.
         """
         # GIVEN
         admin = User(

--- a/tests/integration/api/db/test_migrations.py
+++ b/tests/integration/api/db/test_migrations.py
@@ -1,0 +1,78 @@
+"""Migration tests: run Alembic against a clean PostgreSQL database.
+
+These exercise the migration scripts themselves (upgrade/downgrade), not just the
+models, so a reversible schema change is proven end to end. Skipped when
+PostgreSQL is not installed.
+"""
+
+import shutil
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("pg_ctl"),
+    reason="PostgreSQL not installed (pg_ctl not found in PATH)",
+)
+
+# A clean database with no schema preloaded, so Alembic owns every table.
+try:
+    from pytest_postgresql import factories
+
+    migration_pg_proc = factories.postgresql_proc()
+    migration_pg = factories.postgresql("migration_pg_proc")
+except ImportError:
+    migration_pg_proc = None
+    migration_pg = None
+
+
+def _url(pg) -> str:
+    """Build a psycopg2 URL for the temporary database."""
+    return f"postgresql+psycopg2://{pg.info.user}:@{pg.info.host}:{pg.info.port}/{pg.info.dbname}"
+
+
+def _delete_rule(engine, constraint_name: str) -> str | None:
+    """Return the ON DELETE rule of a foreign key from information_schema."""
+    with engine.connect() as conn:
+        return conn.execute(
+            text(
+                "SELECT delete_rule FROM information_schema.referential_constraints "
+                "WHERE constraint_name = :name"
+            ),
+            {"name": constraint_name},
+        ).scalar()
+
+
+class TestProjectAdminRestrictMigration:
+    """The migration switching projects.admin_id to ON DELETE RESTRICT."""
+
+    def test_upgrade_sets_restrict_and_downgrade_restores_cascade(self, migration_pg, monkeypatch):
+        """upgrade applies RESTRICT, downgrade reverts to CASCADE, and it is reversible."""
+        # GIVEN - a clean database with Alembic aimed at it
+        url = _url(migration_pg)
+        monkeypatch.setenv("ALEMBIC_DATABASE_URL", url)
+        config = Config("alembic.ini")
+        engine = create_engine(url)
+
+        try:
+            # WHEN - the full migration chain is applied
+            command.upgrade(config, "head")
+
+            # THEN - admin_id is protected by RESTRICT
+            assert _delete_rule(engine, "projects_admin_id_fkey") == "RESTRICT"
+
+            # WHEN - the RESTRICT migration is rolled back one step
+            command.downgrade(config, "-1")
+
+            # THEN - the constraint reverts to CASCADE (downgrade works)
+            assert _delete_rule(engine, "projects_admin_id_fkey") == "CASCADE"
+
+            # WHEN - re-applied (reversibility holds)
+            command.upgrade(config, "head")
+
+            # THEN
+            assert _delete_rule(engine, "projects_admin_id_fkey") == "RESTRICT"
+        finally:
+            engine.dispose()

--- a/tests/integration/api/db/test_postgres_integration.py
+++ b/tests/integration/api/db/test_postgres_integration.py
@@ -182,6 +182,35 @@ class TestForeignKeyEnforcement:
         assert pg_session.get(ExpertOpinion, opinion_id) is None
         assert pg_session.get(CalculationResult, result_id) is None
 
+    def test_deleting_admin_with_project_is_restricted(self, pg_session):
+        """
+        GIVEN a user who admins a project
+        WHEN the user is deleted in PostgreSQL
+        THEN IntegrityError is raised (ON DELETE RESTRICT on projects.admin_id)
+
+        This is the database backstop behind the API's 409: erasing an owner must
+        not silently cascade away the project and other experts' contributions.
+        """
+        # GIVEN
+        admin = User(
+            email="restrict-admin@example.com",
+            hashed_password="hash",
+            first_name="Admin",
+            last_name="User",
+        )
+        pg_session.add(admin)
+        pg_session.commit()
+
+        project = Project(name="Owned Project", admin_id=admin.id)
+        pg_session.add(project)
+        pg_session.commit()
+
+        # WHEN / THEN - RESTRICT blocks deleting an owner who still has a project
+        pg_session.delete(admin)
+        with pytest.raises(IntegrityError):
+            pg_session.commit()
+        pg_session.rollback()
+
 
 class TestConcurrentAccess:
     """Tests for concurrent database access patterns."""

--- a/tests/integration/api/routes/test_photo.py
+++ b/tests/integration/api/routes/test_photo.py
@@ -329,3 +329,22 @@ class TestPhotoProxy:
 
         # THEN
         assert response.status_code == 404
+
+    def test_returns_404_when_stored_object_missing(self, client_with_mock_storage):
+        """The proxy returns 404 when the key is set but the object is gone from storage."""
+        # GIVEN - a user with a photo whose backing object has since disappeared
+        client, mock_storage = client_with_mock_storage
+        token = register_and_login(client, "gone@example.com")
+        user_id = client.get("/api/v1/users/me", headers=auth_header(token)).json()["id"]
+        client.post(
+            "/api/v1/users/me/photo",
+            headers=auth_header(token),
+            files={"file": ("photo.jpg", VALID_JPEG_BYTES, "image/jpeg")},
+        )
+        mock_storage.open.return_value = None
+
+        # WHEN
+        response = client.get(f"/api/v1/users/{user_id}/photo")
+
+        # THEN
+        assert response.status_code == 404

--- a/tests/integration/api/routes/test_projects.py
+++ b/tests/integration/api/routes/test_projects.py
@@ -3,7 +3,23 @@
 from unittest.mock import patch
 
 from api.services.project_membership_service import ProjectMembershipService
-from tests.integration.api.conftest import auth_header, register_and_login
+from tests.integration.api.conftest import auth_header, create_project, register_and_login
+
+
+def _add_expert(client, owner_token, project_id, email):
+    """Invite an expert into the project, accept, and return (token, user_id)."""
+    expert_token = register_and_login(client, email)
+    client.post(
+        f"/api/v1/projects/{project_id}/invite",
+        json={"email": email},
+        headers=auth_header(owner_token),
+    )
+    invitations = client.get("/api/v1/invitations", headers=auth_header(expert_token)).json()
+    accept = client.post(
+        f"/api/v1/invitations/{invitations[0]['id']}/accept",
+        headers=auth_header(expert_token),
+    )
+    return expert_token, accept.json()["user_id"]
 
 
 class TestCreateProject:
@@ -513,3 +529,105 @@ class TestRemoveMember:
 
         # THEN
         assert response.status_code == 403
+
+
+class TestTransferOwnership:
+    """Tests for POST /api/v1/projects/{id}/transfer-ownership."""
+
+    def test_transfer_ownership_success(self, client):
+        """Admin transfers ownership; admin_id moves and roles are swapped."""
+        # GIVEN
+        owner = register_and_login(client, "owner@example.com")
+        project = create_project(client, owner, "Shared")
+        project_id = project["id"]
+        owner_id = project["admin_id"]
+        _expert_token, expert_id = _add_expert(client, owner, project_id, "expert@example.com")
+
+        # WHEN
+        response = client.post(
+            f"/api/v1/projects/{project_id}/transfer-ownership",
+            json={"new_admin_id": expert_id},
+            headers=auth_header(owner),
+        )
+
+        # THEN
+        assert response.status_code == 200
+        assert response.json()["admin_id"] == expert_id
+        members = client.get(
+            f"/api/v1/projects/{project_id}/members", headers=auth_header(owner)
+        ).json()
+        roles = {m["user_id"]: m["role"] for m in members}
+        assert roles[expert_id] == "admin"
+        assert roles[owner_id] == "expert"
+
+    def test_transfer_to_non_member_returns_404(self, client):
+        """Transferring to a user who is not a member returns 404."""
+        # GIVEN
+        owner = register_and_login(client, "owner@example.com")
+        project = create_project(client, owner, "Solo")
+        fake_id = "00000000-0000-0000-0000-000000000000"
+
+        # WHEN
+        response = client.post(
+            f"/api/v1/projects/{project['id']}/transfer-ownership",
+            json={"new_admin_id": fake_id},
+            headers=auth_header(owner),
+        )
+
+        # THEN
+        assert response.status_code == 404
+
+    def test_transfer_to_self_returns_400(self, client):
+        """Transferring ownership to yourself returns 400."""
+        # GIVEN
+        owner = register_and_login(client, "owner@example.com")
+        project = create_project(client, owner, "Solo")
+        owner_id = project["admin_id"]
+
+        # WHEN
+        response = client.post(
+            f"/api/v1/projects/{project['id']}/transfer-ownership",
+            json={"new_admin_id": owner_id},
+            headers=auth_header(owner),
+        )
+
+        # THEN
+        assert response.status_code == 400
+
+    def test_transfer_not_admin_returns_403(self, client):
+        """A non-admin cannot transfer ownership."""
+        # GIVEN
+        owner = register_and_login(client, "owner@example.com")
+        outsider = register_and_login(client, "outsider@example.com")
+        project = create_project(client, owner, "Shared")
+        project_id = project["id"]
+        _expert_token, expert_id = _add_expert(client, owner, project_id, "expert@example.com")
+
+        # WHEN
+        response = client.post(
+            f"/api/v1/projects/{project_id}/transfer-ownership",
+            json={"new_admin_id": expert_id},
+            headers=auth_header(outsider),
+        )
+
+        # THEN
+        assert response.status_code == 403
+
+    def test_transfer_unblocks_account_deletion(self, client):
+        """The former owner can delete their account once ownership is transferred."""
+        # GIVEN
+        owner = register_and_login(client, "owner@example.com")
+        project = create_project(client, owner, "Shared")
+        project_id = project["id"]
+        _expert_token, expert_id = _add_expert(client, owner, project_id, "expert@example.com")
+        client.post(
+            f"/api/v1/projects/{project_id}/transfer-ownership",
+            json={"new_admin_id": expert_id},
+            headers=auth_header(owner),
+        )
+
+        # WHEN
+        response = client.delete("/api/v1/users/me", headers=auth_header(owner))
+
+        # THEN
+        assert response.status_code == 204

--- a/tests/integration/api/routes/test_users.py
+++ b/tests/integration/api/routes/test_users.py
@@ -72,10 +72,48 @@ class TestDeleteAccount:
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
-# NOTE: Tests for account deletion with projects are not included because
-# the current data model has NOT NULL constraints on admin_id and user_id.
-# This requires either:
-# 1. CASCADE DELETE on projects when admin is deleted
-# 2. Business logic to transfer ownership before deletion
-# 3. Preventing deletion when user owns projects
-# This is a separate feature that needs design decision.
+class TestDeleteAccountWithOwnedProjects:
+    """Account deletion is blocked while the user owns (is admin of) projects.
+
+    Right to erasure must not silently destroy other experts' contributions, so a
+    user who admins a project must transfer ownership or delete the project first.
+    """
+
+    def test_delete_account_with_owned_project_returns_409(self, client):
+        """Deletion is rejected with 409 while the user admins a project."""
+        # GIVEN
+        token = register_and_login(client, "owner@example.com")
+        client.post("/api/v1/projects", json={"name": "Owned"}, headers=auth_header(token))
+
+        # WHEN
+        response = client.delete("/api/v1/users/me", headers=auth_header(token))
+
+        # THEN
+        assert response.status_code == status.HTTP_409_CONFLICT
+
+    def test_account_survives_blocked_deletion(self, client):
+        """A blocked deletion leaves the account usable."""
+        # GIVEN
+        token = register_and_login(client, "survivor@example.com")
+        client.post("/api/v1/projects", json={"name": "Owned"}, headers=auth_header(token))
+        client.delete("/api/v1/users/me", headers=auth_header(token))
+
+        # WHEN
+        response = client.get("/api/v1/auth/me", headers=auth_header(token))
+
+        # THEN
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_delete_account_succeeds_after_project_deleted(self, client):
+        """Deletion succeeds once the owned project is gone."""
+        # GIVEN
+        token = register_and_login(client, "freed@example.com")
+        create = client.post("/api/v1/projects", json={"name": "Owned"}, headers=auth_header(token))
+        project_id = create.json()["id"]
+        client.delete(f"/api/v1/projects/{project_id}", headers=auth_header(token))
+
+        # WHEN
+        response = client.delete("/api/v1/users/me", headers=auth_header(token))
+
+        # THEN
+        assert response.status_code == status.HTTP_204_NO_CONTENT

--- a/tests/unit/api/services/test_project.py
+++ b/tests/unit/api/services/test_project.py
@@ -5,8 +5,8 @@ from uuid import uuid4
 
 import pytest
 
-from api.db.models import Project
-from api.exceptions import ProjectNotFoundError, ScaleRangeError
+from api.db.models import MemberRole, Project, ProjectMember
+from api.exceptions import MemberNotFoundError, ProjectNotFoundError, ScaleRangeError
 from api.schemas.project import ProjectCreate, ProjectUpdate
 from api.services.base import BaseService
 from api.services.project_service import ProjectService
@@ -329,3 +329,80 @@ class TestProjectServiceGetMemberCount:
 
         # THEN
         assert result == 0
+
+
+class TestProjectServiceGetOwnedProjects:
+    """Tests for ProjectService.get_owned_projects method."""
+
+    def test_returns_projects_where_user_is_admin(self):
+        """Returns projects the user owns (is admin of)."""
+        # GIVEN
+        user_id = uuid4()
+        owned = [
+            Project(id=uuid4(), name="A", admin_id=user_id, scale_min=0, scale_max=100),
+            Project(id=uuid4(), name="B", admin_id=user_id, scale_min=0, scale_max=100),
+        ]
+        mock_session = MagicMock()
+        mock_session.exec.return_value.all.return_value = owned
+        service = ProjectService(mock_session)
+
+        # WHEN
+        result = service.get_owned_projects(user_id)
+
+        # THEN
+        assert result == owned
+
+    def test_returns_empty_list_when_no_owned_projects(self):
+        """Returns empty list when the user owns no projects."""
+        # GIVEN
+        mock_session = MagicMock()
+        mock_session.exec.return_value.all.return_value = []
+        service = ProjectService(mock_session)
+
+        # WHEN
+        result = service.get_owned_projects(uuid4())
+
+        # THEN
+        assert result == []
+
+
+class TestProjectServiceTransferOwnership:
+    """Tests for ProjectService.transfer_ownership method."""
+
+    def test_transfers_ownership_and_swaps_roles(self):
+        """admin_id moves to the new owner and the two roles are swapped."""
+        # GIVEN
+        admin_id = uuid4()
+        new_admin_id = uuid4()
+        project_id = uuid4()
+        project = Project(id=project_id, name="P", admin_id=admin_id, scale_min=0, scale_max=100)
+        new_membership = ProjectMember(
+            project_id=project_id, user_id=new_admin_id, role=MemberRole.EXPERT
+        )
+        old_membership = ProjectMember(
+            project_id=project_id, user_id=admin_id, role=MemberRole.ADMIN
+        )
+        mock_session = MagicMock()
+        mock_session.exec.return_value.first.side_effect = [new_membership, old_membership]
+        service = ProjectService(mock_session)
+
+        # WHEN
+        result = service.transfer_ownership(project, new_admin_id)
+
+        # THEN
+        assert result.admin_id == new_admin_id
+        assert new_membership.role == MemberRole.ADMIN
+        assert old_membership.role == MemberRole.EXPERT
+        mock_session.commit.assert_called_once()
+
+    def test_raises_when_new_admin_not_member(self):
+        """MemberNotFoundError is raised when the target user is not a member."""
+        # GIVEN
+        project = Project(id=uuid4(), name="P", admin_id=uuid4(), scale_min=0, scale_max=100)
+        mock_session = MagicMock()
+        mock_session.exec.return_value.first.return_value = None
+        service = ProjectService(mock_session)
+
+        # WHEN / THEN
+        with pytest.raises(MemberNotFoundError):
+            service.transfer_ownership(project, uuid4())

--- a/tests/unit/api/services/test_service_logging.py
+++ b/tests/unit/api/services/test_service_logging.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+from api.db.models import MemberRole, Project, ProjectMember
 from api.schemas.project import ProjectCreate, ProjectUpdate
 from api.services.calculation_service import CalculationService
 from api.services.invitation_service import InvitationService
@@ -49,6 +50,29 @@ class TestProjectServiceLogging:
 
         # THEN
         assert mock_logger.info.call_args[1]["extra"]["event"] == "project_deleted"
+
+    def test_transfer_ownership_logs_event(self):
+        """transfer_ownership logs the event with both the old and new admin IDs."""
+        # GIVEN
+        old_admin_id = uuid4()
+        new_admin_id = uuid4()
+        project = Project(id=uuid4(), name="P", admin_id=old_admin_id, scale_min=0, scale_max=10)
+        mock_session = MagicMock()
+        mock_session.exec.return_value.first.side_effect = [
+            ProjectMember(project_id=project.id, user_id=new_admin_id, role=MemberRole.EXPERT),
+            ProjectMember(project_id=project.id, user_id=old_admin_id, role=MemberRole.ADMIN),
+        ]
+        service = ProjectService(mock_session)
+
+        # WHEN
+        with patch("api.services.project_service.logger") as mock_logger:
+            service.transfer_ownership(project, new_admin_id)
+
+        # THEN
+        extra = mock_logger.info.call_args[1]["extra"]
+        assert extra["event"] == "ownership_transferred"
+        assert extra["old_admin_id"] == str(old_admin_id)
+        assert extra["new_admin_id"] == str(new_admin_id)
 
 
 class TestUserServiceLogging:


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces two coordinated safety features: a `POST /api/v1/projects/{id}/transfer-ownership` endpoint that atomically swaps `Project.admin_id` and the two `ProjectMember` role rows, and a deletion guard on `DELETE /api/v1/users/me` that blocks account erasure while the user still admins any project (409 at the API layer, `ON DELETE RESTRICT` at the DB layer as a backstop).

- **Model / migration**: `projects.admin_id` FK is changed from `ON DELETE CASCADE` to `ON DELETE RESTRICT` via a reversible Alembic migration; the migration test exercises both `upgrade` and `downgrade` against a real PostgreSQL process.
- **Backend**: `ProjectService.transfer_ownership` is the single transactional unit; `get_owned_projects` feeds the deletion guard in `delete_current_user`; `AccountHasOwnedProjectsError` follows the existing domain-exception hierarchy and is wired into `EXCEPTION_MAP`.
- **Frontend**: A confirmation modal with `Crown` icon button is added to the team table; `Profile.tsx` discriminates the 409 response and shows an ownership-warning toast; all new strings are parallel in both `en` and `cs` locale files.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the self-transfer guard refactored to use a domain exception; the DB migration and ownership-transfer logic are sound.

The transfer route directly raises HTTPException(400) for the self-transfer case, while every other guarded condition in this codebase raises a typed domain exception routed through the centralized handler — meaning this error skips structured logging and request_id enrichment. The rest of the change (migration, service logic, exception hierarchy, i18n, tests) is well-constructed and complete.

api/routes/projects.py — the self-transfer guard needs a domain exception instead of a bare HTTPException.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| api/routes/projects.py | Adds transfer-ownership endpoint; self-transfer guard raises a bare HTTPException instead of a domain exception, violating the codebase's centralized exception-handler pattern. |
| api/services/project_service.py | Adds get_owned_projects and transfer_ownership; ownership transfer is atomic, membership roles are swapped correctly, but the audit log loses the old admin ID after assignment. |
| api/db/models.py | Switches projects.admin_id FK from ON DELETE CASCADE to RESTRICT with a clear rationale comment; paired with the Alembic migration. |
| migrations/versions/2026_06_25_1200-b1d9f4a2c7e3_restrict_project_admin_ondelete.py | Correctly drops and recreates the FK constraint with RESTRICT; downgrade restores CASCADE, and the migration test verifies both directions. |
| api/middleware/exception_handlers.py | Maps AccountHasOwnedProjectsError to 409 in EXCEPTION_MAP; consistent with the established OCP pattern. |
| api/routes/users.py | Injects ProjectService via Depends, raises AccountHasOwnedProjectsError (domain exception) correctly, docstring updated with :raises:. |
| frontend/src/pages/ProjectDetail.tsx | Adds transfer-ownership confirmation modal and Crown button; i18n keys used throughout, aria-label present, modal reuses DeleteConfirmModal correctly. |
| tests/integration/api/routes/test_projects.py | Comprehensive GIVEN/WHEN/THEN integration tests covering success, non-member 404, self-transfer 400, non-admin 403, and account-unblocking flow. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Route as transfer_ownership route
    participant Service as ProjectService
    participant DB as PostgreSQL

    Client->>Route: "POST /projects/{id}/transfer-ownership"
    Route->>Route: ProjectAdmin dependency (verifies current user is admin)
    Route->>Route: "new_admin_id == current_user.id? raise HTTPException(400)"
    Route->>Service: transfer_ownership(project, new_admin_id)
    Service->>DB: "SELECT ProjectMember WHERE user_id=new_admin_id"
    alt not a member
        Service-->>Route: raise MemberNotFoundError
        Route-->>Client: 404
    end
    Service->>DB: "SELECT ProjectMember WHERE user_id=old_admin_id"
    Service->>DB: "UPDATE Project.admin_id = new_admin_id"
    Service->>DB: "UPDATE ProjectMember role=ADMIN (new owner)"
    Service->>DB: "UPDATE ProjectMember role=EXPERT (old owner)"
    Service->>DB: COMMIT
    Service-->>Route: updated Project
    Route-->>Client: 200 ProjectResponse

    Note over Client,DB: Account deletion guard
    Client->>Route: DELETE /users/me
    Route->>Service: get_owned_projects(user_id)
    alt user admins one or more projects
        Route-->>Client: 409 AccountHasOwnedProjectsError
    else no owned projects
        Route->>DB: DELETE user
        Route-->>Client: 204
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Route as transfer_ownership route
    participant Service as ProjectService
    participant DB as PostgreSQL

    Client->>Route: "POST /projects/{id}/transfer-ownership"
    Route->>Route: ProjectAdmin dependency (verifies current user is admin)
    Route->>Route: "new_admin_id == current_user.id? raise HTTPException(400)"
    Route->>Service: transfer_ownership(project, new_admin_id)
    Service->>DB: "SELECT ProjectMember WHERE user_id=new_admin_id"
    alt not a member
        Service-->>Route: raise MemberNotFoundError
        Route-->>Client: 404
    end
    Service->>DB: "SELECT ProjectMember WHERE user_id=old_admin_id"
    Service->>DB: "UPDATE Project.admin_id = new_admin_id"
    Service->>DB: "UPDATE ProjectMember role=ADMIN (new owner)"
    Service->>DB: "UPDATE ProjectMember role=EXPERT (old owner)"
    Service->>DB: COMMIT
    Service-->>Route: updated Project
    Route-->>Client: 200 ProjectResponse

    Note over Client,DB: Account deletion guard
    Client->>Route: DELETE /users/me
    Route->>Service: get_owned_projects(user_id)
    alt user admins one or more projects
        Route-->>Client: 409 AccountHasOwnedProjectsError
    else no owned projects
        Route->>DB: DELETE user
        Route-->>Client: 204
    end
```

</a>

<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. `api/routes/projects.py`, line 117-121 ([link](https://github.com/caitlon/become/blob/2c24c28e0112f47f9191edd4f5afdbcc74886813/api/routes/projects.py#L117-L121)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Bare `HTTPException` bypasses the centralized exception handler**

   Every other guarded condition in this codebase raises a typed domain exception (e.g. `UserAlreadyMemberError`, `AccountHasOwnedProjectsError`) that flows through `EXCEPTION_MAP` in `exception_handlers.py`. This self-transfer guard breaks that pattern by raising `HTTPException` directly, which skips the handler, the structured logging, and the `request_id` enrichment. A `TransferToSelfError(ValidationError)` entry in `api/exceptions.py` mapped to `HTTP_400_BAD_REQUEST` in `EXCEPTION_MAP` would keep the pattern consistent per the `api-thin-endpoints` and `api-domain-exceptions` rules. The `:raises:` in the docstring also lists `HTTPException` rather than the domain class.

   **Rule Used:** Keep endpoints thin. Business logic belongs in ser... ([source](.greptile))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: api/routes/projects.py
   Line: 117-121
   
   Comment:
   **Bare `HTTPException` bypasses the centralized exception handler**
   
   Every other guarded condition in this codebase raises a typed domain exception (e.g. `UserAlreadyMemberError`, `AccountHasOwnedProjectsError`) that flows through `EXCEPTION_MAP` in `exception_handlers.py`. This self-transfer guard breaks that pattern by raising `HTTPException` directly, which skips the handler, the structured logging, and the `request_id` enrichment. A `TransferToSelfError(ValidationError)` entry in `api/exceptions.py` mapped to `HTTP_400_BAD_REQUEST` in `EXCEPTION_MAP` would keep the pattern consistent per the `api-thin-endpoints` and `api-domain-exceptions` rules. The `:raises:` in the docstring also lists `HTTPException` rather than the domain class.
   
   **Rule Used:** Keep endpoints thin. Business logic belongs in ser... ([source](.greptile))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
api/routes/projects.py:117-121
**Bare `HTTPException` bypasses the centralized exception handler**

Every other guarded condition in this codebase raises a typed domain exception (e.g. `UserAlreadyMemberError`, `AccountHasOwnedProjectsError`) that flows through `EXCEPTION_MAP` in `exception_handlers.py`. This self-transfer guard breaks that pattern by raising `HTTPException` directly, which skips the handler, the structured logging, and the `request_id` enrichment. A `TransferToSelfError(ValidationError)` entry in `api/exceptions.py` mapped to `HTTP_400_BAD_REQUEST` in `EXCEPTION_MAP` would keep the pattern consistent per the `api-thin-endpoints` and `api-domain-exceptions` rules. The `:raises:` in the docstring also lists `HTTPException` rather than the domain class.

### Issue 2 of 2
api/services/project_service.py:184-191
**Audit log is missing the previous owner's ID**

The structured log event records `new_admin_id` but omits the `old_admin_id` (which is available as `project.admin_id` before the mutation, but the log fires after `project.admin_id` has already been overwritten to `new_admin_id`). Anyone reviewing audit logs for ownership changes cannot tell who transferred away their admin rights without cross-referencing a second query. The old admin ID should be captured into a local variable before `project.admin_id` is reassigned and then included in the log's `extra` dict.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: document deletion guard and owners..."](https://github.com/caitlon/become/commit/2c24c28e0112f47f9191edd4f5afdbcc74886813) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39802995)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->