### PR TITLE
fix: harden HSTS and client-IP handling behind the Cloudflare proxy

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -130,6 +130,13 @@ class Settings(BaseSettings):
     # Public base URL of this API, used to build profile photo proxy links.
     api_public_url: str = "http://localhost:8000"
 
+    # Cloudflare origin lock: shared secret that Cloudflare injects (via a Transform
+    # Rule) as the X-Origin-Verify request header. When set, only requests carrying it
+    # are trusted to have transited Cloudflare, so CF-Connecting-IP is honoured only for
+    # them; direct hits on the bare origin are keyed under a single constant instead.
+    # Leave unset where Cloudflare is not in front (local/dev/staging).
+    cloudflare_origin_secret: str = ""
+
     # Railway Storage Bucket (S3-compatible; photo upload disabled if not set).
     # Railway injects these when a bucket is attached to the service.
     bucket_name: str | None = None

--- a/api/utils/client_ip.py
+++ b/api/utils/client_ip.py
@@ -1,32 +1,48 @@
 """Shared client-IP extraction for middleware and security logging."""
 
+import hmac
+
 from starlette.requests import Request
+
+from api.config import get_settings
+
+# Rate-limit / log key for any request that should have transited Cloudflare but did
+# not carry the origin-verify secret. Bucketing all such traffic under one constant
+# stops a direct *.up.railway.app caller from spoofing an arbitrary client IP: it can
+# neither mint fresh rate-limit buckets nor poison logs with a chosen address.
+_UNVERIFIED_ORIGIN = "unverified-origin"
 
 
 def get_client_ip(request: Request | None) -> str:
-    """Extract the client IP, honouring reverse-proxy headers.
+    """Resolve the client IP used for rate limiting and security logging.
 
-    Resolution order, most trustworthy first:
+    The trust model depends on whether a Cloudflare origin secret is configured
+    (``CLOUDFLARE_ORIGIN_SECRET``, set only where Cloudflare fronts the service):
 
-    1. ``CF-Connecting-IP`` -- set by the Cloudflare proxy to the real client IP.
-       Unlike the leftmost ``X-Forwarded-For`` entry (which the client controls and
-       can spoof) this header cannot be forged once traffic arrives via Cloudflare.
-    2. First entry of ``X-Forwarded-For`` -- the original client behind a plain
-       reverse proxy, used when Cloudflare is absent (local runs or the bare
-       ``*.up.railway.app`` domain).
-    3. The direct peer address.
+    - **Secret configured** (production): a request is trusted only when it carries the
+      matching ``X-Origin-Verify`` header that Cloudflare injects via a Transform Rule.
+      Trusted requests use ``CF-Connecting-IP`` (the real client, which Cloudflare sets
+      and a client cannot forge). A request without the secret reached the bare origin
+      directly, bypassing Cloudflare, so its client-supplied headers are untrusted and
+      it is keyed under a single constant instead of a spoofable address.
+    - **No secret** (local/dev/staging, no Cloudflare in front): use the first
+      ``X-Forwarded-For`` entry, then the direct peer.
 
     :param request: Incoming request, or ``None`` when unavailable.
-    :return: Client IP address, or ``"unknown"`` when it cannot be determined.
+    :return: Client IP, the unverified-origin sentinel, or ``"unknown"``.
     """
     if request is None:
         return "unknown"
-    cloudflare_ip = request.headers.get("CF-Connecting-IP")
-    if cloudflare_ip:
-        return cloudflare_ip.strip()
+    secret = get_settings().cloudflare_origin_secret
+    if secret:
+        verify = request.headers.get("X-Origin-Verify")
+        if verify and hmac.compare_digest(verify, secret):
+            cloudflare_ip = request.headers.get("CF-Connecting-IP")
+            if cloudflare_ip:
+                return cloudflare_ip.strip()
+            return request.client.host if request.client else "unknown"
+        return _UNVERIFIED_ORIGIN
     forwarded = request.headers.get("X-Forwarded-For")
     if forwarded:
         return forwarded.split(",")[0].strip()
-    if request.client:
-        return request.client.host
-    return "unknown"
+    return request.client.host if request.client else "unknown"

--- a/api/utils/client_ip.py
+++ b/api/utils/client_ip.py
@@ -4,16 +4,26 @@ from starlette.requests import Request
 
 
 def get_client_ip(request: Request | None) -> str:
-    """Extract the client IP, honouring a reverse-proxy forwarded header.
+    """Extract the client IP, honouring reverse-proxy headers.
 
-    Prefers the first entry of ``X-Forwarded-For`` (the original client behind a
-    reverse proxy), then the direct peer address.
+    Resolution order, most trustworthy first:
+
+    1. ``CF-Connecting-IP`` -- set by the Cloudflare proxy to the real client IP.
+       Unlike the leftmost ``X-Forwarded-For`` entry (which the client controls and
+       can spoof) this header cannot be forged once traffic arrives via Cloudflare.
+    2. First entry of ``X-Forwarded-For`` -- the original client behind a plain
+       reverse proxy, used when Cloudflare is absent (local runs or the bare
+       ``*.up.railway.app`` domain).
+    3. The direct peer address.
 
     :param request: Incoming request, or ``None`` when unavailable.
     :return: Client IP address, or ``"unknown"`` when it cannot be determined.
     """
     if request is None:
         return "unknown"
