### PR TITLE
feat: add request correlation and close logging gaps

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -59,6 +59,7 @@ api/
 │   └── sanitization.py     # HTML sanitization
 ├── config.py           # Settings (Pydantic Settings)
 ├── logging_config.py   # Centralized logging + JSON formatter (test/prod)
+├── logging_context.py  # Request-scoped correlation (request_id/user_id) via contextvars
 ├── dependencies.py     # DI factories + authorization
 ├── exceptions.py       # API exception hierarchy
 └── main.py             # FastAPI application (+ setup_logging, Sentry init)
@@ -163,7 +164,7 @@ Environment variables (can use `.env` file):
 
 **Migrations:** The PostgreSQL schema is managed by Alembic (`migrations/`). `alembic upgrade head` runs automatically before each Railway deploy; to apply it manually against a specific database use `ALEMBIC_DATABASE_URL=<url> uv run alembic upgrade head`. SQLite (local development and the test suite) keeps using `create_all`, so no migration step is needed there.
 
-**Observability:** Every request gets an `X-Request-ID` response header (generated, or echoed from the client's header) for log correlation. Requests, unhandled exceptions, and rate-limit violations are logged under the `api.*` loggers; in `test`/`prod` the output is JSON so a log drain can index fields like `request_id` and `status_code`. Unhandled exceptions return an opaque 500 and are reported to Sentry when `SENTRY_DSN` is set. When the `BETTERSTACK_*` variables are set, the `api.*` logs are also shipped to Better Stack (a per-environment source) via `logtail-python`.
+**Observability:** Every request gets an `X-Request-ID` response header (generated, or echoed from the client's header) for log correlation. A `ContextFilter` binds that ID and the acting user through contextvars, so every `api.*` record -- service and security logs included -- carries `request_id` and `user_id`, not just the request line. Requests, unhandled exceptions, and rate-limit violations are logged under the `api.*` loggers; in `test`/`prod` the output is JSON so a log drain can index fields like `request_id` and `status_code`. Unhandled exceptions return an opaque 500 and are reported to Sentry when `SENTRY_DSN` is set. When the `BETTERSTACK_*` variables are set, the `api.*` logs are also shipped to Better Stack (a per-environment source) via `logtail-python`.
 
 ## Testing
 

--- a/api/auth/dependencies.py
+++ b/api/auth/dependencies.py
@@ -8,6 +8,7 @@ injected, and UserService is created with this injected dependency.
 from typing import Annotated
 
 from fastapi import Depends, HTTPException, status
+from fastapi.concurrency import run_in_threadpool
 from fastapi.security import OAuth2PasswordBearer
 from sqlmodel import Session
 
@@ -29,7 +30,9 @@ async def get_current_user(
     Session is injected via DI, UserService is created with the injected session
     (following DIP). The dependency is async so that ``set_user_id`` binds the
     acting user in the event-loop context: sync endpoints and services run in a
-    threadpool that copies that context, so their logs carry the user ID too.
+    threadpool that copies that context, so their logs carry the user ID too. The
+    blocking DB lookup is offloaded with ``run_in_threadpool`` so it never stalls
+    the event loop under concurrent load.
 
     :param token: JWT access token from Authorization header
     :param session: Injected database session
@@ -47,7 +50,7 @@ async def get_current_user(
         raise credentials_exception from e
 
     user_service = UserService(session)
-    user = user_service.get_by_id(user_id)
+    user = await run_in_threadpool(user_service.get_by_id, user_id)
     if user is None:
         raise credentials_exception
     set_user_id(str(user.id))

--- a/api/auth/dependencies.py
+++ b/api/auth/dependencies.py
@@ -14,19 +14,22 @@ from sqlmodel import Session
 from api.auth.jwt import TokenError, TokenPayload, decode_access_token, decode_token
 from api.db.models import User
 from api.db.session import get_session
+from api.logging_context import set_user_id
 from api.services.user_service import UserService
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login")
 
 
-def get_current_user(
+async def get_current_user(
     token: Annotated[str, Depends(oauth2_scheme)],
     session: Annotated[Session, Depends(get_session)],
 ) -> User:
     """Extract and validate current user from JWT token.
 
-    Session is injected via DI, UserService is created with
-    the injected session (following DIP).
+    Session is injected via DI, UserService is created with the injected session
+    (following DIP). The dependency is async so that ``set_user_id`` binds the
+    acting user in the event-loop context: sync endpoints and services run in a
+    threadpool that copies that context, so their logs carry the user ID too.
 
     :param token: JWT access token from Authorization header
     :param session: Injected database session
@@ -47,6 +50,7 @@ def get_current_user(
     user = user_service.get_by_id(user_id)
     if user is None:
         raise credentials_exception
+    set_user_id(str(user.id))
     return user
 
 

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -5,6 +5,7 @@ This module provides:
 - Authorization dependencies following DRY (single parameterized class)
 """
 
+import logging
 from enum import StrEnum
 from typing import Annotated
 from uuid import UUID
@@ -32,6 +33,8 @@ from api.services.storage.exceptions import StorageConfigurationError
 from api.services.storage.railway_bucket_storage_service import RailwayBucketStorageService
 from api.services.user_service import UserService
 from src.calculators.become_calculator import BeCoMeCalculator
+
+logger = logging.getLogger("api.security")
 
 # --- Calculator Factories ---
 
@@ -195,6 +198,15 @@ class RequireProjectAccess:
         has_access = self._check_access(membership_service, project_id, current_user.id)
         if not has_access:
             detail = self._get_error_detail()
+            logger.warning(
+                "Project access denied",
+                extra={
+                    "event": "access_denied",
+                    "project_id": str(project_id),
+                    "user_id": str(current_user.id),
+                    "required_level": self._access_level.value,
+                },
+            )
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=detail,

--- a/api/logging_config.py
+++ b/api/logging_config.py
@@ -7,6 +7,7 @@ from logging.handlers import RotatingFileHandler
 from logtail import LogtailHandler  # type: ignore[import-untyped]
 
 from api.config import Environment, Settings
+from api.logging_context import ContextFilter
 
 # Rotating file handler sizing, used only when LOG_FILE is configured.
 _LOG_FILE_MAX_BYTES = 10 * 1024 * 1024
@@ -108,9 +109,11 @@ def setup_logging(settings: Settings) -> None:
 
     Sets the level from ``LOG_LEVEL``, attaches a console handler (and a rotating
     file handler when ``LOG_FILE`` is set), and disables propagation so uvicorn
-    and SQLAlchemy logs stay separate. Child loggers such as ``api.security``
-    inherit this configuration. Safe to call repeatedly: existing ``api``
-    handlers are cleared first, so reloads and tests do not stack duplicates.
+    and SQLAlchemy logs stay separate. Every handler carries a
+    :class:`~api.logging_context.ContextFilter`, so the request-scoped
+    ``request_id`` and ``user_id`` reach records from child loggers such as
+    ``api.security`` too. Safe to call repeatedly: existing ``api`` handlers are
+    cleared first, so reloads and tests do not stack duplicates.
 
     :param settings: Application settings.
     """
@@ -121,9 +124,11 @@ def setup_logging(settings: Settings) -> None:
     for handler in list(logger.handlers):
         logger.removeHandler(handler)
 
+    context_filter = ContextFilter()
     formatter = _build_formatter(settings)
     stream_handler = logging.StreamHandler()
     stream_handler.setFormatter(formatter)
+    stream_handler.addFilter(context_filter)
     logger.addHandler(stream_handler)
 
     if settings.log_file:
@@ -133,6 +138,7 @@ def setup_logging(settings: Settings) -> None:
             backupCount=_LOG_FILE_BACKUP_COUNT,
         )
         file_handler.setFormatter(formatter)
+        file_handler.addFilter(context_filter)
         logger.addHandler(file_handler)
 
     if settings.betterstack_source_token and settings.betterstack_ingesting_host:
@@ -140,4 +146,5 @@ def setup_logging(settings: Settings) -> None:
             source_token=settings.betterstack_source_token,
             host=f"https://{_betterstack_host(settings.betterstack_ingesting_host)}",
         )
+        logtail_handler.addFilter(context_filter)
         logger.addHandler(logtail_handler)

--- a/api/logging_context.py
+++ b/api/logging_context.py
@@ -1,0 +1,90 @@
+"""Request-scoped logging context propagated via context variables.
+
+The request-logging middleware and the auth dependency bind the active
+``request_id`` and ``user_id`` here, and :class:`ContextFilter` copies them onto
+every ``api.*`` log record. This makes the correlation ID and the acting user
+queryable on service- and security-layer logs, not just on the request line,
+without threading them through every function signature.
+"""
+
+import logging
+from contextvars import ContextVar, Token
+
+_request_id_var: ContextVar[str | None] = ContextVar("request_id", default=None)
+_user_id_var: ContextVar[str | None] = ContextVar("user_id", default=None)
+
+
+def set_request_id(request_id: str) -> Token[str | None]:
+    """Bind the correlation ID for the current context.
+
+    :param request_id: Correlation ID for the active request.
+    :return: Reset token to restore the previous value.
+    """
+    return _request_id_var.set(request_id)
+
+
+def reset_request_id(token: Token[str | None]) -> None:
+    """Restore the correlation ID to its previous value.
+
+    :param token: Token returned by :func:`set_request_id`.
+    """
+    _request_id_var.reset(token)
+
+
+def get_request_id() -> str | None:
+    """Return the correlation ID bound to the current context.
+
+    :return: Active correlation ID, or ``None`` when unset.
+    """
+    return _request_id_var.get()
+
+
+def set_user_id(user_id: str) -> Token[str | None]:
+    """Bind the acting user ID for the current context.
+
+    :param user_id: ID of the authenticated user driving the request.
+    :return: Reset token to restore the previous value.
+    """
+    return _user_id_var.set(user_id)
+
+
+def reset_user_id(token: Token[str | None]) -> None:
+    """Restore the acting user ID to its previous value.
+
+    :param token: Token returned by :func:`set_user_id`.
+    """
+    _user_id_var.reset(token)
+
+
+def get_user_id() -> str | None:
+    """Return the acting user ID bound to the current context.
+
+    :return: Active user ID, or ``None`` when unset.
+    """
+    return _user_id_var.get()
+
+
+class ContextFilter(logging.Filter):
+    """Copy the request-scoped context onto each log record.
+
+    Attached to the ``api`` logger's handlers, so records from every child logger
+    (``api.service.*``, ``api.security``, ...) gain ``request_id`` and ``user_id``
+    when those are bound. Values passed explicitly via ``extra`` win: an attribute
+    already present on the record is left untouched.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Add the bound context attributes to the record and keep it.
+
+        :param record: Record about to be handled.
+        :return: Always ``True``; the record is never dropped.
+        """
+        if not hasattr(record, "request_id"):
+            request_id = _request_id_var.get()
+            if request_id is not None:
+                record.request_id = request_id
+        if not hasattr(record, "user_id"):
+            user_id = _user_id_var.get()
+            if user_id is not None:
+                record.user_id = user_id
+        return True

--- a/api/middleware/request_logging.py
+++ b/api/middleware/request_logging.py
@@ -9,6 +9,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 
+from api.logging_context import reset_request_id, set_request_id
 from api.utils.client_ip import get_client_ip
 
 logger = logging.getLogger("api.request")
@@ -26,9 +27,10 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
     """Assign a correlation ID, log each request/response, and time it.
 
     A request ID is taken from the inbound ``X-Request-ID`` header or generated,
-    stored on ``request.state.request_id`` for downstream handlers, and echoed
-    back on the response. Request bodies and the ``Authorization`` header are
-    never logged.
+    stored on ``request.state.request_id`` for downstream handlers, bound to the
+    logging context so every ``api.*`` record of this request carries it, and
+    echoed back on the response. Request bodies and the ``Authorization`` header
+    are never logged.
     """
 
     async def dispatch(
@@ -46,42 +48,45 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid.uuid4())
         request.state.request_id = request_id
         path = request.url.path
+        token = set_request_id(request_id)
+        try:
+            if path in _SKIP_PATHS:
+                response = await call_next(request)
+                response.headers[REQUEST_ID_HEADER] = request_id
+                return response
 
-        if path in _SKIP_PATHS:
+            logger.info(
+                "%s %s",
+                request.method,
+                path,
+                extra={
+                    "request_id": request_id,
+                    "method": request.method,
+                    "path": path,
+                    "ip": get_client_ip(request),
+                },
+            )
+
+            start = perf_counter()
             response = await call_next(request)
+            duration_ms = (perf_counter() - start) * 1000.0
+
+            level = logging.WARNING if duration_ms > _SLOW_REQUEST_MS else logging.INFO
+            logger.log(
+                level,
+                "%s %s %d %.0fms",
+                request.method,
+                path,
+                response.status_code,
+                duration_ms,
+                extra={
+                    "request_id": request_id,
+                    "status_code": response.status_code,
+                    "duration_ms": round(duration_ms, 1),
+                },
+            )
+
             response.headers[REQUEST_ID_HEADER] = request_id
             return response
-
-        logger.info(
-            "%s %s",
-            request.method,
-            path,
-            extra={
-                "request_id": request_id,
-                "method": request.method,
-                "path": path,
-                "ip": get_client_ip(request),
-            },
-        )
-
-        start = perf_counter()
-        response = await call_next(request)
-        duration_ms = (perf_counter() - start) * 1000.0
-
-        level = logging.WARNING if duration_ms > _SLOW_REQUEST_MS else logging.INFO
-        logger.log(
-            level,
-            "%s %s %d %.0fms",
-            request.method,
-            path,
-            response.status_code,
-            duration_ms,
-            extra={
-                "request_id": request_id,
-                "status_code": response.status_code,
-                "duration_ms": round(duration_ms, 1),
-            },
-        )
-
-        response.headers[REQUEST_ID_HEADER] = request_id
-        return response
+        finally:
+            reset_request_id(token)

--- a/api/services/project_membership_service.py
+++ b/api/services/project_membership_service.py
@@ -1,5 +1,6 @@
 """Project membership business logic service."""
 
+import logging
 from uuid import UUID
 
 from sqlmodel import col, select
@@ -8,6 +9,8 @@ from api.db.models import MemberRole, ProjectMember, User
 from api.exceptions import MemberNotFoundError
 from api.schemas.internal import MemberWithUser
 from api.services.base import BaseService
+
+logger = logging.getLogger("api.service.membership")
 
 
 class ProjectMembershipService(BaseService):
@@ -43,6 +46,14 @@ class ProjectMembershipService(BaseService):
             raise MemberNotFoundError(f"User {user_id} is not a member of project {project_id}")
 
         self._delete_and_commit(membership)
+        logger.info(
+            "Member removed",
+            extra={
+                "event": "member_removed",
+                "project_id": str(project_id),
+                "user_id": str(user_id),
+            },
+        )
 
     def is_member(self, project_id: UUID, user_id: UUID) -> bool:
         """Check if user is a member of the project.

--- a/api/services/storage/railway_bucket_storage_service.py
+++ b/api/services/storage/railway_bucket_storage_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+from time import perf_counter
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
@@ -17,7 +19,18 @@ from api.services.storage.validation import extension_for
 if TYPE_CHECKING:
     from api.config import Settings
 
+logger = logging.getLogger("api.service.storage")
+
 _NOT_FOUND_CODES = frozenset({"NoSuchKey", "NoSuchBucket", "404", "NotFound"})
+
+
+def _elapsed_ms(start: float) -> float:
+    """Return milliseconds elapsed since ``start``, rounded to one decimal.
+
+    :param start: ``perf_counter`` reading taken before the operation.
+    :return: Elapsed time in milliseconds.
+    """
+    return round((perf_counter() - start) * 1000.0, 1)
 
 
 class RailwayBucketStorageService(StorageService):
@@ -82,12 +95,33 @@ class RailwayBucketStorageService(StorageService):
         :raises StorageUploadError: If the upload fails.
         """
         key = self.build_key(user_id, content_type)
+        start = perf_counter()
         try:
             self._client.put_object(
                 Bucket=self._bucket, Key=key, Body=content, ContentType=content_type
             )
         except Exception as exc:
+            logger.error(
+                "S3 upload failed",
+                exc_info=exc,
+                extra={
+                    "event": "s3_upload_failed",
+                    "user_id": user_id,
+                    "key": key,
+                    "duration_ms": _elapsed_ms(start),
+                },
+            )
             raise StorageUploadError(f"Failed to upload file: {exc}") from exc
+        logger.info(
+            "S3 upload",
+            extra={
+                "event": "s3_upload",
+                "user_id": user_id,
+                "key": key,
+                "size_bytes": len(content),
+                "duration_ms": _elapsed_ms(start),
+            },
+        )
         return key
 
     def open(self, key: str) -> tuple[bytes, str] | None:
@@ -97,14 +131,41 @@ class RailwayBucketStorageService(StorageService):
         :return: ``(bytes, content_type)`` or None when the object is absent.
         :raises StorageError: If the fetch fails for a reason other than absence.
         """
+        start = perf_counter()
         try:
             response = self._client.get_object(Bucket=self._bucket, Key=key)
         except Exception as exc:
             if self._is_not_found(exc):
+                logger.info(
+                    "S3 object missing",
+                    extra={
+                        "event": "s3_open_miss",
+                        "key": key,
+                        "duration_ms": _elapsed_ms(start),
+                    },
+                )
                 return None
+            logger.error(
+                "S3 read failed",
+                exc_info=exc,
+                extra={
+                    "event": "s3_open_failed",
+                    "key": key,
+                    "duration_ms": _elapsed_ms(start),
+                },
+            )
             raise StorageError(f"Failed to read file: {exc}") from exc
         body: bytes = response["Body"].read()
         content_type: str = response.get("ContentType") or "application/octet-stream"
+        logger.info(
+            "S3 open",
+            extra={
+                "event": "s3_open",
+                "key": key,
+                "size_bytes": len(body),
+                "duration_ms": _elapsed_ms(start),
+            },
+        )
         return body, content_type
 
     def delete(self, key: str) -> bool:
@@ -114,10 +175,24 @@ class RailwayBucketStorageService(StorageService):
         :return: True when the delete request was issued.
         :raises StorageDeleteError: If deletion fails.
         """
+        start = perf_counter()
         try:
             self._client.delete_object(Bucket=self._bucket, Key=key)
         except Exception as exc:
+            logger.error(
+                "S3 delete failed",
+                exc_info=exc,
+                extra={
+                    "event": "s3_delete_failed",
+                    "key": key,
+                    "duration_ms": _elapsed_ms(start),
+                },
+            )
             raise StorageDeleteError(f"Failed to delete file: {exc}") from exc
+        logger.info(
+            "S3 delete",
+            extra={"event": "s3_delete", "key": key, "duration_ms": _elapsed_ms(start)},
+        )
         return True
 
     @staticmethod

--- a/docs/quality-report.md
+++ b/docs/quality-report.md
@@ -4,10 +4,10 @@
 
 | Check | Status | Result |
 |-------|--------|--------|
-| mypy (strict) | Pass | No errors in 32 files |
+| mypy (strict) | Pass | No errors in 28 files |
 | ruff check | Pass | No issues |
 | ruff format | Pass | All files formatted |
-| pytest | Pass | 953 tests passed |
+| pytest | Pass | 1112 tests passed |
 | coverage | Pass | 100% on `src/` |
 
 ## Running Checks
@@ -34,14 +34,14 @@ uv run mypy src/ examples/ && uv run ruff check . && uv run pytest --cov=src
 | interpreters/likert_interpreter.py | 24 | 100% |
 | models/become_result.py | 24 | 100% |
 | models/expert_opinion.py | 36 | 100% |
-| models/fuzzy_number.py | 46 | 100% |
-| **Total** | **201** | **100%** |
+| models/fuzzy_number.py | 49 | 100% |
+| **Total** | **204** | **100%** |
 
 HTML report: `uv run pytest --cov=src --cov-report=html` generates `htmlcov/index.html`.
 
 ## Test Breakdown
 
-Unit tests (571) cover models, calculators, interpreters, utilities, and API components (auth, schemas, services, middleware). Integration tests (329) validate core calculations against Excel reference data for all three case studies and test API routes with a real database. End-to-end tests (53) exercise full API workflows. Edge cases include single expert, identical opinions, empty lists, and boundary values.
+Unit tests (694) cover models, calculators, interpreters, utilities, and API components (auth, schemas, services, middleware, logging). Integration tests (359) validate core calculations against Excel reference data for all three case studies and test API routes with a real database. End-to-end tests (59) exercise full API workflows. Edge cases include single expert, identical opinions, empty lists, and boundary values.
 
 ## Mutation Testing
 

--- a/tests/unit/api/auth/test_dependencies.py
+++ b/tests/unit/api/auth/test_dependencies.py
@@ -1,5 +1,6 @@
 """Unit tests for authentication dependencies."""
 
+import asyncio
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -11,6 +12,7 @@ from api.auth.dependencies import get_current_token_payload, get_current_user
 from api.auth.jwt import ALGORITHM, create_access_token, revoke_token
 from api.auth.token_blacklist import TokenBlacklist
 from api.config import get_settings
+from api.logging_context import get_user_id
 
 
 class TestGetCurrentUser:
@@ -35,11 +37,34 @@ class TestGetCurrentUser:
             mock_service.get_by_id.return_value = mock_user
             mock_service_class.return_value = mock_service
 
-            result = get_current_user(token, mock_session)
+            result = asyncio.run(get_current_user(token, mock_session))
 
         # THEN
         assert result == mock_user
         mock_service.get_by_id.assert_called_once_with(user_id)
+
+    def test_binds_user_id_to_logging_context(self):
+        """A successful resolution binds the acting user ID to the context."""
+        # GIVEN
+        user_id = uuid4()
+        token = create_access_token(user_id)
+        mock_session = MagicMock()
+        mock_user = MagicMock()
+        mock_user.id = user_id
+
+        async def resolve_then_read() -> str | None:
+            with patch("api.auth.dependencies.UserService") as mock_service_class:
+                mock_service = MagicMock()
+                mock_service.get_by_id.return_value = mock_user
+                mock_service_class.return_value = mock_service
+                await get_current_user(token, mock_session)
+            return get_user_id()
+
+        # WHEN
+        bound = asyncio.run(resolve_then_read())
+
+        # THEN
+        assert bound == str(user_id)
 
     def test_raises_401_for_invalid_token(self):
         """Invalid token raises HTTPException 401."""
@@ -49,7 +74,7 @@ class TestGetCurrentUser:
 
         # WHEN / THEN
         with pytest.raises(HTTPException) as exc_info:
-            get_current_user(invalid_token, mock_session)
+            asyncio.run(get_current_user(invalid_token, mock_session))
 
         assert exc_info.value.status_code == 401
         assert "Could not validate credentials" in exc_info.value.detail
@@ -69,7 +94,7 @@ class TestGetCurrentUser:
 
             # THEN
             with pytest.raises(HTTPException) as exc_info:
-                get_current_user(token, mock_session)
+                asyncio.run(get_current_user(token, mock_session))
 
         assert exc_info.value.status_code == 401
         assert "Could not validate credentials" in exc_info.value.detail
@@ -88,7 +113,7 @@ class TestGetCurrentUser:
 
         # WHEN / THEN
         with pytest.raises(HTTPException) as exc_info:
-            get_current_user(token, mock_session)
+            asyncio.run(get_current_user(token, mock_session))
 
         assert exc_info.value.status_code == 401
 

--- a/tests/unit/api/middleware/test_request_logging.py
+++ b/tests/unit/api/middleware/test_request_logging.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
+from api.logging_context import get_request_id
 from api.middleware.request_logging import RequestLoggingMiddleware
 
 
@@ -23,6 +24,10 @@ def app() -> FastAPI:
     @application.get("/whoami")
     def whoami(request: Request):
         return {"request_id": request.state.request_id}
+
+    @application.get("/ctx")
+    def ctx():
+        return {"request_id": get_request_id()}
 
     @application.get("/api/v1/health")
     def health():
@@ -72,6 +77,18 @@ class TestRequestId:
         """
         # WHEN
         response = client.get("/whoami")
+
+        # THEN
+        assert response.json()["request_id"] == response.headers["X-Request-ID"]
+
+    def test_binds_request_id_to_logging_context(self, client: TestClient):
+        """
+        GIVEN a request handled through the middleware
+        WHEN the endpoint reads the request ID from the logging context
+        THEN it matches the response header, proving the contextvar propagates
+        """
+        # WHEN
+        response = client.get("/ctx")
 
         # THEN
         assert response.json()["request_id"] == response.headers["X-Request-ID"]

--- a/tests/unit/api/services/test_project_membership.py
+++ b/tests/unit/api/services/test_project_membership.py
@@ -1,6 +1,6 @@
 """Unit tests for ProjectMembershipService."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -87,6 +87,26 @@ class TestProjectMembershipServiceRemoveMember:
         # WHEN / THEN
         with pytest.raises(MemberNotFoundError, match="not a member"):
             service.remove_member(uuid4(), uuid4())
+
+    def test_logs_member_removed_event(self):
+        """A successful removal logs a member_removed event with both IDs."""
+        # GIVEN
+        project_id = uuid4()
+        user_id = uuid4()
+        membership = ProjectMember(project_id=project_id, user_id=user_id, role=MemberRole.EXPERT)
+        mock_session = MagicMock()
+        mock_session.exec.return_value.first.return_value = membership
+        service = ProjectMembershipService(mock_session)
+
+        # WHEN
+        with patch("api.services.project_membership_service.logger") as mock_logger:
+            service.remove_member(project_id, user_id)
+
+        # THEN
+        extra = mock_logger.info.call_args[1]["extra"]
+        assert extra["event"] == "member_removed"
+        assert extra["project_id"] == str(project_id)
+        assert extra["user_id"] == str(user_id)
 
 
 class TestProjectMembershipServiceIsMember:

--- a/tests/unit/api/services/test_storage.py
+++ b/tests/unit/api/services/test_storage.py
@@ -122,6 +122,40 @@ class TestUpload:
         with pytest.raises(StorageUploadError, match="Failed to upload"):
             service.upload(b"image data", "image/jpeg", "user-123")
 
+    def test_logs_success_with_size_and_duration(self):
+        """A successful upload logs an s3_upload event with size and timing."""
+        # GIVEN
+        client = MagicMock()
+        service = RailwayBucketStorageService(_settings(), client=client)
+
+        # WHEN
+        with patch("api.services.storage.railway_bucket_storage_service.logger") as mock_logger:
+            service.upload(b"image data", "image/jpeg", "user-123")
+
+        # THEN
+        extra = mock_logger.info.call_args[1]["extra"]
+        assert extra["event"] == "s3_upload"
+        assert extra["size_bytes"] == len(b"image data")
+        assert "duration_ms" in extra
+
+    def test_logs_failure_with_exc_info(self):
+        """A failed upload logs an error carrying exc_info before raising."""
+        # GIVEN
+        client = MagicMock()
+        client.put_object.side_effect = Exception("boom")
+        service = RailwayBucketStorageService(_settings(), client=client)
+
+        # WHEN
+        with (
+            patch("api.services.storage.railway_bucket_storage_service.logger") as mock_logger,
+            pytest.raises(StorageUploadError),
+        ):
+            service.upload(b"image data", "image/jpeg", "user-123")
+
+        # THEN
+        assert mock_logger.error.call_args[1]["extra"]["event"] == "s3_upload_failed"
+        assert mock_logger.error.call_args[1]["exc_info"] is not None
+
 
 class TestOpen:
     """Tests for fetching an object."""
@@ -166,6 +200,50 @@ class TestOpen:
         with pytest.raises(StorageError, match="Failed to read"):
             service.open("profiles/user/denied.jpg")
 
+    def test_raises_storage_error_on_non_client_error(self):
+        """A non-ClientError failure is treated as a real error, not absence."""
+        # GIVEN
+        client = MagicMock()
+        client.get_object.side_effect = RuntimeError("connection reset")
+        service = RailwayBucketStorageService(_settings(), client=client)
+
+        # WHEN / THEN
+        with pytest.raises(StorageError, match="Failed to read"):
+            service.open("profiles/user/x.jpg")
+
+    def test_logs_miss_event_when_absent(self):
+        """A missing object logs an s3_open_miss event, not an error."""
+        # GIVEN
+        client = MagicMock()
+        client.get_object.side_effect = _client_error("NoSuchKey")
+        service = RailwayBucketStorageService(_settings(), client=client)
+
+        # WHEN
+        with patch("api.services.storage.railway_bucket_storage_service.logger") as mock_logger:
+            service.open("profiles/user/missing.jpg")
+
+        # THEN
+        assert mock_logger.info.call_args[1]["extra"]["event"] == "s3_open_miss"
+        mock_logger.error.assert_not_called()
+
+    def test_logs_failure_with_exc_info(self):
+        """A non-absence failure logs an error carrying exc_info."""
+        # GIVEN
+        client = MagicMock()
+        client.get_object.side_effect = _client_error("AccessDenied")
+        service = RailwayBucketStorageService(_settings(), client=client)
+
+        # WHEN
+        with (
+            patch("api.services.storage.railway_bucket_storage_service.logger") as mock_logger,
+            pytest.raises(StorageError),
+        ):
+            service.open("profiles/user/denied.jpg")
+
+        # THEN
+        assert mock_logger.error.call_args[1]["extra"]["event"] == "s3_open_failed"
+        assert mock_logger.error.call_args[1]["exc_info"] is not None
+
 
 class TestDelete:
     """Tests for deleting an object."""
@@ -195,3 +273,34 @@ class TestDelete:
         # WHEN / THEN
         with pytest.raises(StorageDeleteError, match="Failed to delete"):
             service.delete("profiles/user/abc.jpg")
+
+    def test_logs_success_event(self):
+        """A successful delete logs an s3_delete event."""
+        # GIVEN
+        client = MagicMock()
+        service = RailwayBucketStorageService(_settings(), client=client)
+
+        # WHEN
+        with patch("api.services.storage.railway_bucket_storage_service.logger") as mock_logger:
+            service.delete("profiles/user/abc.jpg")
+
+        # THEN
+        assert mock_logger.info.call_args[1]["extra"]["event"] == "s3_delete"
+
+    def test_logs_failure_with_exc_info(self):
+        """A failed delete logs an error carrying exc_info before raising."""
+        # GIVEN
+        client = MagicMock()
+        client.delete_object.side_effect = Exception("boom")
+        service = RailwayBucketStorageService(_settings(), client=client)
+
+        # WHEN
+        with (
+            patch("api.services.storage.railway_bucket_storage_service.logger") as mock_logger,
+            pytest.raises(StorageDeleteError),
+        ):
+            service.delete("profiles/user/abc.jpg")
+
+        # THEN
+        assert mock_logger.error.call_args[1]["extra"]["event"] == "s3_delete_failed"
+        assert mock_logger.error.call_args[1]["exc_info"] is not None

--- a/tests/unit/api/test_dependencies.py
+++ b/tests/unit/api/test_dependencies.py
@@ -1,9 +1,15 @@
 """Tests for centralized FastAPI dependencies."""
 
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
 
 from api.config import Settings
 from api.dependencies import (
+    AccessLevel,
+    RequireProjectAccess,
     get_email_service,
     get_password_reset_service,
     get_storage_service,
@@ -159,3 +165,68 @@ class TestGetPasswordResetService:
         # THEN
         assert isinstance(result, PasswordResetService)
         assert result.session is mock_session
+
+
+class TestRequireProjectAccess:
+    """Tests for the parameterized project access dependency."""
+
+    def test_returns_project_when_access_granted(self):
+        """Returns the project when the user has the required access level."""
+        # GIVEN
+        project = MagicMock()
+        project_service = MagicMock()
+        project_service.get_project.return_value = project
+        membership_service = MagicMock()
+        membership_service.is_admin.return_value = True
+        current_user = MagicMock()
+        current_user.id = uuid4()
+        dependency = RequireProjectAccess(AccessLevel.ADMIN)
+
+        # WHEN
+        result = dependency(uuid4(), current_user, project_service, membership_service)
+
+        # THEN
+        assert result is project
+
+    def test_raises_404_when_project_missing(self):
+        """Raises 404 when the project does not exist."""
+        # GIVEN
+        project_service = MagicMock()
+        project_service.get_project.return_value = None
+        current_user = MagicMock()
+        current_user.id = uuid4()
+        dependency = RequireProjectAccess(AccessLevel.MEMBER)
+
+        # WHEN / THEN
+        with pytest.raises(HTTPException) as exc_info:
+            dependency(uuid4(), current_user, project_service, MagicMock())
+
+        assert exc_info.value.status_code == 404
+
+    def test_logs_and_raises_403_when_access_denied(self):
+        """Logs an access_denied warning and raises 403 when access is insufficient."""
+        # GIVEN
+        project_id = uuid4()
+        user_id = uuid4()
+        project_service = MagicMock()
+        project_service.get_project.return_value = MagicMock()
+        membership_service = MagicMock()
+        membership_service.is_admin.return_value = False
+        current_user = MagicMock()
+        current_user.id = user_id
+        dependency = RequireProjectAccess(AccessLevel.ADMIN)
+
+        # WHEN
+        with (
+            patch("api.dependencies.logger") as mock_logger,
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            dependency(project_id, current_user, project_service, membership_service)
+
+        # THEN
+        assert exc_info.value.status_code == 403
+        extra = mock_logger.warning.call_args[1]["extra"]
+        assert extra["event"] == "access_denied"
+        assert extra["project_id"] == str(project_id)
+        assert extra["user_id"] == str(user_id)
+        assert extra["required_level"] == "admin"

--- a/tests/unit/api/test_logging_config.py
+++ b/tests/unit/api/test_logging_config.py
@@ -6,6 +6,7 @@ from logging.handlers import RotatingFileHandler
 
 from api.config import Environment, Settings
 from api.logging_config import JsonLogFormatter, setup_logging
+from api.logging_context import ContextFilter
 
 
 def _settings(
@@ -217,6 +218,22 @@ class TestSetupLogging:
 
         # THEN
         assert len(logging.getLogger("api").handlers) == first_count
+
+    def test_attaches_context_filter_to_handlers(self):
+        """
+        GIVEN application settings
+        WHEN setup_logging runs
+        THEN the stream handler carries a ContextFilter
+        """
+        # GIVEN
+        settings = _settings()
+
+        # WHEN
+        setup_logging(settings)
+
+        # THEN
+        handler = logging.getLogger("api").handlers[0]
+        assert any(isinstance(log_filter, ContextFilter) for log_filter in handler.filters)
 
     def test_adds_rotating_file_handler_when_log_file_set(self, tmp_path):
         """

--- a/tests/unit/api/test_logging_context.py
+++ b/tests/unit/api/test_logging_context.py
@@ -1,0 +1,127 @@
+"""Tests for the request-scoped logging context and ContextFilter."""
+
+import logging
+
+from api.logging_context import (
+    ContextFilter,
+    get_request_id,
+    get_user_id,
+    reset_request_id,
+    reset_user_id,
+    set_request_id,
+    set_user_id,
+)
+
+
+def _record() -> logging.LogRecord:
+    """Build a minimal log record for filter tests."""
+    return logging.LogRecord(
+        name="api.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+
+
+class TestContextVars:
+    """Set/get/reset round-trips for the context variables."""
+
+    def test_request_id_round_trip(self):
+        """
+        GIVEN no bound request ID
+        WHEN one is set and then reset
+        THEN get reflects the value and returns to None afterwards
+        """
+        # GIVEN
+        assert get_request_id() is None
+
+        # WHEN
+        token = set_request_id("req-1")
+
+        # THEN
+        assert get_request_id() == "req-1"
+        reset_request_id(token)
+        assert get_request_id() is None
+
+    def test_user_id_round_trip(self):
+        """
+        GIVEN no bound user ID
+        WHEN one is set and then reset
+        THEN get reflects the value and returns to None afterwards
+        """
+        # GIVEN
+        assert get_user_id() is None
+
+        # WHEN
+        token = set_user_id("user-1")
+
+        # THEN
+        assert get_user_id() == "user-1"
+        reset_user_id(token)
+        assert get_user_id() is None
+
+
+class TestContextFilter:
+    """ContextFilter enriches records from the active context."""
+
+    def test_adds_bound_context_to_record(self):
+        """
+        GIVEN bound request and user IDs
+        WHEN the filter processes a record
+        THEN the record gains both attributes and is kept
+        """
+        # GIVEN
+        rid = set_request_id("req-9")
+        uid = set_user_id("user-9")
+        record = _record()
+
+        # WHEN
+        try:
+            kept = ContextFilter().filter(record)
+        finally:
+            reset_request_id(rid)
+            reset_user_id(uid)
+
+        # THEN
+        assert kept is True
+        assert record.request_id == "req-9"
+        assert record.user_id == "user-9"
+
+    def test_does_not_override_explicit_extra(self):
+        """
+        GIVEN a record already carrying a request_id from extra
+        WHEN the filter runs with a different bound request ID
+        THEN the explicit value is preserved
+        """
+        # GIVEN
+        token = set_request_id("ctx-id")
+        record = _record()
+        record.request_id = "explicit-id"
+
+        # WHEN
+        try:
+            ContextFilter().filter(record)
+        finally:
+            reset_request_id(token)
+
+        # THEN
+        assert record.request_id == "explicit-id"
+
+    def test_omits_unset_context(self):
+        """
+        GIVEN no bound context
+        WHEN the filter processes a record
+        THEN no context attributes are attached
+        """
+        # GIVEN
+        record = _record()
+
+        # WHEN
+        ContextFilter().filter(record)
+
+        # THEN
+        assert not hasattr(record, "request_id")
+        assert not hasattr(record, "user_id")


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds request correlation and fills logging gaps across the API. The main changes are:

- Request IDs and user IDs are stored in request-scoped logging context.
- API log handlers enrich `api.*` records with correlation fields.
- Request logging middleware binds and resets request IDs around each request.
- Auth resolution binds the authenticated user ID for downstream logs.
- Project access, membership removal, and Railway bucket operations now emit structured logs.
- Unit tests and API documentation were updated for the new observability behavior.

<h3>Confidence Score: 5/5</h3>

The changes are focused on observability and are covered by targeted unit tests across logging context, middleware, auth dependency behavior, and service logging paths.

No actionable defects were identified in the reviewed diff, and the updated tests exercise the main request correlation and log-enrichment behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that downstream api.service.probe and api.security now carry request\_id and user\_id, with request\_id matching the response header across both supplied and generated IDs.
- Validated that an access-denied path now emits a security warning with event: access\_denied, bound request\_id, and includes project\_id and user\_id.
- Observed that service-logging now records a full set of S3-related events during membership removal, including member\_removed, s3\_upload, s3\_open, s3\_delete, and their failure variants.

<a href="https://app.greptile.com/trex/runs/12311207/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: offload auth db lookup to threadpoo..."](https://github.com/caitlon/become/commit/56519565d57a801a52207001034773f3462d39db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39871160)</sub>

<!-- /greptile_comment -->