### PR TITLE
feat: back the rate limiter with Redis storage

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -207,7 +207,7 @@
         "filename": "api/middleware/rate_limit.py",
         "hashed_secret": "80a62c4b184a694a61ae89287eddec3953259eac",
         "is_verified": false,
-        "line_number": 21
+        "line_number": 41
       }
     ],
     "frontend/e2e/full-flow.spec.ts": [
@@ -958,5 +958,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-02T13:30:14Z"
+  "generated_at": "2026-07-02T14:45:53Z"
 }

--- a/api/middleware/rate_limit.py
+++ b/api/middleware/rate_limit.py
@@ -7,14 +7,34 @@ from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from starlette.responses import Response
 
-from api.config import get_settings
+from api.config import Settings, get_settings
 from api.utils.client_ip import get_client_ip
 
 logger = logging.getLogger("api.ratelimit")
 
-# Disable rate limiting only while the automated test suite runs (TESTING flag).
+
+def build_limiter(settings: Settings) -> Limiter:
+    """Create the slowapi Limiter, backed by Redis when configured.
+
+    Uses ``settings.redis_url`` as the storage backend so counters are shared
+    across replicas (M6); without it slowapi falls back to in-memory. Fails open
+    (``swallow_errors``): a storage outage skips the limit rather than blocking
+    requests such as login. Limiting is disabled only under the TESTING flag.
+
+    :param settings: Application settings.
+    :return: A configured slowapi Limiter.
+    """
+    return Limiter(
+        key_func=get_client_ip,
+        enabled=not settings.testing,
+        storage_uri=settings.redis_url or None,
+        swallow_errors=True,
+    )
+
+
+# Rate limiting is disabled only while the automated test suite runs (TESTING flag).
 # Deployed profiles, including staging, keep limiting enabled.
-limiter = Limiter(key_func=get_client_ip, enabled=not get_settings().testing)
+limiter = build_limiter(get_settings())
 
 # Rate limit constants for different endpoint types
 LIMIT_AUTH_ENDPOINTS = "5/minute"  # Login, register - strict to prevent brute-force

--- a/tests/unit/api/middleware/test_rate_limit.py
+++ b/tests/unit/api/middleware/test_rate_limit.py
@@ -1,8 +1,9 @@
 """Tests for rate limiting middleware."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from api.middleware.rate_limit import rate_limit_handler
+from api.middleware.rate_limit import build_limiter, rate_limit_handler
 
 
 class TestRateLimitHandler:
@@ -79,3 +80,29 @@ class TestRateLimitWiring:
 
         # THEN
         assert app.exception_handlers[RateLimitExceeded] is rate_limit_handler
+
+
+class TestBuildLimiter:
+    """Tests that build_limiter wires the storage backend and fail-open flag."""
+
+    def test_uses_redis_storage_when_configured(self):
+        """
+        GIVEN settings with a redis_url
+        WHEN build_limiter runs
+        THEN the limiter uses that storage URI and swallows storage errors (fail-open)
+        """
+        settings = SimpleNamespace(testing=False, redis_url="redis://localhost:6379/0")
+        limiter = build_limiter(settings)
+        assert limiter._storage_uri == "redis://localhost:6379/0"
+        assert limiter._swallow_errors is True
+
+    def test_no_storage_uri_without_redis(self):
+        """
+        GIVEN settings without a redis_url
+        WHEN build_limiter runs
+        THEN no storage URI is set (slowapi defaults to in-memory) and it still fails open
+        """
+        settings = SimpleNamespace(testing=True, redis_url="")
+        limiter = build_limiter(settings)
+        assert limiter._storage_uri is None
+        assert limiter._swallow_errors is True


### PR DESCRIPTION
## Summary

PR 3 of the auth shared-state epic — points the slowapi rate limiter at Redis (M6), so per-IP counters are shared across replicas and workers instead of living per-process. Without Redis the limiter stays in-memory exactly as before, so dev/test are unchanged.

> Builds on PR 2 (`redis_url` config + the deployed Redis services on dev/staging/prod).

- **Runtime / backend**
  - Extract `build_limiter(settings)` and use it for the module `limiter` (`api/middleware/rate_limit.py`).
  - `storage_uri = settings.redis_url or None` — Redis-backed when configured, else slowapi's in-memory default.
  - `swallow_errors=True` — **fail-open**: a Redis outage skips the limit rather than blocking requests such as login. This is deliberately the opposite of the blacklist, which is fail-closed (a store error there returns 401). Rationale: the same outage must not lock everyone out of logging in.
- **Tests**
  - `build_limiter` uses the Redis storage URI when configured, and stays in-memory + fail-open without it (`tests/unit/api/middleware/test_rate_limit.py`). Full backend suite: 1096 passed.

## Important Files Changed

| Filename | Overview |
| --- | --- |
| `api/middleware/rate_limit.py` | `build_limiter(settings)` wires `storage_uri` from `redis_url` + `swallow_errors` (fail-open); the module `limiter` uses it. |
| `tests/unit/api/middleware/test_rate_limit.py` | Cover Redis-storage selection and the in-memory / fail-open default. |
