### PR TITLE
refactor: dedupe triangular centroid formula across schemas

### DIFF
--- a/api/routes/opinions.py
+++ b/api/routes/opinions.py
@@ -126,33 +126,20 @@ def get_result(
         return None
 
     return CalculationResultResponse(
-        best_compromise=FuzzyNumberOutput(
-            lower=result.best_compromise_lower,
-            peak=result.best_compromise_peak,
-            upper=result.best_compromise_upper,
-            centroid=(
-                result.best_compromise_lower
-                + result.best_compromise_peak
-                + result.best_compromise_upper
-            )
-            / 3,
+        best_compromise=FuzzyNumberOutput.from_bounds(
+            result.best_compromise_lower,
+            result.best_compromise_peak,
+            result.best_compromise_upper,
         ),
-        arithmetic_mean=FuzzyNumberOutput(
-            lower=result.arithmetic_mean_lower,
-            peak=result.arithmetic_mean_peak,
-            upper=result.arithmetic_mean_upper,
-            centroid=(
-                result.arithmetic_mean_lower
-                + result.arithmetic_mean_peak
-                + result.arithmetic_mean_upper
-            )
-            / 3,
+        arithmetic_mean=FuzzyNumberOutput.from_bounds(
+            result.arithmetic_mean_lower,
+            result.arithmetic_mean_peak,
+            result.arithmetic_mean_upper,
         ),
-        median=FuzzyNumberOutput(
-            lower=result.median_lower,
-            peak=result.median_peak,
-            upper=result.median_upper,
-            centroid=(result.median_lower + result.median_peak + result.median_upper) / 3,
+        median=FuzzyNumberOutput.from_bounds(
+            result.median_lower,
+            result.median_peak,
+            result.median_upper,
         ),
         max_error=result.max_error,
         num_experts=result.num_experts,

--- a/api/schemas/calculation.py
+++ b/api/schemas/calculation.py
@@ -6,7 +6,7 @@ from typing import Self
 from pydantic import BaseModel, Field, model_validator
 
 from api.schemas.validators import validate_fuzzy_constraints
-from src.models.fuzzy_number import FuzzyTriangleNumber
+from src.models.fuzzy_number import FuzzyTriangleNumber, triangular_centroid
 
 
 class ExpertInput(BaseModel):
@@ -49,6 +49,22 @@ class FuzzyNumberOutput(BaseModel):
             peak=fuzzy.peak,
             upper=fuzzy.upper_bound,
             centroid=fuzzy.centroid,
+        )
+
+    @classmethod
+    def from_bounds(cls, lower: float, peak: float, upper: float) -> "FuzzyNumberOutput":
+        """Create from raw triangular bounds, computing the centroid.
+
+        :param lower: Lower bound (pessimistic estimate).
+        :param peak: Peak value (most likely).
+        :param upper: Upper bound (optimistic estimate).
+        :return: FuzzyNumberOutput with the centroid computed from the bounds.
+        """
+        return cls(
+            lower=lower,
+            peak=peak,
+            upper=upper,
+            centroid=triangular_centroid(lower, peak, upper),
         )
 
 

--- a/api/schemas/data_export.py
+++ b/api/schemas/data_export.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 from api.schemas.calculation import FuzzyNumberOutput
 from api.utils.photo_links import build_photo_url
+from src.models.fuzzy_number import triangular_centroid
 
 if TYPE_CHECKING:
     from api.db.models import (
@@ -29,33 +30,6 @@ EXPORT_DESCRIPTION = (
     "Personal data export under GDPR Article 20 (right to data portability). "
     "Contains all data associated with your BeCoMe account."
 )
-
-
-def _centroid(lower: float, peak: float, upper: float) -> float:
-    """Compute the centroid of a triangular fuzzy number from its three vertices.
-
-    :param lower: Lower bound (pessimistic estimate).
-    :param peak: Peak value (most likely).
-    :param upper: Upper bound (optimistic estimate).
-    :return: The centroid, i.e. the mean of the triangle's three vertices.
-    """
-    return (lower + peak + upper) / 3
-
-
-def _fuzzy(lower: float, peak: float, upper: float) -> FuzzyNumberOutput:
-    """Build a fuzzy-number output with a centroid from raw bounds.
-
-    :param lower: Lower bound (pessimistic estimate).
-    :param peak: Peak value (most likely).
-    :param upper: Upper bound (optimistic estimate).
-    :return: FuzzyNumberOutput with the computed centroid.
-    """
-    return FuzzyNumberOutput(
-        lower=lower,
-        peak=peak,
-        upper=upper,
-        centroid=_centroid(lower, peak, upper),
-    )
 
 
 class ExportMetadata(BaseModel):
@@ -113,17 +87,17 @@ class ExportResult(BaseModel):
         :return: ExportResult with grouped fuzzy components.
         """
         return cls(
-            best_compromise=_fuzzy(
+            best_compromise=FuzzyNumberOutput.from_bounds(
                 result.best_compromise_lower,
                 result.best_compromise_peak,
                 result.best_compromise_upper,
             ),
-            arithmetic_mean=_fuzzy(
+            arithmetic_mean=FuzzyNumberOutput.from_bounds(
                 result.arithmetic_mean_lower,
                 result.arithmetic_mean_peak,
                 result.arithmetic_mean_upper,
             ),
-            median=_fuzzy(
+            median=FuzzyNumberOutput.from_bounds(
                 result.median_lower,
                 result.median_peak,
                 result.median_upper,
@@ -228,7 +202,7 @@ class ExportOpinion(BaseModel):
             lower_bound=opinion.lower_bound,
             peak=opinion.peak,
             upper_bound=opinion.upper_bound,
-            centroid=_centroid(opinion.lower_bound, opinion.peak, opinion.upper_bound),
+            centroid=triangular_centroid(opinion.lower_bound, opinion.peak, opinion.upper_bound),
             created_at=opinion.created_at,
             updated_at=opinion.updated_at,
         )

--- a/api/schemas/opinion.py
+++ b/api/schemas/opinion.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 from api.schemas.validators import validate_fuzzy_constraints
 from api.utils.sanitization import sanitize_text
+from src.models.fuzzy_number import triangular_centroid
 
 if TYPE_CHECKING:
     from api.db.models import ExpertOpinion, User
@@ -71,7 +72,7 @@ class OpinionResponse(BaseModel):
             lower_bound=opinion.lower_bound,
             peak=opinion.peak,
             upper_bound=opinion.upper_bound,
-            centroid=(opinion.lower_bound + opinion.peak + opinion.upper_bound) / 3,
+            centroid=triangular_centroid(opinion.lower_bound, opinion.peak, opinion.upper_bound),
             created_at=opinion.created_at,
             updated_at=opinion.updated_at,
         )

--- a/src/models/fuzzy_number.py
+++ b/src/models/fuzzy_number.py
@@ -4,6 +4,28 @@ import statistics
 from typing import Protocol, runtime_checkable
 
 
+def triangular_centroid(lower_bound: float, peak: float, upper_bound: float) -> float:
+    """
+    Centroid of a triangular fuzzy number from its three vertices.
+
+    The centroid (center of gravity) is the arithmetic mean of the lower
+    bound, peak, and upper bound. Shared by the domain value object and the
+    API response schemas so the formula lives in exactly one place.
+
+    Formula (from article, equation 9):
+        Gx = (A + C + B) / 3
+
+    :param lower_bound: Minimum value (pessimistic estimate)
+    :param peak: Most likely value
+    :param upper_bound: Maximum value (optimistic estimate)
+    :return: The centroid value as a float
+
+    >>> triangular_centroid(5.0, 10.0, 15.0)
+    10.0
+    """
+    return (lower_bound + peak + upper_bound) / 3.0
+
+
 @runtime_checkable
 class FuzzyNumber(Protocol):
     """Structural interface for fuzzy number types.
@@ -113,7 +135,7 @@ class FuzzyTriangleNumber:
         >>> fuzzy.centroid
         10.0
         """
-        return (self._lower_bound + self._peak + self._upper_bound) / 3.0
+        return triangular_centroid(self._lower_bound, self._peak, self._upper_bound)
 
     @staticmethod
     def average(fuzzy_numbers: list["FuzzyTriangleNumber"]) -> "FuzzyTriangleNumber":


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the duplicated triangular-centroid formula that had been reimplemented across several response schemas and a route, consolidating it behind a single shared helper. The main changes are:

- Adds a `triangular_centroid(lower, peak, upper)` helper in `src/models/fuzzy_number.py` as the single source of truth for the `(A + C + B) / 3` formula.
- Makes the `FuzzyTriangleNumber.centroid` property delegate to that helper instead of inlining the arithmetic.
- Adds a `FuzzyNumberOutput.from_bounds(...)` constructor alongside `from_domain(...)` that computes the centroid through the shared helper.
- Replaces the inline centroid math in `OpinionResponse`, the GDPR data-export schema (dropping the local `_centroid` / `_fuzzy` helpers), and the project-result route (`get_result`) with the shared helpers.

This is a behaviour-preserving refactor: the formula is numerically unchanged (`/ 3` and `/ 3.0` are equivalent for floats), so the API response shapes and values stay identical. No blocking issues identified.

The touched areas are the domain model and the API response schemas; the implementation is consistent and removes the duplication tracked in #233.

<details><summary><h3>Verification</h3></summary>

**What was checked**
- Ran the full test suite: 1062 passed, 59 skipped, 0 failed, 99% total coverage (`src/models/fuzzy_number.py` at 100%).
- Ran `mypy --strict` over `src/` and `api/` (81 source files, no issues) and `ruff check` on the changed files (all clean).
- Confirmed no remaining inline `(lower + peak + upper) / 3` occurrences and no dangling references to the removed `_centroid` / `_fuzzy` helpers.
</details>

<sub>Refactor for #233 - last commit `014e365` "refactor: dedupe triangular centroid formula across schemas"</sub>

<!-- /greptile_comment -->
