### PR TITLE
feat: close observability logging follow-ups

### DIFF
--- a/api/auth/logging.py
+++ b/api/auth/logging.py
@@ -87,6 +87,25 @@ def log_password_change(user_id: UUID, request: "Request | None" = None) -> None
     )
 
 
+def log_password_change_failure(request: "Request | None" = None) -> None:
+    """Log a failed password change (wrong current password).
+
+    Kept as a distinct event so brute-force alerting on ``login_failure`` is not
+    polluted by password-change attempts. The acting ``user_id`` is bound by the
+    logging ContextFilter from the authenticated request.
+
+    :param request: FastAPI request (for IP extraction)
+    """
+    ip = get_client_ip(request)
+    logger.warning(
+        "Password change failed",
+        extra={
+            "event": "password_change_failure",
+            "ip": ip,
+        },
+    )
+
+
 def log_password_reset_requested(email: str, request: "Request | None" = None) -> None:
     """Log a password reset request (forgot-password).
 

--- a/api/main.py
+++ b/api/main.py
@@ -1,5 +1,6 @@
 """FastAPI application entry point."""
 
+import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
@@ -17,12 +18,23 @@ from api.middleware.request_logging import RequestLoggingMiddleware
 from api.middleware.security_headers import SecurityHeadersMiddleware
 from api.routes import auth, calculate, health, invitations, opinions, projects, users
 
+logger = logging.getLogger("api.main")
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
-    """Initialize database tables on startup."""
+    """Initialize database tables and log the application lifecycle.
+
+    The startup and shutdown records carry the running version and active
+    profile so the journal pins which build and environment served the run.
+    """
+    settings = get_settings()
+    lifecycle = {"api_version": settings.api_version, "environment": settings.environment.value}
+
     create_db_and_tables()
+    logger.info("Application started", extra={"event": "app_startup", **lifecycle})
     yield
+    logger.info("Application stopped", extra={"event": "app_shutdown", **lifecycle})
 
 
 def _init_sentry(settings: Settings) -> None:

--- a/api/middleware/exception_handlers.py
+++ b/api/middleware/exception_handlers.py
@@ -10,7 +10,7 @@ import logging
 from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
 
-from api.auth.logging import log_login_failure
+from api.auth.logging import log_login_failure, log_password_change_failure
 from api.exceptions import (
     AccountHasOwnedProjectsError,
     BeCoMeAPIError,
@@ -136,8 +136,11 @@ def become_api_error_handler(request: Request, exc: BeCoMeAPIError) -> JSONRespo
     headers = None
     if isinstance(exc, InvalidCredentialsError):
         headers = {"WWW-Authenticate": "Bearer"}
-        # Log failed authentication attempt
-        if exc.email:
+        # A wrong current password is a distinct security event from a failed
+        # login, so it does not pollute brute-force alerting on login_failure.
+        if exc.reason == "invalid_current_password":
+            log_password_change_failure(request)
+        elif exc.email:
             log_login_failure(exc.email, exc.reason, request)
 
     return JSONResponse(

--- a/api/services/email/console_email_sender.py
+++ b/api/services/email/console_email_sender.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from api.services.email.base import EmailSender
 
@@ -11,6 +12,30 @@ if TYPE_CHECKING:
     from api.config import Settings
 
 logger = logging.getLogger("api.service.email")
+
+_TOKEN_PREFIX_LEN = 8
+
+
+def _mask_token(reset_url: str) -> str:
+    """Mask the reset token value in a reset URL.
+
+    Keeps a few leading characters so two links stay distinguishable in the log
+    without exposing the full single-use token. Returns the URL unchanged when
+    it carries no ``token`` parameter.
+
+    :param reset_url: Full reset link carrying a ``token`` query parameter.
+    :return: The URL with the token value masked.
+
+    >>> _mask_token("https://app/reset-password?token=abcdefghijklmnop")
+    'https://app/reset-password?token=abcdefgh...'
+    """
+    parts = urlparse(reset_url)
+    params = parse_qs(parts.query)
+    raw = params.get("token", [""])[0]
+    if not raw:
+        return reset_url
+    params["token"] = [f"{raw[:_TOKEN_PREFIX_LEN]}..." if len(raw) > _TOKEN_PREFIX_LEN else "..."]
+    return urlunparse(parts._replace(query=urlencode(params, doseq=True)))
 
 
 class ConsoleEmailSender(EmailSender):
@@ -31,11 +56,20 @@ class ConsoleEmailSender(EmailSender):
     async def send_password_reset(self, *, to_email: str, reset_url: str) -> None:
         """Log the reset link; perform no network call.
 