+    cloudflare_ip = request.headers.get("CF-Connecting-IP")
+    if cloudflare_ip:
+        return cloudflare_ip.strip()
     forwarded = request.headers.get("X-Forwarded-For")
     if forwarded:
         return forwarded.split(",")[0].strip()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -90,5 +90,9 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/health')" || exit 1
 
-# Run with uvicorn (worker count configurable via UVICORN_WORKERS env var)
-CMD uvicorn api.main:app --host 0.0.0.0 --port 8000 --workers ${UVICORN_WORKERS}
+# Run with uvicorn (worker count configurable via UVICORN_WORKERS env var).
+# --proxy-headers + --forwarded-allow-ips='*': trust X-Forwarded-Proto/For from the
+# Railway edge (the only path that can reach the container; Cloudflare sits in front
+# of it). Without this uvicorn treats the internal hop as http, so request.url.scheme
+# is wrong and the HSTS response header is never emitted.
+CMD uvicorn api.main:app --host 0.0.0.0 --port 8000 --workers ${UVICORN_WORKERS} --proxy-headers --forwarded-allow-ips='*'

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -27,4 +27,8 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
+    # nginx serves the internal http hop, so add HSTS unconditionally (the client
+    # reaches us over https via Cloudflare/Railway). No "preload" until the domain
+    # is actually submitted to the HSTS preload list.
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 }

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -17,10 +17,15 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # Cache static assets
+    # Cache static assets. A location with its own add_header stops inheriting the
+    # server-level ones, so the security headers are repeated here to cover JS/CSS/images.
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     }
 
     # Security headers

--- a/tests/unit/api/utils/test_client_ip.py
+++ b/tests/unit/api/utils/test_client_ip.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from api.utils.client_ip import get_client_ip
 
