### PR TITLE
feat: revoke sessions on password change and reset

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -468,14 +468,14 @@
         "filename": "tests/integration/api/auth/test_password_reset.py",
         "hashed_secret": "6e9119e671bbe324edd23d0453db69fe73f5f240",
         "is_verified": false,
-        "line_number": 171
+        "line_number": 194
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/api/auth/test_password_reset.py",
         "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
         "is_verified": false,
-        "line_number": 187
+        "line_number": 210
       }
     ],
     "tests/integration/api/db/test_cascade.py": [
@@ -585,6 +585,15 @@
         "hashed_secret": "07231459bd9aa24caa9870ce32fb02135d95bacc",
         "is_verified": false,
         "line_number": 80
+      }
+    ],
+    "tests/integration/api/routes/test_users.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/integration/api/routes/test_users.py",
+        "hashed_secret": "4d81c30a1e76bc8adbbb6af9fc64162241e13f34",
+        "is_verified": false,
+        "line_number": 135
       }
     ],
     "tests/shared/helpers.py": [
@@ -958,5 +967,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-02T14:45:53Z"
+  "generated_at": "2026-07-02T17:58:56Z"
 }

--- a/api/auth/jwt.py
+++ b/api/auth/jwt.py
@@ -136,12 +136,22 @@ def decode_token(token: str, expected_type: str, store: RevocationStore) -> Toke
         user_id_str: str | None = payload.get("sub")
         if not user_id_str:
             raise TokenError("Missing user ID in token")
