### PR TITLE
fix: bound and rate-limit the calculate endpoint

### DIFF
--- a/api/routes/calculate.py
+++ b/api/routes/calculate.py
@@ -6,9 +6,10 @@ Uses dependency injection for calculator following DIP.
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 
 from api.dependencies import get_calculator
+from api.middleware.rate_limit import LIMIT_STANDARD, limiter
 from api.schemas.calculation import CalculateRequest, CalculateResponse, FuzzyNumberOutput
 from src.calculators.become_calculator import BeCoMeCalculator
 from src.exceptions import BeCoMeError
@@ -22,13 +23,16 @@ router = APIRouter(prefix="/api/v1", tags=["calculation"])
     "/calculate",
     responses={400: {"description": "Invalid input or calculation error"}},
 )
+@limiter.limit(LIMIT_STANDARD)
 def calculate(
-    request: CalculateRequest,
+    request: Request,
+    payload: CalculateRequest,
     calculator: Annotated[BeCoMeCalculator, Depends(get_calculator)],
 ) -> CalculateResponse:
     """Calculate BeCoMe result from expert opinions.
 
-    :param request: Expert opinions to aggregate
+    :param request: FastAPI request (for rate limiting)
+    :param payload: Expert opinions to aggregate
     :param calculator: Injected BeCoMeCalculator instance
     :return: Calculation result with fuzzy numbers
     """
@@ -41,7 +45,7 @@ def calculate(
                 upper_bound=expert.upper,
             ),
         )
-        for expert in request.experts
+        for expert in payload.experts
     ]
 
     try:

--- a/api/schemas/calculation.py
+++ b/api/schemas/calculation.py
@@ -27,7 +27,9 @@ class ExpertInput(BaseModel):
 class CalculateRequest(BaseModel):
     """Request body for calculation endpoint."""
 
-    experts: list[ExpertInput] = Field(..., min_length=1, description="List of expert opinions")
+    experts: list[ExpertInput] = Field(
+        ..., min_length=1, max_length=1000, description="List of expert opinions"
+    )
 
 
 class FuzzyNumberOutput(BaseModel):

--- a/tests/integration/api/routes/test_calculate.py
+++ b/tests/integration/api/routes/test_calculate.py
@@ -289,6 +289,23 @@ class TestValidation:
         assert response.status_code == 400
         assert response.json()["detail"] == error_message
 
+    def test_too_many_experts_returns_422(self, client: TestClient):
+        """
+        GIVEN more experts than the allowed maximum
+        WHEN POST /api/v1/calculate is called
+        THEN response status is 422 (validation error)
+        """
+        # GIVEN
+        experts = [
+            {"name": f"E{i}", "lower": 0.0, "peak": 10.0, "upper": 20.0} for i in range(1001)
+        ]
+
+        # WHEN
+        response = client.post("/api/v1/calculate", json={"experts": experts})
+
+        # THEN
+        assert response.status_code == 422
+
 
 class TestCalculateEdgeCases:
     """Edge case tests for /calculate endpoint."""


### PR DESCRIPTION
## Summary

The public `POST /api/v1/calculate` endpoint accepted an unbounded `experts` array with no throttling, so a single caller could send a very large payload (or many requests) and burn CPU/memory — an unauthenticated DoS surface. This PR bounds the input size and applies the standard per-IP rate limit, closing the surface without changing the endpoint's public, stateless contract.

- **Runtime / backend**
  - Bound `CalculateRequest.experts` with `max_length=1000`, so oversized payloads are rejected with `422` before any parsing or calculation runs (`api/schemas/calculation.py`).
  - Apply `@limiter.limit(LIMIT_STANDARD)` (60/min per client IP) to the `/calculate` route and add the `request: Request` parameter slowapi requires; the request body is renamed to `payload` to free the `request` name (`api/routes/calculate.py`).
- **Tests**
  - Add `test_too_many_experts_returns_422`, which sends 1001 experts and asserts `422` (`tests/integration/api/routes/test_calculate.py`).
- **Known limitation** — the endpoint stays public (no auth). It is a stateless demo calculator with no project context, so the hardening here is bounding + throttling, not access control.

## Important Files Changed

| Filename | Overview |
| --- | --- |
| `api/schemas/calculation.py` | Cap `experts` at 1000 items; over-limit payloads now fail validation with `422`. |
| `api/routes/calculate.py` | Add per-IP rate limit + `request: Request`; body parameter renamed `request` → `payload`. |
| `tests/integration/api/routes/test_calculate.py` | New test asserting >1000 experts returns `422`. |

## Sequence Diagram

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme':'neutral'}}%%
sequenceDiagram
    participant C as Client
    participant RL as Rate limiter (slowapi)
    participant V as Pydantic (CalculateRequest)
    participant CALC as BeCoMeCalculator
    C->>RL: POST /api/v1/calculate
    alt over 60 req/min per IP
        RL-->>C: 429 Too Many Requests
    else within limit
        RL->>V: validate body
        alt experts > 1000 or invalid fuzzy
            V-->>C: 422 Unprocessable Entity
        else valid
            V->>CALC: calculate_compromise(opinions)
            CALC-->>C: 200 result
        end
    end
```

</a>

<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme':'dark', 'themeVariables': {'primaryColor':'#1f2937','primaryTextColor':'#e5e7eb','lineColor':'#9ca3af'}}}%%
sequenceDiagram
    participant C as Client
    participant RL as Rate limiter (slowapi)
    participant V as Pydantic (CalculateRequest)
    participant CALC as BeCoMeCalculator
    C->>RL: POST /api/v1/calculate
    alt over 60 req/min per IP
        RL-->>C: 429 Too Many Requests
    else within limit
        RL->>V: validate body
        alt experts > 1000 or invalid fuzzy
            V-->>C: 422 Unprocessable Entity
        else valid
            V->>CALC: calculate_compromise(opinions)
            CALC-->>C: 200 result
        end
    end
```

</a>