+        The INFO record masks the single-use token so an aggregated log never
+        captures it; the full link stays at DEBUG for the local dev flow.
+
         :param to_email: Recipient email address.
         :param reset_url: Full frontend reset link (carries the raw token).
         """
         logger.info(
             "Password reset link (console sender) for %s: %s",
+            to_email,
+            _mask_token(reset_url),
+            extra={"event": "password_reset_email", "to_email": to_email},
+        )
+        logger.debug(
+            "Password reset link (full, console sender) for %s: %s",
             to_email,
             reset_url,
             extra={"event": "password_reset_email", "to_email": to_email},

--- a/api/services/invitation_service.py
+++ b/api/services/invitation_service.py
@@ -84,6 +84,8 @@ class InvitationService(BaseService):
                 "event": "invitation_created",
                 "invitation_id": str(saved.id),
                 "project_id": str(project_id),
+                "inviter_id": str(inviter_id),
+                "invitee_id": str(saved.invitee_id),
             },
         )
         return saved, invitee
@@ -151,6 +153,7 @@ class InvitationService(BaseService):
             raise UserAlreadyMemberError("User is already a member of this project")
 
         project_id = invitation.project_id
+        inviter_id = invitation.inviter_id
         membership = ProjectMember(
             project_id=project_id,
             user_id=user_id,
@@ -166,6 +169,8 @@ class InvitationService(BaseService):
                 "event": "invitation_accepted",
                 "invitation_id": str(invitation_id),
                 "project_id": str(project_id),
+                "inviter_id": str(inviter_id),
+                "user_id": str(user_id),
             },
         )
         return membership
@@ -195,8 +200,16 @@ class InvitationService(BaseService):
         if not invitation or invitation.invitee_id != user_id:
             raise InvitationNotFoundError("Invitation not found")
 
+        project_id = invitation.project_id
+        inviter_id = invitation.inviter_id
         self._delete_and_commit(invitation)
         logger.info(
             "Invitation declined",
-            extra={"event": "invitation_declined", "invitation_id": str(invitation_id)},
+            extra={
+                "event": "invitation_declined",
+                "invitation_id": str(invitation_id),
+                "project_id": str(project_id),
+                "inviter_id": str(inviter_id),
+                "user_id": str(user_id),
+            },
         )

--- a/api/services/user_service.py
+++ b/api/services/user_service.py
@@ -123,7 +123,10 @@ class UserService(BaseService):
         :raises InvalidCredentialsError: If current password is incorrect
         """
         if not verify_password(current_password, user.hashed_password):