+        user_id = UUID(user_id_str)
+
+        # Reject tokens issued before the user's valid_after cutoff (M1): a password
+        # change or reset invalidates every token minted earlier.
+        try:
+            valid_after = store.get_user_valid_after(user_id)
+        except RevocationStoreError as e:
+            raise TokenError("Revocation store unavailable") from e
+        if valid_after is not None and datetime.fromtimestamp(payload["iat"], tz=UTC) < valid_after:
+            raise TokenError("Token has been revoked")
 
         # exp is guaranteed by PyJWT with require=["exp"]
         exp_datetime = datetime.fromtimestamp(payload["exp"], tz=UTC)
 
         return TokenPayload(
-            user_id=UUID(user_id_str),
+            user_id=user_id,
             jti=jti,
             token_type=token_type,
             exp=exp_datetime,

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -5,6 +5,7 @@ by centralized middleware, routes focus on business logic only.
 """
 
 import logging
+from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -219,17 +220,21 @@ def reset_password(
     request: Request,
     data: ResetPasswordRequest,
     service: Annotated[PasswordResetService, Depends(get_password_reset_service)],
+    store: Annotated[RevocationStore, Depends(get_revocation_store)],
 ) -> None:
     """Set a new password using a valid reset token.
 
     InvalidResetTokenError and ResetTokenExpiredError are handled by centralized
     middleware and both map to 400 with the same opaque message. Rate limited.
+    Every token issued before the reset is invalidated (M1).
 
     :param request: FastAPI request (for rate limiting and logging)
     :param data: Reset token and new password
     :param service: Password reset service
+    :param store: Revocation store (invalidates sessions issued before the reset)
     """
     user = service.reset_password(data.token, data.new_password)
+    store.set_user_valid_after(user.id, datetime.now(UTC))
     log_password_reset_completed(user.id, request)
 
 

--- a/api/routes/users.py
+++ b/api/routes/users.py
@@ -1,6 +1,7 @@
 """User management routes: profile, password, photo, account deletion."""
 
 from contextlib import suppress
+from datetime import UTC, datetime
 from typing import Annotated
 from uuid import UUID
 
@@ -8,6 +9,7 @@ from fastapi import APIRouter, Depends, File, HTTPException, Request, Response, 
 
 from api.auth.dependencies import CurrentUser
 from api.auth.logging import log_account_deletion, log_data_export, log_password_change
+from api.auth.revocation_store import RevocationStore, get_revocation_store
 from api.dependencies import (
     get_data_export_service,
     get_project_service,
@@ -102,22 +104,26 @@ def change_password(
     current_user: CurrentUser,
     data: ChangePasswordRequest,
     service: Annotated[UserService, Depends(get_user_service)],
+    store: Annotated[RevocationStore, Depends(get_revocation_store)],
 ) -> None:
     """Change the authenticated user's password.
 
     InvalidCredentialsError is handled by centralized exception middleware.
-    Rate limited to prevent password guessing attacks.
+    Rate limited to prevent password guessing attacks. Every token issued before
+    the change is invalidated (M1).
 
     :param request: FastAPI request (for rate limiting)
     :param current_user: User from JWT token
     :param data: Current and new password
     :param service: User service
+    :param store: Revocation store (invalidates sessions issued before the change)
     """
     service.change_password(
         user=current_user,
         current_password=data.current_password,
         new_password=data.new_password,
     )
+    store.set_user_valid_after(current_user.id, datetime.now(UTC))
 
     log_password_change(current_user.id, request)
 

--- a/tests/integration/api/auth/test_password_reset.py
+++ b/tests/integration/api/auth/test_password_reset.py
@@ -14,7 +14,7 @@ from api.db.models import PasswordResetToken, User
 from api.db.utils import utc_now
 from api.dependencies import get_email_service
 from api.services.email.exceptions import EmailSendError
-from tests.shared.helpers import DEFAULT_TEST_PASSWORD
+from tests.shared.helpers import DEFAULT_TEST_PASSWORD, auth_header
 
 NEW_PASSWORD = "BrandNewPass456!"
 
@@ -141,6 +141,29 @@ class TestResetPassword:
             data={"username": "user@example.com", "password": NEW_PASSWORD},
         )
         assert new_login.status_code == 200
+
+    def test_reset_revokes_existing_access_tokens(self, client, fake_email):
+        """A password reset invalidates access tokens issued before it (M1)."""
+        # GIVEN a logged-in user with a working access token
+        _register(client, "resetrevoke@example.com")
+        login = client.post(
+            "/api/v1/auth/login",
+            data={"username": "resetrevoke@example.com", "password": DEFAULT_TEST_PASSWORD},
+        )
+        access = login.json()["access_token"]
+        assert client.get("/api/v1/auth/me", headers=auth_header(access)).status_code == 200
+
+        # WHEN the password is reset
+        client.post("/api/v1/auth/forgot-password", json={"email": "resetrevoke@example.com"})
+        token = _captured_token(fake_email)
+        reset = client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": token, "new_password": NEW_PASSWORD},
+        )
+        assert reset.status_code == 204
+
+        # THEN the old access token is rejected
+        assert client.get("/api/v1/auth/me", headers=auth_header(access)).status_code == 401
 
     def test_rejects_unknown_token(self, client):
         """An unknown token is rejected with 400."""

--- a/tests/integration/api/routes/test_users.py
+++ b/tests/integration/api/routes/test_users.py
@@ -117,3 +117,24 @@ class TestDeleteAccountWithOwnedProjects:
 
         # THEN
         assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+class TestChangePasswordRevokesSessions:
+    """Changing the password invalidates tokens issued earlier (M1)."""
+
+    def test_change_password_revokes_existing_tokens(self, client):
+        """After a password change, a previously issued access token is rejected."""
+        # GIVEN a logged-in user whose token works
+        token = register_and_login(client, "changepw@example.com")
+        assert client.get("/api/v1/auth/me", headers=auth_header(token)).status_code == 200
+
+        # WHEN the password is changed
+        resp = client.put(
+            "/api/v1/users/me/password",
+            headers=auth_header(token),
+            json={"current_password": DEFAULT_TEST_PASSWORD, "new_password": "NewSecurePass456!"},
+        )
+        assert resp.status_code == 204
+
+        # THEN the old token no longer works
+        assert client.get("/api/v1/auth/me", headers=auth_header(token)).status_code == 401

--- a/tests/unit/api/auth/test_jwt.py
+++ b/tests/unit/api/auth/test_jwt.py
@@ -442,3 +442,21 @@ def test_decode_fails_closed_when_store_unavailable():
     token = create_access_token(uuid4())
     with pytest.raises(TokenError, match="unavailable"):
         decode_access_token(token, Down())
+
+
+def test_decode_rejects_token_older_than_valid_after(store):
+    """A token issued before the user's valid_after cutoff is rejected (M1)."""
+    user_id = uuid4()
+    token = create_access_token(user_id)
+    # Password changed "after" this token was issued.
+    store.set_user_valid_after(user_id, datetime.now(UTC) + timedelta(seconds=5))
+    with pytest.raises(TokenError, match="revoked"):
+        decode_access_token(token, store)
+
+
+def test_decode_accepts_token_newer_than_valid_after(store):
+    """A token issued after the valid_after cutoff still works (M1)."""
+    user_id = uuid4()
+    store.set_user_valid_after(user_id, datetime.now(UTC) - timedelta(seconds=5))
+    token = create_access_token(user_id)
+    assert decode_access_token(token, store) == user_id


### PR DESCRIPTION
## Summary

PR 5 — the **final** PR of the auth shared-state epic — invalidates every existing session when a user changes or resets their password (M1). Previously a password change left outstanding tokens usable for up to 7 days, so an attacker's session survived the victim resetting their password.

With this, the whole epic is done: H2 (reliable logout, #250/#251), M6 (Redis rate limiter, #253), H3 (refresh rotation, #254), M1 (this PR).

- **Runtime / backend**
  - `decode_token` (`api/auth/jwt.py`) now rejects a token whose `iat` is older than the user's `valid_after` cutoff; fail-closed on a store error (401). It uses the per-user `valid_after` already on the `RevocationStore` Protocol (added in PR 1, unused until now) — one extra store read per authenticated request.
  - `change_password` (`api/routes/users.py`) and `reset_password` (`api/routes/auth.py`) call `store.set_user_valid_after(user_id, now)` after the password changes, so every token minted earlier stops working immediately.
- **Tests**
  - `decode_token` rejects a token older than `valid_after` and accepts a newer one; changing the password revokes existing tokens; resetting the password revokes existing access tokens. Full backend suite: 1100 passed.

## Important Files Changed

| Filename | Overview |
| --- | --- |
| `api/auth/jwt.py` | `decode_token` rejects tokens issued before the user's `valid_after` cutoff (fail-closed on store error). |
| `api/routes/users.py` | `change_password` sets `valid_after=now`, invalidating earlier sessions. |
| `api/routes/auth.py` | `reset_password` sets `valid_after=now`, invalidating earlier sessions. |
