### PR TITLE
chore: switch dependabot to the uv ecosystem so it updates uv.lock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
Switches the `pip` package-ecosystem to `uv` so Dependabot regenerates `uv.lock` together with `pyproject.toml`.

Under `pip`, Dependabot bumped the pins in `pyproject.toml` but left `uv.lock` stale, so CI's `uv sync --locked` failed on every grouped Python update. It happened this month on #252 and before that on #224, which needed the manual follow-up #226 to resync the lockfile. The `uv` ecosystem resolves the lockfile natively and ships both files in the same PR, so the group stops landing red.

Groups, labels, reviewers, and the monthly schedule stay as they are.