-_SECRET = "s3cret-origin-token"
+_SECRET = "s3cret-origin-token"  # pragma: allowlist secret
 
 
 def _request(

--- a/tests/unit/api/utils/test_client_ip.py
+++ b/tests/unit/api/utils/test_client_ip.py
@@ -5,27 +5,56 @@ from unittest.mock import MagicMock
 from api.utils.client_ip import get_client_ip
 
 
+def _request(
+    headers: dict[str, str] | None = None,
+    client_host: str | None = None,
+) -> MagicMock:
+    """Build a request mock whose header lookup is keyed by name.
+
+    :param headers: Header name -> value map the mock should expose.
+    :param client_host: Direct peer host, or ``None`` for no client.
+    :return: Configured request mock.
+    """
+    request = MagicMock()
+    request.headers.get.side_effect = lambda name, default=None: (headers or {}).get(name, default)
+    if client_host is None:
+        request.client = None
+    else:
+        request.client.host = client_host
+    return request
+
+
 class TestGetClientIp:
     """get_client_ip resolves the caller IP across proxy and direct setups."""
 
-    def test_returns_forwarded_ip_when_present(self):
-        """GIVEN an X-Forwarded-For header WHEN extracting THEN the header wins."""
+    def test_prefers_cf_connecting_ip_over_forwarded(self):
+        """GIVEN both CF and forwarded headers WHEN extracting THEN Cloudflare wins."""
+        # GIVEN -- X-Forwarded-For is client-spoofable, CF-Connecting-IP is not
+        request = _request({"CF-Connecting-IP": "203.0.113.50", "X-Forwarded-For": "1.2.3.4"})
+
+        # WHEN / THEN
+        assert get_client_ip(request) == "203.0.113.50"
+
+    def test_strips_whitespace_from_cf_connecting_ip(self):
+        """GIVEN whitespace around the CF IP WHEN extracting THEN it is trimmed."""
         # GIVEN
-        request = MagicMock()
-        request.headers.get.return_value = "203.0.113.50"
+        request = _request({"CF-Connecting-IP": "  203.0.113.50  "})
 
-        # WHEN
-        result = get_client_ip(request)
+        # WHEN / THEN
+        assert get_client_ip(request) == "203.0.113.50"
 
-        # THEN
-        assert result == "203.0.113.50"
-        request.headers.get.assert_called_once_with("X-Forwarded-For")
+    def test_returns_forwarded_ip_when_no_cf_header(self):
+        """GIVEN only an X-Forwarded-For header WHEN extracting THEN the header wins."""
+        # GIVEN
+        request = _request({"X-Forwarded-For": "203.0.113.50"})
+
+        # WHEN / THEN
+        assert get_client_ip(request) == "203.0.113.50"
 
     def test_returns_first_ip_from_comma_list(self):
         """GIVEN a multi-hop forwarded header WHEN extracting THEN the first IP wins."""
         # GIVEN
-        request = MagicMock()
-        request.headers.get.return_value = "203.0.113.50, 70.41.3.18, 150.172.238.178"
+        request = _request({"X-Forwarded-For": "203.0.113.50, 70.41.3.18, 150.172.238.178"})
 
         # WHEN / THEN
         assert get_client_ip(request) == "203.0.113.50"
@@ -33,28 +62,23 @@ class TestGetClientIp:
     def test_strips_whitespace_from_forwarded_ip(self):
         """GIVEN whitespace around the forwarded IP WHEN extracting THEN it is trimmed."""
         # GIVEN
-        request = MagicMock()
-        request.headers.get.return_value = "  192.168.1.1  , 10.0.0.1"
+        request = _request({"X-Forwarded-For": "  192.168.1.1  , 10.0.0.1"})
 
         # WHEN / THEN
         assert get_client_ip(request) == "192.168.1.1"
 
     def test_falls_back_to_client_host(self):
-        """GIVEN no forwarded header WHEN extracting THEN the direct peer host is used."""
+        """GIVEN no proxy headers WHEN extracting THEN the direct peer host is used."""
         # GIVEN
-        request = MagicMock()
-        request.headers.get.return_value = None
-        request.client.host = "127.0.0.1"
+        request = _request(client_host="127.0.0.1")
 
         # WHEN / THEN
         assert get_client_ip(request) == "127.0.0.1"
 
     def test_returns_unknown_when_no_client(self):
-        """GIVEN no header and no client WHEN extracting THEN it is 'unknown'."""
+        """GIVEN no headers and no client WHEN extracting THEN it is 'unknown'."""
         # GIVEN
-        request = MagicMock()
-        request.headers.get.return_value = None
-        request.client = None
+        request = _request()
 
         # WHEN / THEN
         assert get_client_ip(request) == "unknown"

--- a/tests/unit/api/utils/test_client_ip.py
+++ b/tests/unit/api/utils/test_client_ip.py
@@ -1,8 +1,10 @@
 """Tests for the shared client-IP extraction helper."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from api.utils.client_ip import get_client_ip
+
+_SECRET = "s3cret-origin-token"
 
 
 def _request(
@@ -24,66 +26,85 @@ def _request(
     return request
 
 
-class TestGetClientIp:
-    """get_client_ip resolves the caller IP across proxy and direct setups."""
+def _with_secret(secret: str) -> object:
+    """Patch get_settings so cloudflare_origin_secret returns ``secret``."""
+    settings = MagicMock()
+    settings.cloudflare_origin_secret = secret
+    return patch("api.utils.client_ip.get_settings", return_value=settings)
 
-    def test_prefers_cf_connecting_ip_over_forwarded(self):
-        """GIVEN both CF and forwarded headers WHEN extracting THEN Cloudflare wins."""
-        # GIVEN -- X-Forwarded-For is client-spoofable, CF-Connecting-IP is not
-        request = _request({"CF-Connecting-IP": "203.0.113.50", "X-Forwarded-For": "1.2.3.4"})
 
-        # WHEN / THEN
-        assert get_client_ip(request) == "203.0.113.50"
+class TestNoOriginSecret:
+    """Without a Cloudflare secret (dev/staging/local), use XFF then the peer."""
 
-    def test_strips_whitespace_from_cf_connecting_ip(self):
-        """GIVEN whitespace around the CF IP WHEN extracting THEN it is trimmed."""
-        # GIVEN
-        request = _request({"CF-Connecting-IP": "  203.0.113.50  "})
+    def test_returns_first_forwarded_ip(self):
+        """GIVEN no secret and an XFF header WHEN extracting THEN the first IP wins."""
+        with _with_secret(""):
+            request = _request({"X-Forwarded-For": "203.0.113.50, 70.41.3.18"})
+            assert get_client_ip(request) == "203.0.113.50"
 
-        # WHEN / THEN
-        assert get_client_ip(request) == "203.0.113.50"
+    def test_strips_whitespace(self):
+        """GIVEN no secret and padded XFF WHEN extracting THEN it is trimmed."""
+        with _with_secret(""):
+            request = _request({"X-Forwarded-For": "  192.168.1.1  , 10.0.0.1"})
+            assert get_client_ip(request) == "192.168.1.1"
 
-    def test_returns_forwarded_ip_when_no_cf_header(self):
-        """GIVEN only an X-Forwarded-For header WHEN extracting THEN the header wins."""
-        # GIVEN
-        request = _request({"X-Forwarded-For": "203.0.113.50"})
+    def test_ignores_cf_connecting_ip_without_secret(self):
+        """GIVEN no secret WHEN only CF-Connecting-IP is set THEN it is not trusted."""
+        with _with_secret(""):
+            request = _request({"CF-Connecting-IP": "9.9.9.9"}, client_host="127.0.0.1")
+            assert get_client_ip(request) == "127.0.0.1"
 
-        # WHEN / THEN
-        assert get_client_ip(request) == "203.0.113.50"
+    def test_falls_back_to_peer(self):
+        """GIVEN no secret and no headers WHEN extracting THEN the peer host is used."""
+        with _with_secret(""):
+            assert get_client_ip(_request(client_host="127.0.0.1")) == "127.0.0.1"
 
-    def test_returns_first_ip_from_comma_list(self):
-        """GIVEN a multi-hop forwarded header WHEN extracting THEN the first IP wins."""
-        # GIVEN
-        request = _request({"X-Forwarded-For": "203.0.113.50, 70.41.3.18, 150.172.238.178"})
+    def test_unknown_without_client(self):
+        """GIVEN no secret, no headers, no client WHEN extracting THEN it is 'unknown'."""
+        with _with_secret(""):
+            assert get_client_ip(_request()) == "unknown"
 
-        # WHEN / THEN
-        assert get_client_ip(request) == "203.0.113.50"
 
-    def test_strips_whitespace_from_forwarded_ip(self):
-        """GIVEN whitespace around the forwarded IP WHEN extracting THEN it is trimmed."""
-        # GIVEN
-        request = _request({"X-Forwarded-For": "  192.168.1.1  , 10.0.0.1"})
+class TestOriginSecretConfigured:
+    """With a Cloudflare secret, trust CF-Connecting-IP only for verified requests."""
 
-        # WHEN / THEN
-        assert get_client_ip(request) == "192.168.1.1"
+    def test_verified_request_uses_cf_connecting_ip(self):
+        """GIVEN the matching secret WHEN extracting THEN CF-Connecting-IP wins."""
+        with _with_secret(_SECRET):
+            request = _request(
+                {
+                    "X-Origin-Verify": _SECRET,
+                    "CF-Connecting-IP": "203.0.113.50",
+                    "X-Forwarded-For": "1.2.3.4",
+                }
+            )
+            assert get_client_ip(request) == "203.0.113.50"
 
-    def test_falls_back_to_client_host(self):
-        """GIVEN no proxy headers WHEN extracting THEN the direct peer host is used."""
-        # GIVEN
-        request = _request(client_host="127.0.0.1")
+    def test_verified_request_strips_whitespace(self):
+        """GIVEN the matching secret WHEN the CF IP is padded THEN it is trimmed."""
+        with _with_secret(_SECRET):
+            request = _request({"X-Origin-Verify": _SECRET, "CF-Connecting-IP": "  203.0.113.50  "})
+            assert get_client_ip(request) == "203.0.113.50"
 
-        # WHEN / THEN
-        assert get_client_ip(request) == "127.0.0.1"
+    def test_verified_without_cf_ip_falls_back_to_peer(self):
+        """GIVEN the secret but no CF IP WHEN extracting THEN the peer host is used."""
+        with _with_secret(_SECRET):
+            request = _request({"X-Origin-Verify": _SECRET}, client_host="10.0.0.9")
+            assert get_client_ip(request) == "10.0.0.9"
 
-    def test_returns_unknown_when_no_client(self):
-        """GIVEN no headers and no client WHEN extracting THEN it is 'unknown'."""
-        # GIVEN
-        request = _request()
+    def test_missing_verify_header_is_unverified(self):
+        """GIVEN no verify header WHEN extracting THEN the sentinel is returned."""
+        with _with_secret(_SECRET):
+            request = _request({"CF-Connecting-IP": "1.2.3.4", "X-Forwarded-For": "5.6.7.8"})
+            assert get_client_ip(request) == "unverified-origin"
 
-        # WHEN / THEN
-        assert get_client_ip(request) == "unknown"
+    def test_wrong_verify_header_is_unverified(self):
+        """GIVEN a wrong verify header WHEN extracting THEN the sentinel is returned."""
+        with _with_secret(_SECRET):
+            request = _request({"X-Origin-Verify": "nope", "CF-Connecting-IP": "1.2.3.4"})
+            assert get_client_ip(request) == "unverified-origin"
 
-    def test_returns_unknown_for_none_request(self):
-        """GIVEN no request WHEN extracting THEN it is 'unknown'."""
-        # WHEN / THEN
-        assert get_client_ip(None) == "unknown"
+
+def test_returns_unknown_for_none_request():
+    """GIVEN no request WHEN extracting THEN it is 'unknown'."""
+    assert get_client_ip(None) == "unknown"


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens proxy-aware client IP handling and HSTS behavior. The main changes are:

- Prefer `CF-Connecting-IP` before `X-Forwarded-For` in `get_client_ip`.
- Enable uvicorn proxy header handling in the API Docker image.
- Add HSTS to the frontend nginx server config.
- Add unit tests for Cloudflare and forwarded-IP precedence.

<h3>Confidence Score: 4/5</h3>

The changes are focused, but the proxy trust boundary and static header inheritance issues should be addressed before merge.

The reviewed files are small and covered by targeted tests/config checks, with clear remaining risks around accepting untrusted forwarding headers and preserving HSTS on static responses.

api/utils/client_ip.py and frontend/nginx.conf

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A focused runtime script reproduced the header spoofing path by invoking the real API function get\_client\_ip with a spoofed CF-Connecting-IP and attacker IP, and the function returned the attacker-supplied 1.2.3.4.
- An nginx HSTS reproduction harness was used to test static asset handling, and it showed that a static asset response lacked Strict-Transport-Security while the root page response included it.
- Observations showed that after a change, responses began including the Strict-Transport-Security header (the post-change artifact confirms the presence of the header for HTTPS requests).
- A subsequent verification confirmed the same HSTS header presence after the change in the related test scenario, with successful curl runs and verbose headers.

<a href="https://app.greptile.com/trex/runs/12836750/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
api/utils/client_ip.py:24-26
**Header spoofing path**
`CF-Connecting-IP` is accepted from every request before `X-Forwarded-For` or the peer address, while the documented bare `*.up.railway.app` path still works without Cloudflare. A direct request to that hostname can send `CF-Connecting-IP: 1.2.3.4`, so rate limits and security logs use an attacker-chosen IP instead of the real client.

### Issue 2 of 2
frontend/nginx.conf:33
**Static HSTS gap**
`Strict-Transport-Security` is added only at `server` scope, but the static-asset `location` already defines `add_header Cache-Control`. nginx inherits parent `add_header` values only when the current level has no `add_header`, so JS, CSS, and image responses from this location still omit HSTS.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: derive client IP from CF-Connecting..."](https://github.com/caitlon/become/commit/b8ea349653d65ed31353698e5b0f8fab1416d476) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40943861)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->