-            raise InvalidCredentialsError("Current password is incorrect")
+            raise InvalidCredentialsError(
+                "Current password is incorrect",
+                reason="invalid_current_password",
+            )
 
         user.hashed_password = hash_password(new_password)
         return self._save_and_refresh(user)

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import { Navbar } from "@/components/layout/Navbar";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { logger } from "@/lib/logger";
 
 const NotFound = () => {
   const { t } = useTranslation();
@@ -11,10 +12,7 @@ const NotFound = () => {
   useDocumentTitle(t("pageTitle.notFound"));
 
   useEffect(() => {
-    console.error(
-      "404 Error: User attempted to access non-existent route:",
-      location.pathname
-    );
+    logger.error("404 Error: route not found", { path: location.pathname });
   }, [location.pathname]);
 
   return (

--- a/frontend/tests/pages/NotFound.test.tsx
+++ b/frontend/tests/pages/NotFound.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { screen } from '@testing-library/react';
 import { render } from '@tests/utils';
 import NotFound from '@/pages/NotFound';
+import { logger } from '@/lib/logger';
 
 // Mock useAuth
 vi.mock('@/contexts/AuthContext', () => ({
@@ -13,15 +14,13 @@ vi.mock('@/contexts/AuthContext', () => ({
 }));
 
 describe('NotFound', () => {
-  const originalConsoleError = console.error;
-
   beforeEach(() => {
-    // Suppress the expected 404 console.error log
-    console.error = vi.fn();
+    // Silence and observe the expected 404 log emitted on mount
+    vi.spyOn(logger, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    console.error = originalConsoleError;
+    vi.restoreAllMocks();
   });
 
   it('renders 404 heading', () => {
@@ -41,5 +40,14 @@ describe('NotFound', () => {
 
     const homeLink = screen.getByRole('link', { name: /home|back/i });
     expect(homeLink).toHaveAttribute('href', '/');
+  });
+
+  it('logs the 404 through the app logger', () => {
+    render(<NotFound />);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('404'),
+      expect.objectContaining({ path: expect.any(String) })
+    );
   });
 });

--- a/tests/integration/api/auth/test_logging.py
+++ b/tests/integration/api/auth/test_logging.py
@@ -8,6 +8,7 @@ from api.auth.logging import (
     log_login_failure,
     log_login_success,
     log_password_change,
+    log_password_change_failure,
     log_registration,
 )
 
@@ -242,6 +243,46 @@ class TestLogPasswordChange:
         # THEN
         extra = mock_logger.info.call_args[1]["extra"]
         assert extra["ip"] == "172.16.0.1"
+
+
+class TestLogPasswordChangeFailure:
+    """Tests for log_password_change_failure function."""
+
+    def test_logs_warning_with_event(self):
+        """A failed password change is logged at WARNING with its own event type."""
+        # WHEN
+        with patch("api.auth.logging.logger") as mock_logger:
+            log_password_change_failure()
+
+        # THEN
+        mock_logger.warning.assert_called_once()
+        extra = mock_logger.warning.call_args[1]["extra"]
+        assert extra["event"] == "password_change_failure"
+
+    def test_extracts_ip_from_request(self):
+        """Failed password change extracts IP from request."""
+        # GIVEN
+        mock_request = MagicMock()
+        mock_request.headers.get.return_value = "10.0.0.7"
+
+        # WHEN
+        with patch("api.auth.logging.logger") as mock_logger:
+            log_password_change_failure(mock_request)
+
+        # THEN
+        extra = mock_logger.warning.call_args[1]["extra"]
+        assert extra["ip"] == "10.0.0.7"
+
+    def test_handles_none_request(self):
+        """Failed password change handles None request gracefully."""
+        # WHEN
+        with patch("api.auth.logging.logger") as mock_logger:
+            log_password_change_failure(None)
+
+        # THEN
+        extra = mock_logger.warning.call_args[1]["extra"]
+        assert extra["event"] == "password_change_failure"
+        assert extra["ip"] == "unknown"
 
 
 class TestLogAccountDeletion:

--- a/tests/unit/api/middleware/test_exception_handlers.py
+++ b/tests/unit/api/middleware/test_exception_handlers.py
@@ -210,6 +210,27 @@ class TestBecomeApiErrorHandler:
             # THEN
             mock_log.assert_not_called()
 
+    def test_invalid_current_password_logs_password_change_failure(self):
+        """
+        GIVEN an InvalidCredentialsError flagged as a wrong current password
+        WHEN become_api_error_handler is called
+        THEN it logs a password-change failure, not a login failure
+        """
+        # GIVEN
+        request = MagicMock()
+        exc = InvalidCredentialsError(reason="invalid_current_password")
+
+        with (
+            patch("api.middleware.exception_handlers.log_password_change_failure") as mock_pcf,
+            patch("api.middleware.exception_handlers.log_login_failure") as mock_lf,
+        ):
+            # WHEN
+            become_api_error_handler(request, exc)
+
+            # THEN
+            mock_pcf.assert_called_once_with(request)
+            mock_lf.assert_not_called()
+
 
 class TestRegisterExceptionHandlers:
     """Tests for register_exception_handlers function."""

--- a/tests/unit/api/services/test_email.py
+++ b/tests/unit/api/services/test_email.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from api.services.email.console_email_sender import ConsoleEmailSender
+from api.services.email.console_email_sender import ConsoleEmailSender, _mask_token
 from api.services.email.exceptions import EmailSendError
 from api.services.email.resend_email_sender import ResendEmailSender
 
@@ -66,6 +66,27 @@ class TestConsoleEmailSender:
         # THEN
         mock_logger.debug.assert_called_once()
         assert self._RESET_URL in str(mock_logger.debug.call_args)
+
+
+class TestMaskToken:
+    """Tests for the reset-link token masking helper."""
+
+    def test_fully_masks_a_short_token(self):
+        """A token at or below the prefix length is hidden entirely."""
+        # WHEN
+        masked = _mask_token("https://app.example/reset-password?token=short")
+
+        # THEN
+        assert "short" not in masked
+        assert "token=..." in masked
+
+    def test_returns_url_unchanged_without_a_token(self):
+        """A URL without a token query parameter is returned as-is."""
+        # GIVEN
+        url = "https://app.example/reset-password"
+
+        # WHEN / THEN
+        assert _mask_token(url) == url
 
 
 class TestResendEmailSender:

--- a/tests/unit/api/services/test_email.py
+++ b/tests/unit/api/services/test_email.py
@@ -27,27 +27,45 @@ def _settings(**overrides: object) -> MagicMock:
 class TestConsoleEmailSender:
     """Tests for the development console email sender."""
 
-    def test_logs_reset_link_without_network(self):
+    _RAW_TOKEN = "S3cret-Reset-Token-abcdefghijklmnop-1234567890"
+    _RESET_URL = f"https://app.example/reset-password?token={_RAW_TOKEN}"
+
+    def _send(self, mock_logger_attr: str = "logger"):
+        """Send a reset email through the console sender with the logger patched."""
+        sender = ConsoleEmailSender(_settings())
+        with patch("api.services.email.console_email_sender.logger") as mock_logger:
+            asyncio.run(
+                sender.send_password_reset(to_email="user@example.com", reset_url=self._RESET_URL)
+            )
+        return mock_logger
+
+    def test_info_log_masks_the_raw_token(self):
         """
         GIVEN a console email sender
         WHEN a password reset email is sent
-        THEN the reset link is logged and no network call is made
+        THEN the INFO record never carries the full raw token
         """
-        # GIVEN
-        sender = ConsoleEmailSender(_settings())
-
         # WHEN
-        with patch("api.services.email.console_email_sender.logger") as mock_logger:
-            asyncio.run(
-                sender.send_password_reset(
-                    to_email="user@example.com",
-                    reset_url="https://app.example/reset-password?token=abc123",
-                )
-            )
+        mock_logger = self._send()
 
         # THEN
         mock_logger.info.assert_called_once()
-        assert "https://app.example/reset-password?token=abc123" in str(mock_logger.info.call_args)
+        info_str = str(mock_logger.info.call_args)
+        assert self._RAW_TOKEN not in info_str
+        assert "..." in info_str
+
+    def test_debug_log_keeps_the_full_link_for_local_dev(self):
+        """
+        GIVEN a console email sender
+        WHEN a password reset email is sent
+        THEN the full link stays available at DEBUG so the dev flow still works
+        """
+        # WHEN
+        mock_logger = self._send()
+
+        # THEN
+        mock_logger.debug.assert_called_once()
+        assert self._RESET_URL in str(mock_logger.debug.call_args)
 
 
 class TestResendEmailSender:

--- a/tests/unit/api/services/test_service_logging.py
+++ b/tests/unit/api/services/test_service_logging.py
@@ -143,56 +143,75 @@ class TestOpinionServiceLogging:
 
 
 class TestInvitationServiceLogging:
-    """Invitation lifecycle events are logged at INFO."""
+    """Invitation lifecycle events are logged at INFO with actor context."""
 
-    def test_invite_logs_event(self):
-        """invite_by_email logs an invitation_created event."""
+    def test_invite_logs_event_with_actor_context(self):
+        """invite_by_email logs invitation_created with inviter, invitee, and project."""
         # GIVEN
+        project_id, inviter_id, invitee_id = uuid4(), uuid4(), uuid4()
+        invitee = MagicMock()
+        invitee.id = invitee_id
         session = MagicMock()
-        session.exec.return_value.first.side_effect = [MagicMock(), None, None]
+        session.exec.return_value.first.side_effect = [invitee, None, None]
         service = InvitationService(session)
 
         # WHEN
         with patch("api.services.invitation_service.logger") as mock_logger:
-            service.invite_by_email(uuid4(), uuid4(), "user@example.com")
+            service.invite_by_email(project_id, inviter_id, "user@example.com")
 
         # THEN
-        assert mock_logger.info.call_args[1]["extra"]["event"] == "invitation_created"
+        extra = mock_logger.info.call_args[1]["extra"]
+        assert extra["event"] == "invitation_created"
+        assert extra["inviter_id"] == str(inviter_id)
+        assert extra["invitee_id"] == str(invitee_id)
+        assert extra["project_id"] == str(project_id)
 
-    def test_accept_logs_event(self):
-        """accept_invitation logs an invitation_accepted event."""
+    def test_accept_logs_event_with_actor_context(self):
+        """accept_invitation logs invitation_accepted with the acceptor and inviter."""
         # GIVEN
-        session = MagicMock()
-        user_id = uuid4()
+        invitation_id, user_id, inviter_id, project_id = uuid4(), uuid4(), uuid4(), uuid4()
         invitation = MagicMock()
         invitation.invitee_id = user_id
+        invitation.inviter_id = inviter_id
+        invitation.project_id = project_id
+        session = MagicMock()
         session.get.return_value = invitation
         session.exec.return_value.first.return_value = None
         service = InvitationService(session)
 
         # WHEN
         with patch("api.services.invitation_service.logger") as mock_logger:
-            service.accept_invitation(uuid4(), user_id)
+            service.accept_invitation(invitation_id, user_id)
 
         # THEN
-        assert mock_logger.info.call_args[1]["extra"]["event"] == "invitation_accepted"
+        extra = mock_logger.info.call_args[1]["extra"]
+        assert extra["event"] == "invitation_accepted"
+        assert extra["user_id"] == str(user_id)
+        assert extra["inviter_id"] == str(inviter_id)
+        assert extra["project_id"] == str(project_id)
 
-    def test_decline_logs_event(self):
-        """decline_invitation logs an invitation_declined event."""
+    def test_decline_logs_event_with_actor_context(self):
+        """decline_invitation logs invitation_declined with the decliner and inviter."""
         # GIVEN
-        session = MagicMock()
-        user_id = uuid4()
+        invitation_id, user_id, inviter_id, project_id = uuid4(), uuid4(), uuid4(), uuid4()
         invitation = MagicMock()
         invitation.invitee_id = user_id
+        invitation.inviter_id = inviter_id
+        invitation.project_id = project_id
+        session = MagicMock()
         session.get.return_value = invitation
         service = InvitationService(session)
 
         # WHEN
         with patch("api.services.invitation_service.logger") as mock_logger:
-            service.decline_invitation(uuid4(), user_id)
+            service.decline_invitation(invitation_id, user_id)
 
         # THEN
-        assert mock_logger.info.call_args[1]["extra"]["event"] == "invitation_declined"
+        extra = mock_logger.info.call_args[1]["extra"]
+        assert extra["event"] == "invitation_declined"
+        assert extra["user_id"] == str(user_id)
+        assert extra["inviter_id"] == str(inviter_id)
+        assert extra["project_id"] == str(project_id)
 
 
 class TestCalculationServiceLogging:

--- a/tests/unit/api/services/test_user.py
+++ b/tests/unit/api/services/test_user.py
@@ -464,7 +464,7 @@ class TestUserServiceChangePassword:
         mock_session.refresh.assert_called_once_with(user)
 
     def test_raises_error_on_wrong_current_password(self):
-        """InvalidCredentialsError is raised when current password is wrong."""
+        """InvalidCredentialsError with a labelling reason is raised when current is wrong."""
         # GIVEN
         user = User(
             id=uuid4(),
@@ -478,9 +478,12 @@ class TestUserServiceChangePassword:
         # WHEN / THEN
         with (
             patch("api.services.user_service.verify_password", return_value=False),
-            pytest.raises(InvalidCredentialsError, match="Current password is incorrect"),
+            pytest.raises(
+                InvalidCredentialsError, match="Current password is incorrect"
+            ) as exc_info,
         ):
             service.change_password(user, "wrong_pass", "new_pass")
+        assert exc_info.value.reason == "invalid_current_password"
 
     def test_new_password_is_hashed(self):
         """New password is hashed before storing."""

--- a/tests/unit/api/test_logging_config.py
+++ b/tests/unit/api/test_logging_config.py
@@ -392,3 +392,70 @@ class TestSentryInit:
             _init_sentry(settings)
 
         mock_init.assert_not_called()
+
+
+class TestLifespanLogging:
+    """Tests that the lifespan logs application start and stop."""
+
+    @staticmethod
+    def _run_lifespan():
+        """Start and stop the app under TestClient, returning the captured logger mock."""
+        from unittest.mock import patch
+
+        from fastapi.testclient import TestClient
+
+        from api.main import create_app
+
+        with (
+            patch("api.main.create_db_and_tables"),
+            patch("api.main.logger") as mock_logger,
+        ):
+            app = create_app()
+            with TestClient(app):
+                pass
+        return mock_logger
+
+    @staticmethod
+    def _events(mock_logger):
+        """Collect the ``event`` field from every info call carrying an extra mapping."""
+        return [
+            call.kwargs["extra"]["event"]
+            for call in mock_logger.info.call_args_list
+            if "extra" in call.kwargs
+        ]
+
+    @staticmethod
+    def _record_for(mock_logger, event):
+        """Return the extra mapping of the info call matching the given event."""
+        for call in mock_logger.info.call_args_list:
+            extra = call.kwargs.get("extra", {})
+            if extra.get("event") == event:
+                return extra
+        raise AssertionError(f"No info log with event={event!r}")
+
+    def test_logs_startup_event_with_version_and_environment(self):
+        """
+        GIVEN the application factory
+        WHEN the app starts under lifespan
+        THEN an app_startup record carries the api_version and environment
+        """
+        # WHEN
+        mock_logger = self._run_lifespan()
+
+        # THEN
+        assert "app_startup" in self._events(mock_logger)
+        extra = self._record_for(mock_logger, "app_startup")
+        assert extra["api_version"]
+        assert extra["environment"]
+
+    def test_logs_shutdown_event(self):
+        """
+        GIVEN the application factory
+        WHEN the app stops after lifespan
+        THEN an app_shutdown record is emitted
+        """
+        # WHEN
+        mock_logger = self._run_lifespan()
+
+        # THEN
+        assert "app_shutdown" in self._events(mock_logger)


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes observability logging follow-ups. The main changes are:

- Adds a separate password-change-failure security event.
- Adds app startup and shutdown lifecycle logs with version and environment context.
- Adds inviter, invitee, user, and project context to invitation lifecycle logs.
- Masks password reset tokens in INFO console-email logs while keeping the full local development link at DEBUG.
- Routes the NotFound page 404 report through the frontend app logger.
- Updates tests for the new logging behavior.

<h3>Confidence Score: 5/5</h3>

The logging-focused changes appear safe to merge.

The updates are scoped to observability behavior and corresponding tests, with no identified blocking issues.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the login failure scenario and observed HTTP 401 responses and the login failure logging state, including the before state with one log\_login\_failure call and the after state with log\_login\_failure count 0 and log\_password\_change\_failure count 1, plus request evidence showing the path /api/users/me/password and x-forwarded-for: 203.0.113.7.
- Ran the token handling tests for reset flow and verified token exposure behavior, noting before: raw token appears in INFO and not in DEBUG; after: raw token masked in INFO and the full reset URL appears in DEBUG, with both proof files capturing command, working directory, exit code, and verbose logger output.
- Launched a TestClient session and compared base versus head lifespans, observing that the base run lacked api.main.logger and info\_calls, while the head run produced two logger.info calls (app\_startup and app\_shutdown) with api\_version 0.0.0 and environment dev, and both runs hit a 404 Not Found on GET /health to drive the context.
- Inspected event/invitation payloads across base and head, noting that the base extras only included event/invitation\_id/project\_id, whereas the head extras added inviter\_id for created and, for accepted/declined, inviter\_id plus user\_id and project\_id.
- Observed console and logger error handling for missing routes, recording a 404 error for missing-base-route in the base state, and after the change, LOGGER\_ERROR\_CALLS shows 404 route not found with path /missing-head-route while CONSOLE\_ERROR\_CALLS is cleared.

<a href="https://app.greptile.com/trex/runs/12340308/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["test: cover mask\_token edge cases"](https://github.com/caitlon/become/commit/e6f8b19838df5a338c260815f912321202b4464e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39929981)</sub>

<!-- /greptile_comment -->