### PR TITLE
feat: rotate refresh tokens on refresh

### DIFF
--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -14,7 +14,6 @@ from api.auth.dependencies import CurrentUser, get_current_token_payload
 from api.auth.jwt import (
     TokenError,
     TokenPayload,
-    create_access_token,
     create_token_pair,
     decode_refresh_token,
     revoke_token,
@@ -26,7 +25,6 @@ from api.auth.logging import (
     log_registration,
 )
 from api.auth.revocation_store import RevocationStore, get_revocation_store
-from api.config import get_settings
 from api.dependencies import get_email_service, get_password_reset_service, get_user_service
 from api.middleware.rate_limit import LIMIT_AUTH_ENDPOINTS, LIMIT_PWD_RESET, limiter
 from api.schemas.auth import (
@@ -123,15 +121,17 @@ def refresh_token(
     data: RefreshTokenRequest,
     store: Annotated[RevocationStore, Depends(get_revocation_store)],
 ) -> TokenResponse:
-    """Get new access token using refresh token.
+    """Exchange a refresh token for a new access + refresh pair (rotation).
 
-    The refresh token remains valid until expiration.
-    Rate limited to prevent token abuse.
+    The presented refresh token is revoked and a fresh pair is issued, so a
+    stolen or reused refresh token stops working after its first use. Rate
+    limited to prevent token abuse.
 
     :param request: FastAPI request (for rate limiting)
     :param data: Refresh token request
-    :return: New access token
-    :raises HTTPException: If refresh token is invalid
+    :param store: Revocation store (revokes the old jti, detects reuse)
+    :return: New access and refresh tokens
+    :raises HTTPException: If the refresh token is invalid, expired, or revoked
     """
     try:
         payload = decode_refresh_token(data.refresh_token, store)
@@ -142,12 +142,16 @@ def refresh_token(
             headers={"WWW-Authenticate": "Bearer"},
         ) from None
 
-    settings = get_settings()
-    new_access_token = create_access_token(payload.user_id, payload.jti)
+    # Rotate: revoke the presented refresh token and issue a fresh pair. A reused
+    # (already-rotated) refresh token is then rejected by the revocation check in
+    # decode_refresh_token, which surfaces refresh-token theft.
+    revoke_token(payload.jti, store)
+    token_pair = create_token_pair(payload.user_id)
 
     return TokenResponse(
-        access_token=new_access_token,
-        expires_in=settings.access_token_expire_minutes * 60,
+        access_token=token_pair.access_token,
+        refresh_token=token_pair.refresh_token,
+        expires_in=token_pair.expires_in,
     )
 
 

--- a/tests/integration/api/auth/test_auth.py
+++ b/tests/integration/api/auth/test_auth.py
@@ -781,7 +781,40 @@ class TestRefreshToken:
         assert response.status_code == 200
         data = response.json()
         assert "access_token" in data
+        assert data["refresh_token"]  # rotation returns a fresh refresh token
         assert data["expires_in"] > 0
+
+    def test_refresh_rotates_and_revokes_old_token(self, client):
+        """Refresh issues a new pair, revokes the old refresh token, and detects reuse."""
+        # GIVEN - register and login
+        client.post(
+            "/api/v1/auth/register",
+            json={
+                "email": "rotate@example.com",
+                "password": "SecurePass123!",
+                "first_name": "Rot",
+                "last_name": "Ate",
+            },
+        )
+        login = client.post(
+            "/api/v1/auth/login",
+            data={"username": "rotate@example.com", "password": "SecurePass123!"},
+        )
+        old_refresh = login.json()["refresh_token"]
+
+        # WHEN - first refresh returns a fresh pair
+        first = client.post("/api/v1/auth/refresh", json={"refresh_token": old_refresh})
+        assert first.status_code == 200
+        new_refresh = first.json()["refresh_token"]
+        assert new_refresh and new_refresh != old_refresh
+
+        # THEN - reusing the old refresh token is rejected (revoked on rotation)
+        reused = client.post("/api/v1/auth/refresh", json={"refresh_token": old_refresh})
+        assert reused.status_code == 401
+
+        # AND - the rotated refresh token still works
+        again = client.post("/api/v1/auth/refresh", json={"refresh_token": new_refresh})
+        assert again.status_code == 200
 
     def test_refresh_with_invalid_token_fails(self, client):
         """Refresh with invalid token returns 401."""


### PR DESCRIPTION
## Summary

PR 4 of the auth shared-state epic — makes `/refresh` **rotate** the refresh token (H3). Previously `/refresh` reused the same JTI and returned only a new access token, so a stolen 7-day refresh token was usable for its full life with no theft detection. Now each refresh revokes the presented token and issues a fresh access + refresh pair; a reused (already-rotated) refresh token is rejected, which surfaces refresh-token theft.

Backend-only: the frontend has no refresh flow (it stores only the access token; `refreshUser` there just re-fetches the profile), so nothing on the client needs to change.

- **Runtime / backend**
  - `/refresh` (`api/routes/auth.py`) now revokes the old jti (`revoke_token` -> `store.revoke_jti`) and returns `create_token_pair` (a new jti), so `TokenResponse` carries a fresh `refresh_token`. A reused old refresh token hits the store's revocation check in `decode_refresh_token` and gets a 401.
  - Builds on PR 1/2: rotation revokes through the same shared Redis store, so it holds across replicas.
- **Tests**
  - `/refresh` returns a fresh refresh token; reusing the old one returns 401; the rotated token still works (`tests/integration/api/auth/test_auth.py::TestRefreshToken`). Full backend suite: 1097 passed.

## Important Files Changed

| Filename | Overview |
| --- | --- |
| `api/routes/auth.py` | `/refresh` rotates — revoke the old jti and issue a fresh pair; a reused refresh token -> 401. |
| `tests/integration/api/auth/test_auth.py` | Cover rotation, reuse detection, and the rotated token continuing to work. |
