### PR TITLE
fix: remove profile photo on account deletion

### DIFF
--- a/api/routes/users.py
+++ b/api/routes/users.py
@@ -132,17 +132,20 @@ def delete_current_user(
     current_user: CurrentUser,
     service: Annotated[UserService, Depends(get_user_service)],
     project_service: Annotated[ProjectService, Depends(get_project_service)],
+    storage_service: Annotated[StorageService | None, Depends(get_storage_service)],
 ) -> None:
     """Delete the authenticated user's account.
 
     Rejected with 409 while the user is the admin of any project, so erasure never
     silently cascades away other experts' contributions; the user must transfer
-    ownership or delete those projects first.
+    ownership or delete those projects first. The profile photo blob is removed from
+    object storage as well, so erasure also covers stored media (GDPR Article 17).
 
     :param request: FastAPI request (for logging)
     :param current_user: User from JWT token
     :param service: User service
     :param project_service: Project service for the ownership check
+    :param storage_service: Storage service (None when not configured)
     :raises AccountHasOwnedProjectsError: If the user still admins a project
     """
     if project_service.get_owned_projects(current_user.id):
@@ -150,6 +153,11 @@ def delete_current_user(
 
     user_id = current_user.id
     email = current_user.email
+
+    # Remove the profile photo blob so erasure also covers object storage (GDPR Art. 17).
+    if current_user.photo_url and storage_service:
+        with suppress(StorageDeleteError):
+            storage_service.delete(current_user.photo_url)
 
     service.delete_user(current_user)
 

--- a/tests/integration/api/routes/test_photo.py
+++ b/tests/integration/api/routes/test_photo.py
@@ -348,3 +348,59 @@ class TestPhotoProxy:
 
         # THEN
         assert response.status_code == 404
+
+
+class TestAccountDeletionRemovesPhoto:
+    """Deleting an account must also remove its photo blob (GDPR Art. 17)."""
+
+    def test_delete_account_removes_photo_from_storage(self, client_with_mock_storage):
+        """Deleting the account deletes the user's photo object from storage."""
+        # GIVEN a user with an uploaded photo
+        client, mock_storage = client_with_mock_storage
+        token = register_and_login(client, "erase@example.com")
+        client.post(
+            "/api/v1/users/me/photo",
+            headers=auth_header(token),
+            files={"file": ("photo.jpg", VALID_JPEG_BYTES, "image/jpeg")},
+        )
+
+        # WHEN the account is deleted
+        response = client.delete("/api/v1/users/me", headers=auth_header(token))
+
+        # THEN the photo object is removed from storage
+        assert response.status_code == 204
+        mock_storage.delete.assert_called_once_with(UPLOADED_KEY)
+
+    def test_delete_account_without_photo_skips_storage(self, client_with_mock_storage):
+        """Deleting an account that has no photo never calls storage."""
+        # GIVEN a user with no uploaded photo
+        client, mock_storage = client_with_mock_storage
+        token = register_and_login(client, "nophoto-erase@example.com")
+
+        # WHEN the account is deleted
+        response = client.delete("/api/v1/users/me", headers=auth_header(token))
+
+        # THEN storage is never asked to delete anything
+        assert response.status_code == 204
+        mock_storage.delete.assert_not_called()
+
+    def test_delete_account_succeeds_when_storage_delete_fails(self, client_with_mock_storage):
+        """Account deletion completes even when the photo blob removal fails."""
+        # GIVEN a user with a photo whose storage removal will error
+        client, mock_storage = client_with_mock_storage
+        token = register_and_login(client, "brokenstorage@example.com")
+        client.post(
+            "/api/v1/users/me/photo",
+            headers=auth_header(token),
+            files={"file": ("photo.jpg", VALID_JPEG_BYTES, "image/jpeg")},
+        )
+        mock_storage.delete.side_effect = StorageDeleteError("bucket error")
+
+        # WHEN the account is deleted
+        response = client.delete("/api/v1/users/me", headers=auth_header(token))
+
+        # THEN the account is still removed (the storage failure is suppressed)
+        assert response.status_code == 204
+        mock_storage.delete.assert_called_once_with(UPLOADED_KEY)
+        profile = client.get("/api/v1/users/me", headers=auth_header(token))
+        assert profile.status_code == 401


### PR DESCRIPTION
## Summary

Deleting an account removed the user row (cascading memberships, opinions, and reset tokens) but left the profile-photo blob in object storage, so erasure did not cover stored media — an open gap against GDPR Article 17 (right to erasure). This PR removes the blob during account deletion, mirroring the existing `delete_photo` flow so the two paths behave consistently.

- **Runtime / backend**
  - Inject `storage_service` into `delete_current_user` and delete the photo blob before removing the DB row. The call is guarded by `current_user.photo_url` and storage presence, and `StorageDeleteError` is suppressed so a storage hiccup never blocks account deletion (`api/routes/users.py`).
- **Tests**
  - Add `TestAccountDeletionRemovesPhoto` covering three paths: the blob is deleted on account removal, storage is never called when the user has no photo, and deletion still returns `204` when the storage removal errors (`tests/integration/api/routes/test_photo.py`).

## Important Files Changed

| Filename | Overview |
| --- | --- |
| `api/routes/users.py` | `delete_current_user` now removes the profile-photo blob from storage (GDPR Art. 17) before deleting the account; storage errors are suppressed. |
| `tests/integration/api/routes/test_photo.py` | New `TestAccountDeletionRemovesPhoto` class covering the blob-removal, no-photo, and storage-error paths. |

## Sequence Diagram

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme':'neutral'}}%%
sequenceDiagram
    participant C as Client
    participant R as delete_current_user
    participant P as ProjectService
    participant S as StorageService
    participant U as UserService
    C->>R: DELETE /api/v1/users/me
    R->>P: get_owned_projects(user)
    alt still admins a project
        P-->>C: 409 Conflict
    else no owned projects
        opt photo_url set and storage configured
            R->>S: delete(photo_url)
            note over R,S: StorageDeleteError suppressed
        end
        R->>U: delete_user(user)
        U-->>C: 204 No Content
    end
```

</a>

<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme':'dark', 'themeVariables': {'primaryColor':'#1f2937','primaryTextColor':'#e5e7eb','lineColor':'#9ca3af'}}}%%
sequenceDiagram
    participant C as Client
    participant R as delete_current_user
    participant P as ProjectService
    participant S as StorageService
    participant U as UserService
    C->>R: DELETE /api/v1/users/me
    R->>P: get_owned_projects(user)
    alt still admins a project
        P-->>C: 409 Conflict
    else no owned projects
        opt photo_url set and storage configured
            R->>S: delete(photo_url)
            note over R,S: StorageDeleteError suppressed
        end
        R->>U: delete_user(user)
        U-->>C: 204 No Content
    end
```

</a>
