### PR TITLE
feat: session auth via httpOnly cookies with CSRF

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -243,7 +243,7 @@
         "filename": "frontend/tests/contexts/AuthContext.test.tsx",
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_verified": false,
-        "line_number": 170
+        "line_number": 163
       }
     ],
     "frontend/tests/lib/api.test.ts": [
@@ -252,14 +252,14 @@
         "filename": "frontend/tests/lib/api.test.ts",
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_verified": false,
-        "line_number": 260
+        "line_number": 217
       },
       {
         "type": "Secret Keyword",
         "filename": "frontend/tests/lib/api.test.ts",
         "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
         "is_verified": false,
-        "line_number": 362
+        "line_number": 320
       }
     ],
     "frontend/tests/pages/Profile.test.tsx": [
@@ -990,5 +990,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-03T20:51:29Z"
+  "generated_at": "2026-07-04T21:51:01Z"
 }

--- a/api/README.md
+++ b/api/README.md
@@ -79,6 +79,15 @@ api/
 | POST | `/api/v1/auth/reset-password` | Reset password using a token |
 | GET | `/api/v1/auth/me` | Get current user profile |
 
+**Session transport.** Login and refresh set the access and refresh tokens as
+`Secure; HttpOnly; SameSite=Strict` cookies (the refresh cookie is scoped to
+`/api/v1/auth`) plus a readable `csrf_token` cookie; the tokens are also returned in the
+response body so programmatic clients can keep using the `Authorization: Bearer` header.
+A cookie-authenticated mutating request (POST/PUT/PATCH/DELETE) must echo the
+`csrf_token` cookie back in an `X-CSRF-Token` header (double-submit CSRF); Bearer-header
+requests are exempt. `/auth/refresh` reads the refresh token from the cookie or the body,
+and logout revokes the session and clears the cookies.
+
 ### Users
 
 | Method | Endpoint | Description |

--- a/api/auth/cookies.py
+++ b/api/auth/cookies.py
@@ -10,7 +10,7 @@ response body so programmatic clients and the test suite can keep using the
 
 import secrets
 
-from fastapi import Response
+from fastapi import Request, Response
 
 from api.config import Environment, get_settings
 
@@ -24,17 +24,20 @@ CSRF_HEADER = "X-CSRF-Token"
 REFRESH_COOKIE_PATH = "/api/v1/auth"
 
 
-def cookies_secure() -> bool:
+def cookies_secure(request: Request) -> bool:
     """Return whether auth cookies should carry the ``Secure`` flag.
 
-    Secure on the deployed profiles (served over HTTPS); off for local dev and the
-    pytest client, which both speak plain HTTP so the cookie would otherwise never
-    round-trip.
+    Always on in production; otherwise on only when the request itself arrived over
+    HTTPS. This keeps cookies working over plain HTTP for local dev, the pytest client,
+    and the HTTP e2e stack (a ``Secure`` cookie is dropped by the browser over HTTP),
+    while production behind TLS always gets ``Secure`` cookies.
 
+    :param request: The incoming request, used to read the connection scheme.
     :return: True when cookies must be HTTPS-only.
     """
-    settings = get_settings()
-    return settings.environment is not Environment.DEV and not settings.testing
+    if get_settings().environment is Environment.PROD:
+        return True
+    return request.url.scheme == "https"
 
 
 def new_csrf_token() -> str:
@@ -50,6 +53,7 @@ def set_auth_cookies(
     csrf_token: str,
     access_ttl: int,
     refresh_ttl: int,
+    secure: bool,
 ) -> None:
     """Attach the access, refresh, and CSRF cookies to a response.
 
@@ -59,8 +63,8 @@ def set_auth_cookies(
     :param csrf_token: Double-submit CSRF token (readable cookie).
     :param access_ttl: Access-cookie lifetime in seconds.
     :param refresh_ttl: Refresh- and CSRF-cookie lifetime in seconds.
+    :param secure: Whether to set the ``Secure`` flag (see :func:`cookies_secure`).
     """
-    secure = cookies_secure()
     response.set_cookie(
         ACCESS_COOKIE,
         access_token,

--- a/api/auth/cookies.py
+++ b/api/auth/cookies.py
@@ -1,0 +1,99 @@
+"""Auth session cookies: names, flags, and set/clear helpers.
+
+Access and refresh tokens are delivered as ``Secure; HttpOnly; SameSite=Strict``
+cookies so JavaScript cannot read them (blunts token theft via XSS). A separate,
+readable ``csrf_token`` cookie backs the double-submit CSRF check: the SPA echoes it
+in the ``X-CSRF-Token`` header on mutating requests. The token also stays in the login
+response body so programmatic clients and the test suite can keep using the
+``Authorization: Bearer`` header.
+"""
+
+import secrets
+
+from fastapi import Response
+
+from api.config import Environment, get_settings
+
+ACCESS_COOKIE = "access_token"
+REFRESH_COOKIE = "refresh_token"
+CSRF_COOKIE = "csrf_token"
+CSRF_HEADER = "X-CSRF-Token"
+
+# The refresh cookie is scoped to the auth routes, so the browser only sends it to
+# login/refresh/logout instead of on every API call.
+REFRESH_COOKIE_PATH = "/api/v1/auth"
+
+
+def cookies_secure() -> bool:
+    """Return whether auth cookies should carry the ``Secure`` flag.
+
+    Secure on the deployed profiles (served over HTTPS); off for local dev and the
+    pytest client, which both speak plain HTTP so the cookie would otherwise never
+    round-trip.
+
+    :return: True when cookies must be HTTPS-only.
+    """
+    settings = get_settings()
+    return settings.environment is not Environment.DEV and not settings.testing
+
+
+def new_csrf_token() -> str:
+    """Return a fresh, high-entropy token for the double-submit CSRF cookie."""
+    return secrets.token_urlsafe(32)
+
+
+def set_auth_cookies(
+    response: Response,
+    *,
+    access_token: str,
+    refresh_token: str,
+    csrf_token: str,
+    access_ttl: int,
+    refresh_ttl: int,
+) -> None:
+    """Attach the access, refresh, and CSRF cookies to a response.
+
+    :param response: The response to set cookies on.
+    :param access_token: Short-lived access token (HttpOnly cookie).
+    :param refresh_token: Long-lived refresh token (HttpOnly, auth-scoped cookie).
+    :param csrf_token: Double-submit CSRF token (readable cookie).
+    :param access_ttl: Access-cookie lifetime in seconds.
+    :param refresh_ttl: Refresh- and CSRF-cookie lifetime in seconds.
+    """
+    secure = cookies_secure()
+    response.set_cookie(
+        ACCESS_COOKIE,
+        access_token,
+        max_age=access_ttl,
+        httponly=True,
+        secure=secure,
+        samesite="strict",
+    )
+    response.set_cookie(
+        REFRESH_COOKIE,
+        refresh_token,
+        max_age=refresh_ttl,
+        path=REFRESH_COOKIE_PATH,
+        httponly=True,
+        secure=secure,
+        samesite="strict",
+    )
+    # Not HttpOnly: the SPA reads it to echo back in the X-CSRF-Token header.
+    response.set_cookie(
+        CSRF_COOKIE,
+        csrf_token,
+        max_age=refresh_ttl,
+        httponly=False,
+        secure=secure,
+        samesite="strict",
+    )
+
+
+def clear_auth_cookies(response: Response) -> None:
+    """Delete the access, refresh, and CSRF cookies (used on logout).
+
+    :param response: The response to clear cookies on.
+    """
+    response.delete_cookie(ACCESS_COOKIE)
+    response.delete_cookie(REFRESH_COOKIE, path=REFRESH_COOKIE_PATH)
+    response.delete_cookie(CSRF_COOKIE)

--- a/api/auth/dependencies.py
+++ b/api/auth/dependencies.py
@@ -7,11 +7,12 @@ injected, and UserService is created with this injected dependency.
 
 from typing import Annotated
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Cookie, Depends, HTTPException, status
 from fastapi.concurrency import run_in_threadpool
 from fastapi.security import OAuth2PasswordBearer
 from sqlmodel import Session
 
+from api.auth.cookies import ACCESS_COOKIE
 from api.auth.jwt import TokenError, TokenPayload, decode_access_token, decode_token
 from api.auth.revocation_store import RevocationStore, get_revocation_store
 from api.db.models import User
@@ -19,11 +20,35 @@ from api.db.session import get_session
 from api.logging_context import set_user_id
 from api.services.user_service import UserService
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login", auto_error=False)
+
+
+def _get_access_token(
+    cookie_token: Annotated[str | None, Cookie(alias=ACCESS_COOKIE)] = None,
+    bearer_token: Annotated[str | None, Depends(oauth2_scheme)] = None,
+) -> str:
+    """Return the access token from the session cookie, else the Bearer header.
+
+    The cookie is the primary transport for the browser SPA; the Authorization header
+    stays as a fallback for programmatic clients and the test suite.
+
+    :param cookie_token: Access token from the HttpOnly session cookie.
+    :param bearer_token: Access token from the Authorization header.
+    :return: The access token to validate.
+    :raises HTTPException: 401 when neither transport carries a token.
+    """
+    token = cookie_token or bearer_token
+    if token is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return token
 
 
 async def get_current_user(
-    token: Annotated[str, Depends(oauth2_scheme)],
+    token: Annotated[str, Depends(_get_access_token)],
     session: Annotated[Session, Depends(get_session)],
     store: Annotated[RevocationStore, Depends(get_revocation_store)],
 ) -> User:
@@ -64,7 +89,7 @@ CurrentUser = Annotated[User, Depends(get_current_user)]
 
 
 def get_current_token_payload(
-    token: Annotated[str, Depends(oauth2_scheme)],
+    token: Annotated[str, Depends(_get_access_token)],
     store: Annotated[RevocationStore, Depends(get_revocation_store)],
 ) -> TokenPayload:
     """Extract and validate token payload from JWT.

--- a/api/main.py
+++ b/api/main.py
@@ -18,6 +18,7 @@ from api.middleware.body_size import (
     RequestBodyTooLarge,
     body_too_large_handler,
 )
+from api.middleware.csrf import CSRFMiddleware
 from api.middleware.exception_handlers import register_exception_handlers
 from api.middleware.rate_limit import limiter, rate_limit_handler
 from api.middleware.request_logging import RequestLoggingMiddleware
@@ -112,9 +113,13 @@ def create_app() -> FastAPI:
             "Accept",
             "Accept-Language",
             "X-Request-ID",
+            "X-CSRF-Token",
         ],
         max_age=600,  # Cache preflight requests for 10 minutes
     )
+
+    # CSRF double-submit check for cookie-authenticated mutations (no-op for Bearer clients).
+    app.add_middleware(CSRFMiddleware)
 
     # Request/response logging with correlation IDs.
     app.add_middleware(RequestLoggingMiddleware)

--- a/api/middleware/csrf.py
+++ b/api/middleware/csrf.py
@@ -1,0 +1,46 @@
+"""Double-submit CSRF protection for cookie-authenticated mutations.
+
+The check is enforced only when the request carries the readable ``csrf_token`` cookie,
+i.e. a cookie-based browser client. Programmatic clients that authenticate with a Bearer
+header (and requests made before login) send no such cookie and are unaffected.
+
+``SameSite=Strict`` already stops the session cookies from being sent on cross-site
+requests; this double-submit check is defense-in-depth: an attacker who cannot read the
+``csrf_token`` cookie value cannot forge the matching ``X-CSRF-Token`` header.
+"""
+
+import secrets
+
+from starlette import status
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from api.auth.cookies import CSRF_COOKIE, CSRF_HEADER
+
+# Methods that never change state need no CSRF token (OPTIONS also keeps CORS preflight
+# working, since a cross-origin preflight carries no cookies or custom headers).
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
+
+
+class CSRFMiddleware(BaseHTTPMiddleware):
+    """Reject cookie-authenticated mutating requests that lack a matching CSRF token."""
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        """Validate the double-submit token on cookie-authenticated mutations.
+
+        :param request: Incoming request.
+        :param call_next: Downstream handler.
+        :return: A 403 response when the CSRF token is missing or wrong, else the
+            downstream response.
+        """
+        if request.method not in _SAFE_METHODS:
+            cookie = request.cookies.get(CSRF_COOKIE)
+            if cookie is not None:
+                header = request.headers.get(CSRF_HEADER)
+                if header is None or not secrets.compare_digest(header, cookie):
+                    return JSONResponse(
+                        status_code=status.HTTP_403_FORBIDDEN,
+                        content={"detail": "CSRF token missing or invalid"},
+                    )
+        return await call_next(request)

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -14,6 +14,7 @@ from fastapi.security import OAuth2PasswordRequestForm
 from api.auth.cookies import (
     REFRESH_COOKIE,
     clear_auth_cookies,
+    cookies_secure,
     new_csrf_token,
     set_auth_cookies,
 )
@@ -57,11 +58,12 @@ router = APIRouter(prefix="/api/v1/auth", tags=["auth"])
 logger = logging.getLogger("api.route.auth")
 
 
-def _set_session_cookies(response: Response, token_pair: TokenPair) -> None:
+def _set_session_cookies(response: Response, token_pair: TokenPair, request: Request) -> None:
     """Attach the access, refresh, and CSRF cookies for a freshly issued token pair.
 
     :param response: The response to set cookies on.
     :param token_pair: The newly minted access/refresh pair.
+    :param request: The incoming request, used to decide the cookie Secure flag.
     """
     set_auth_cookies(
         response,
@@ -70,6 +72,7 @@ def _set_session_cookies(response: Response, token_pair: TokenPair) -> None:
         csrf_token=new_csrf_token(),
         access_ttl=token_pair.expires_in,
         refresh_ttl=refresh_token_ttl_seconds(),
+        secure=cookies_secure(request),
     )
 
 
@@ -149,7 +152,7 @@ def login(
     throttle.reset(form_data.username)
     token_pair = create_token_pair(user.id)
     store.start_session(token_pair.sid, token_pair.jti, refresh_token_ttl_seconds())
-    _set_session_cookies(response, token_pair)
+    _set_session_cookies(response, token_pair, request)
 
     log_login_success(user.id, user.email, request)
 
@@ -218,7 +221,7 @@ def refresh_token(
                 detail="Invalid or expired refresh token",
                 headers={"WWW-Authenticate": "Bearer"},
             )
-        _set_session_cookies(response, token_pair)
+        _set_session_cookies(response, token_pair, request)
         return TokenResponse(
             access_token=token_pair.access_token,
             refresh_token=token_pair.refresh_token,
@@ -230,7 +233,7 @@ def refresh_token(
     revoke_token(payload.jti, store)
     token_pair = create_token_pair(payload.user_id)
     store.start_session(token_pair.sid, token_pair.jti, ttl)
-    _set_session_cookies(response, token_pair)
+    _set_session_cookies(response, token_pair, request)
     return TokenResponse(
         access_token=token_pair.access_token,
         refresh_token=token_pair.refresh_token,

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -8,10 +8,15 @@ import logging
 from datetime import UTC, datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
 
-from api.auth.cookies import clear_auth_cookies, new_csrf_token, set_auth_cookies
+from api.auth.cookies import (
+    REFRESH_COOKIE,
+    clear_auth_cookies,
+    new_csrf_token,
+    set_auth_cookies,
+)
 from api.auth.dependencies import CurrentUser, get_current_token_payload
 from api.auth.jwt import (
     TokenError,
@@ -160,8 +165,9 @@ def login(
 def refresh_token(
     request: Request,
     response: Response,
-    data: RefreshTokenRequest,
     store: Annotated[RevocationStore, Depends(get_revocation_store)],
+    data: RefreshTokenRequest | None = None,
+    refresh_cookie: Annotated[str | None, Cookie(alias=REFRESH_COOKIE)] = None,
 ) -> TokenResponse:
     """Exchange a refresh token for a new access + refresh pair (rotation).
 
@@ -176,8 +182,17 @@ def refresh_token(
     :return: New access and refresh tokens
     :raises HTTPException: If the refresh token is invalid, expired, revoked, or reused
     """
+    # The SPA sends the refresh token via the HttpOnly cookie (which it cannot read into
+    # a body); programmatic clients still post it in the request body.
+    refresh = refresh_cookie or (data.refresh_token if data else None)
+    if refresh is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired refresh token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
     try:
-        payload = decode_refresh_token(data.refresh_token, store)
+        payload = decode_refresh_token(refresh, store)
     except TokenError:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -8,12 +8,14 @@ import logging
 from datetime import UTC, datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
 
+from api.auth.cookies import clear_auth_cookies, new_csrf_token, set_auth_cookies
 from api.auth.dependencies import CurrentUser, get_current_token_payload
 from api.auth.jwt import (
     TokenError,
+    TokenPair,
     TokenPayload,
     create_token_pair,
     decode_refresh_token,
@@ -48,6 +50,22 @@ from api.services.user_service import UserService
 router = APIRouter(prefix="/api/v1/auth", tags=["auth"])
 
 logger = logging.getLogger("api.route.auth")
+
+
+def _set_session_cookies(response: Response, token_pair: TokenPair) -> None:
+    """Attach the access, refresh, and CSRF cookies for a freshly issued token pair.
+
+    :param response: The response to set cookies on.
+    :param token_pair: The newly minted access/refresh pair.
+    """
+    set_auth_cookies(
+        response,
+        access_token=token_pair.access_token,
+        refresh_token=token_pair.refresh_token,
+        csrf_token=new_csrf_token(),
+        access_ttl=token_pair.expires_in,
+        refresh_ttl=refresh_token_ttl_seconds(),
+    )
 
 
 @router.post(
@@ -92,6 +110,7 @@ def register(
 @limiter.limit(LIMIT_AUTH_ENDPOINTS)
 def login(
     request: Request,
+    response: Response,
     form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
     service: Annotated[UserService, Depends(get_user_service)],
     store: Annotated[RevocationStore, Depends(get_revocation_store)],
@@ -125,6 +144,7 @@ def login(
     throttle.reset(form_data.username)
     token_pair = create_token_pair(user.id)
     store.start_session(token_pair.sid, token_pair.jti, refresh_token_ttl_seconds())
+    _set_session_cookies(response, token_pair)
 
     log_login_success(user.id, user.email, request)
 
@@ -139,6 +159,7 @@ def login(
 @limiter.limit(LIMIT_AUTH_ENDPOINTS)
 def refresh_token(
     request: Request,
+    response: Response,
     data: RefreshTokenRequest,
     store: Annotated[RevocationStore, Depends(get_revocation_store)],
 ) -> TokenResponse:
@@ -182,6 +203,7 @@ def refresh_token(
                 detail="Invalid or expired refresh token",
                 headers={"WWW-Authenticate": "Bearer"},
             )
+        _set_session_cookies(response, token_pair)
         return TokenResponse(
             access_token=token_pair.access_token,
             refresh_token=token_pair.refresh_token,
@@ -193,6 +215,7 @@ def refresh_token(
     revoke_token(payload.jti, store)
     token_pair = create_token_pair(payload.user_id)
     store.start_session(token_pair.sid, token_pair.jti, ttl)
+    _set_session_cookies(response, token_pair)
     return TokenResponse(
         access_token=token_pair.access_token,
         refresh_token=token_pair.refresh_token,
@@ -206,21 +229,24 @@ def refresh_token(
     summary="Logout and revoke current token",
 )
 def logout(
+    response: Response,
     token_payload: Annotated[TokenPayload, Depends(get_current_token_payload)],
     store: Annotated[RevocationStore, Depends(get_revocation_store)],
 ) -> None:
-    """Revoke the current session.
+    """Revoke the current session and clear the auth cookies.
 
     Blacklists the token's JTI and revokes its whole session, so every access and
     refresh token in the family stops working -- even a still-valid access token
     issued before an earlier rotation.
 
+    :param response: Response used to clear the auth cookies.
     :param token_payload: Current token payload from JWT
     :param store: Revocation store
     """
     revoke_token(token_payload.jti, store)
     if token_payload.sid:
         store.revoke_session(token_payload.sid, refresh_token_ttl_seconds())
+    clear_auth_cookies(response)
 
 
 @router.post(

--- a/frontend/e2e/error-states.spec.ts
+++ b/frontend/e2e/error-states.spec.ts
@@ -65,7 +65,9 @@ test.describe('Error States', () => {
     const email = `err-session-${uniqueId()}@test.com`;
     await registerUser(page, email, 'Session', 'Test');
 
-    // Clear auth tokens from localStorage (simulate expired session)
+    // Simulate an expired session. The session lives in HttpOnly cookies now, so the
+    // cookies must be cleared -- localStorage no longer holds the token.
+    await page.context().clearCookies();
     await page.evaluate(() => {
       const lang = localStorage.getItem('become-language');
       localStorage.clear();

--- a/frontend/e2e/full-flow.spec.ts
+++ b/frontend/e2e/full-flow.spec.ts
@@ -60,7 +60,9 @@ test.describe.serial('Full Application Flow', () => {
   });
 
   test('logout and login with created account', async () => {
-    // Clear auth state, keep language
+    // Clear auth state, keep language. The session lives in HttpOnly cookies now, so
+    // clearing localStorage alone is not enough -- clear the cookies to actually log out.
+    await page.context().clearCookies();
     await page.evaluate(() => {
       const lang = localStorage.getItem('become-language');
       localStorage.clear();

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -34,8 +34,8 @@ export function Navbar() {
     return () => globalThis.removeEventListener("scroll", handleScroll);
   }, []);
 
-  const handleLogout = () => {
-    logout();
+  const handleLogout = async () => {
+    await logout();
     globalThis.location.href = '/';
   };
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -9,7 +9,7 @@ interface AuthContextType {
   readonly isAuthenticated: boolean;
   readonly login: (email: string, password: string) => Promise<void>;
   readonly register: (email: string, password: string, firstName: string, lastName?: string) => Promise<void>;
-  readonly logout: () => void;
+  readonly logout: () => Promise<void>;
   readonly refreshUser: () => Promise<void>;
 }
 
@@ -20,21 +20,15 @@ export function AuthProvider({ children }: { readonly children: React.ReactNode 
   const [isLoading, setIsLoading] = useState(true);
 
   const refreshUser = useCallback(async () => {
-    const token = api.getToken();
-    if (!token) {
-      setUser(null);
-      setIsLoading(false);
-      return;
-    }
-
     try {
-      const userData = await api.getCurrentUser();
+      // Probe the session via the HttpOnly cookie; silent so an anonymous visitor is
+      // not redirected away from a public page.
+      const userData = await api.getCurrentUser(true);
       setUser(userData);
     } catch (err) {
-      logger.warn('Session refresh failed', {
+      logger.debug('No active session', {
         error: err instanceof Error ? err.message : String(err),
       });
-      api.logout();
       setUser(null);
     } finally {
       setIsLoading(false);
@@ -62,8 +56,8 @@ export function AuthProvider({ children }: { readonly children: React.ReactNode 
     await refreshUser();
   }, [refreshUser]);
 
-  const logout = useCallback(() => {
-    api.logout();
+  const logout = useCallback(async () => {
+    await api.logout();
     setUser(null);
   }, []);
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -27,52 +27,47 @@ export class HttpError extends Error {
   }
 }
 
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+function readCsrfToken(): string | null {
+  const match = document.cookie.match(/(?:^|; )csrf_token=([^;]*)/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
 class ApiClient {
-  private token: string | null = null;
-
-  constructor() {
-    this.token = localStorage.getItem('become_token');
-  }
-
-  setToken(token: string | null) {
-    this.token = token;
-    if (token) {
-      localStorage.setItem('become_token', token);
-    } else {
-      localStorage.removeItem('become_token');
-    }
-  }
-
-  getToken(): string | null {
-    return this.token;
-  }
-
   private async request<T>(
     endpoint: string,
-    options: RequestInit = {}
+    options: RequestInit = {},
+    silent = false
   ): Promise<T> {
     const requestId = crypto.randomUUID();
     const method = options.method ?? 'GET';
-    const headers: HeadersInit = {
+    const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       'X-Request-ID': requestId,
-      ...options.headers,
+      ...(options.headers as Record<string, string>),
     };
 
-    if (this.token) {
-      (headers as Record<string, string>)['Authorization'] = `Bearer ${this.token}`;
+    // Cookie-based session: echo the readable csrf_token cookie on mutating requests.
+    if (MUTATING_METHODS.has(method.toUpperCase())) {
+      const csrf = readCsrfToken();
+      if (csrf) {
+        headers['X-CSRF-Token'] = csrf;
+      }
     }
 
     logger.debug('API request', { method, endpoint, requestId });
 
     const response = await fetch(`${API_BASE_URL}${endpoint}`, {
       ...options,
+      credentials: 'include',
       headers,
     });
 
     if (!response.ok) {
-      if (response.status === 401) {
-        this.setToken(null);
+      // A session-expiry 401 sends the user to login; the mount-time auth probe passes
+      // silent=true so an anonymous visitor on a public page is not bounced there.
+      if (response.status === 401 && !silent) {
         globalThis.location.href = '/login';
       }
 
@@ -113,6 +108,7 @@ class ApiClient {
 
     const response = await fetch(`${API_BASE_URL}/auth/login`, {
       method: 'POST',
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
@@ -127,13 +123,18 @@ class ApiClient {
       throw new Error(error.detail || 'Login failed');
     }
 
-    const data: AuthResponse = await response.json();
-    this.setToken(data.access_token);
-    return data;
+    // The session now lives in HttpOnly cookies set by the server; the body token is
+    // ignored here and kept only for programmatic (non-browser) clients.
+    return response.json();
   }
 
-  logout() {
-    this.setToken(null);
+  async logout(): Promise<void> {
+    // Hit the server so it revokes the session and clears the HttpOnly cookies.
+    try {
+      await this.request<void>('/auth/logout', { method: 'POST' });
+    } catch {
+      // Ignore: the user is logging out regardless of a network hiccup.
+    }
   }
 
   async forgotPassword(email: string): Promise<void> {
@@ -151,8 +152,8 @@ class ApiClient {
   }
 
   // Users
-  async getCurrentUser(): Promise<User> {
-    return this.request<User>('/users/me');
+  async getCurrentUser(silent = false): Promise<User> {
+    return this.request<User>('/users/me', {}, silent);
   }
 
   // Returns the user's full GDPR data export. The payload is only downloaded as
@@ -186,20 +187,21 @@ class ApiClient {
     const formData = new FormData();
     formData.append('file', file);
 
-    const headers: HeadersInit = {};
-    if (this.token) {
-      headers['Authorization'] = `Bearer ${this.token}`;
+    const headers: Record<string, string> = {};
+    const csrf = readCsrfToken();
+    if (csrf) {
+      headers['X-CSRF-Token'] = csrf;
     }
 
     const response = await fetch(`${API_BASE_URL}/users/me/photo`, {
       method: 'POST',
+      credentials: 'include',
       headers,
       body: formData,
     });
 
     if (!response.ok) {
       if (response.status === 401) {
-        this.setToken(null);
         globalThis.location.href = '/login';
       }
       const error = await response.json().catch(() => ({ detail: 'Upload failed' }));
@@ -333,19 +335,15 @@ class ApiClient {
     format: 'pdf' | 'csv',
     lang: string
   ): Promise<Blob> {
-    const headers: HeadersInit = { 'X-Request-ID': crypto.randomUUID() };
-    if (this.token) {
-      (headers as Record<string, string>)['Authorization'] = `Bearer ${this.token}`;
-    }
+    const headers: Record<string, string> = { 'X-Request-ID': crypto.randomUUID() };
 
     const response = await fetch(
       `${API_BASE_URL}/projects/${projectId}/result/export?format=${format}&lang=${lang}`,
-      { headers }
+      { credentials: 'include', headers }
     );
 
     if (!response.ok) {
       if (response.status === 401) {
-        this.setToken(null);
         globalThis.location.href = '/login';
       }
       const error = await response.json().catch(() => ({ detail: 'Export failed' }));

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -220,7 +220,7 @@ const Profile = () => {
   const handleDeleteAccount = async () => {
     try {
       await api.deleteAccount();
-      logout();
+      await logout();
       navigate("/");
       toast({ title: t("toast.accountDeleted") });
     } catch (error) {

--- a/frontend/tests/contexts/AuthContext.test.tsx
+++ b/frontend/tests/contexts/AuthContext.test.tsx
@@ -6,7 +6,6 @@ import { createUser } from '@tests/factories/user'
 
 vi.mock('@/lib/api', () => ({
   api: {
-    getToken: vi.fn(),
     getCurrentUser: vi.fn(),
     login: vi.fn(),
     register: vi.fn(),
@@ -34,7 +33,6 @@ describe('AuthContext', () => {
 
   it('sets isAuthenticated to true when user exists', async () => {
     const mockUser = createUser({ id: '1', email: 'test@example.com', first_name: 'Test' })
-    vi.mocked(api.getToken).mockReturnValue('valid-token')
     vi.mocked(api.getCurrentUser).mockResolvedValue(mockUser)
 
     const { result } = renderHook(() => useAuth(), {
@@ -49,8 +47,8 @@ describe('AuthContext', () => {
     expect(result.current.user).toEqual(mockUser)
   })
 
-  it('sets isAuthenticated to false when no token', async () => {
-    vi.mocked(api.getToken).mockReturnValue(null)
+  it('sets isAuthenticated to false when there is no active session', async () => {
+    vi.mocked(api.getCurrentUser).mockRejectedValue(new Error('401'))
 
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,
@@ -66,7 +64,6 @@ describe('AuthContext', () => {
 
   it('login calls api.login and refreshes user', async () => {
     const mockUser = createUser({ id: '1', email: 'test@example.com', first_name: 'Test' })
-    vi.mocked(api.getToken).mockReturnValue(null)
     vi.mocked(api.login).mockResolvedValue({ access_token: 'new-token', token_type: 'bearer' })
     vi.mocked(api.getCurrentUser).mockResolvedValue(mockUser)
 
@@ -87,7 +84,6 @@ describe('AuthContext', () => {
 
   it('logout clears user and calls api.logout', async () => {
     const mockUser = createUser({ id: '1', email: 'test@example.com', first_name: 'Test' })
-    vi.mocked(api.getToken).mockReturnValue('valid-token')
     vi.mocked(api.getCurrentUser).mockResolvedValue(mockUser)
 
     const { result } = renderHook(() => useAuth(), {
@@ -98,8 +94,8 @@ describe('AuthContext', () => {
       expect(result.current.isAuthenticated).toBe(true)
     })
 
-    act(() => {
-      result.current.logout()
+    await act(async () => {
+      await result.current.logout()
     })
 
     expect(api.logout).toHaveBeenCalled()
@@ -107,8 +103,7 @@ describe('AuthContext', () => {
     expect(result.current.isAuthenticated).toBe(false)
   })
 
-  it('clears user and calls api.logout when refreshUser fails', async () => {
-    vi.mocked(api.getToken).mockReturnValue('expired-token')
+  it('clears the user when the session probe fails', async () => {
     vi.mocked(api.getCurrentUser).mockRejectedValue(new Error('Token expired'))
 
     const { result } = renderHook(() => useAuth(), {
@@ -119,13 +114,12 @@ describe('AuthContext', () => {
       expect(result.current.isLoading).toBe(false)
     })
 
-    expect(api.logout).toHaveBeenCalled()
     expect(result.current.user).toBeNull()
     expect(result.current.isAuthenticated).toBe(false)
   })
 
   it('propagates login error to caller', async () => {
-    vi.mocked(api.getToken).mockReturnValue(null)
+    vi.mocked(api.getCurrentUser).mockRejectedValue(new Error('401'))
 
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,
@@ -146,7 +140,7 @@ describe('AuthContext', () => {
 
   it('register calls api.register, api.login, and refreshes user', async () => {
     const mockUser = createUser({ id: '1', email: 'new@example.com', first_name: 'New' })
-    vi.mocked(api.getToken).mockReturnValue(null)
+    vi.mocked(api.getCurrentUser).mockRejectedValue(new Error('401'))
 
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,
@@ -158,7 +152,6 @@ describe('AuthContext', () => {
 
     vi.mocked(api.register).mockResolvedValue(mockUser)
     vi.mocked(api.login).mockResolvedValue({ access_token: 'new-token', token_type: 'bearer' })
-    vi.mocked(api.getToken).mockReturnValue('new-token')
     vi.mocked(api.getCurrentUser).mockResolvedValue(mockUser)
 
     await act(async () => {
@@ -175,7 +168,7 @@ describe('AuthContext', () => {
   })
 
   it('propagates register error to caller', async () => {
-    vi.mocked(api.getToken).mockReturnValue(null)
+    vi.mocked(api.getCurrentUser).mockRejectedValue(new Error('401'))
 
     const { result } = renderHook(() => useAuth(), {
       wrapper: AuthProvider,

--- a/frontend/tests/lib/api.test.ts
+++ b/frontend/tests/lib/api.test.ts
@@ -54,37 +54,8 @@ describe('ApiClient', () => {
     });
   });
 
-  describe('Token Management', () => {
-    it('reads token from localStorage on initialization', async () => {
-      localStorageMock.setItem('become_token', 'stored-token');
-      vi.resetModules();
-      const module = await import('@/lib/api');
-      expect(module.api.getToken()).toBe('stored-token');
-    });
-
-    it('setToken stores token in localStorage', () => {
-      api.setToken('new-token');
-      expect(localStorageMock.setItem).toHaveBeenCalledWith('become_token', 'new-token');
-      expect(api.getToken()).toBe('new-token');
-    });
-
-    it('setToken(null) removes token from localStorage', () => {
-      api.setToken('token');
-      api.setToken(null);
-      expect(localStorageMock.removeItem).toHaveBeenCalledWith('become_token');
-      expect(api.getToken()).toBeNull();
-    });
-
-    it('getToken returns current token', () => {
-      expect(api.getToken()).toBeNull();
-      api.setToken('my-token');
-      expect(api.getToken()).toBe('my-token');
-    });
-  });
-
   describe('Request Handling', () => {
-    it('adds Authorization header when token exists', async () => {
-      api.setToken('bearer-token');
+    it('sends credentials so the session cookie is included, without an Authorization header', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
@@ -95,25 +66,21 @@ describe('ApiClient', () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         expect.any(String),
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            Authorization: 'Bearer bearer-token',
-          }),
-        })
+        expect.objectContaining({ credentials: 'include' })
       );
-    });
-
-    it('omits Authorization header when no token', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve([]),
-      });
-
-      await api.getProjects();
-
       const [, options] = mockFetch.mock.calls[0];
       expect(options.headers.Authorization).toBeUndefined();
+    });
+
+    it('echoes the csrf_token cookie as X-CSRF-Token on mutating requests', async () => {
+      document.cookie = 'csrf_token=csrf-abc';
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 204 });
+
+      await api.deleteProject('1');
+
+      const [, options] = mockFetch.mock.calls[0];
+      expect((options.headers as Record<string, string>)['X-CSRF-Token']).toBe('csrf-abc');
+      document.cookie = 'csrf_token=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
     });
 
     it('handles successful JSON response', async () => {
@@ -124,7 +91,6 @@ describe('ApiClient', () => {
         json: () => Promise.resolve(userData),
       });
 
-      api.setToken('token');
       const result = await api.getCurrentUser();
       expect(result).toEqual(userData);
     });
@@ -135,7 +101,6 @@ describe('ApiClient', () => {
         status: 204,
       });
 
-      api.setToken('token');
       const result = await api.deleteProject('1');
       expect(result).toBeUndefined();
     });
@@ -147,7 +112,6 @@ describe('ApiClient', () => {
         json: () => Promise.resolve({ detail: 'Bad request message' }),
       });
 
-      api.setToken('token');
       await expect(api.getProjects()).rejects.toThrow('Bad request message');
     });
 
@@ -161,12 +125,10 @@ describe('ApiClient', () => {
           }),
       });
 
-      api.setToken('token');
       await expect(api.getProjects()).rejects.toThrow('Invalid email format');
     });
 
-    it('redirects to /login on 401 and clears token', async () => {
-      api.setToken('expired-token');
+    it('redirects to /login on 401', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 401,
@@ -174,7 +136,6 @@ describe('ApiClient', () => {
       });
 
       await expect(api.getProjects()).rejects.toThrow();
-      expect(api.getToken()).toBeNull();
       expect(window.location.href).toBe('/login');
     });
 
@@ -185,7 +146,6 @@ describe('ApiClient', () => {
         json: () => Promise.reject(new Error('Invalid JSON')),
       });
 
-      api.setToken('token');
       await expect(api.getProjects()).rejects.toThrow('An unexpected error occurred');
     });
 
@@ -196,7 +156,6 @@ describe('ApiClient', () => {
         json: () => Promise.resolve({ detail: 'Bad request' }),
       });
 
-      api.setToken('token');
       try {
         await api.getProjects();
         expect.fail('Expected HttpError to be thrown');
@@ -215,7 +174,6 @@ describe('ApiClient', () => {
         json: () => Promise.resolve({ detail: 'Forbidden' }),
       });
 
-      api.setToken('token');
       try {
         await api.getProjects();
         expect.fail('Expected HttpError to be thrown');
@@ -233,7 +191,6 @@ describe('ApiClient', () => {
         json: () => Promise.reject(new Error('Invalid JSON')),
       });
 
-      api.setToken('token');
       try {
         await api.getProjects();
         expect.fail('Expected HttpError to be thrown');
@@ -275,7 +232,7 @@ describe('ApiClient', () => {
       expect(result).toEqual(userData);
     });
 
-    it('login sends form-urlencoded POST and stores token', async () => {
+    it('login sends a form-urlencoded POST with credentials', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
@@ -288,11 +245,11 @@ describe('ApiClient', () => {
         expect.stringContaining('/auth/login'),
         expect.objectContaining({
           method: 'POST',
+          credentials: 'include',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         })
       );
       expect(result.access_token).toBe('new-token');
-      expect(api.getToken()).toBe('new-token');
     });
 
     it('login throws on invalid credentials', async () => {
@@ -305,18 +262,19 @@ describe('ApiClient', () => {
       await expect(api.login('wrong@example.com', 'wrong')).rejects.toThrow('Invalid credentials');
     });
 
-    it('logout clears token', () => {
-      api.setToken('token-to-clear');
-      api.logout();
-      expect(api.getToken()).toBeNull();
+    it('logout posts to /auth/logout to clear the server session', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 204 });
+
+      await api.logout();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/auth/logout'),
+        expect.objectContaining({ method: 'POST' })
+      );
     });
   });
 
   describe('User Endpoints', () => {
-    beforeEach(() => {
-      api.setToken('valid-token');
-    });
-
     it('getCurrentUser fetches /users/me', async () => {
       const user = { id: '1', email: 'me@example.com' };
       mockFetch.mockResolvedValueOnce({
@@ -399,7 +357,7 @@ describe('ApiClient', () => {
         expect.stringContaining('/users/me/photo'),
         expect.objectContaining({
           method: 'POST',
-          headers: { Authorization: 'Bearer valid-token' },
+          credentials: 'include',
         })
       );
       const [, options] = mockFetch.mock.calls[0];
@@ -422,10 +380,6 @@ describe('ApiClient', () => {
   });
 
   describe('Project Endpoints', () => {
-    beforeEach(() => {
-      api.setToken('valid-token');
-    });
-
     it('getProjects fetches /projects', async () => {
       const projects = [{ id: '1', name: 'Project 1' }];
       mockFetch.mockResolvedValueOnce({
@@ -523,7 +477,6 @@ describe('ApiClient', () => {
         status: 200,
         json: () => Promise.resolve([{ id: 'inv-1' }]),
       });
-      api.setToken('token');
       const result = await api.getProjectInvitations('proj-1');
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining('/projects/proj-1/invitations'),
@@ -534,10 +487,6 @@ describe('ApiClient', () => {
   });
 
   describe('Invitation Endpoints', () => {
-    beforeEach(() => {
-      api.setToken('valid-token');
-    });
-
     it('inviteExpert sends POST to /projects/:id/invite', async () => {
       const invitation = { id: 'inv-1', project_id: 'proj-1' };
       mockFetch.mockResolvedValueOnce({
@@ -606,10 +555,6 @@ describe('ApiClient', () => {
   });
 
   describe('Member Endpoints', () => {
-    beforeEach(() => {
-      api.setToken('valid-token');
-    });
-
     it('getMembers fetches /projects/:id/members', async () => {
       const members = [{ user_id: '1', role: 'admin' }];
       mockFetch.mockResolvedValueOnce({
@@ -663,10 +608,6 @@ describe('ApiClient', () => {
   });
 
   describe('Opinion Endpoints', () => {
-    beforeEach(() => {
-      api.setToken('valid-token');
-    });
-
     it('getOpinions fetches /projects/:id/opinions', async () => {
       const opinions = [{ id: 'op-1', lower_bound: 30 }];
       mockFetch.mockResolvedValueOnce({
@@ -724,10 +665,6 @@ describe('ApiClient', () => {
   });
 
   describe('Upload Photo Error Handling', () => {
-    beforeEach(() => {
-      api.setToken('valid-token');
-    });
-
     it('throws error on uploadPhoto 500 response', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
@@ -739,7 +676,7 @@ describe('ApiClient', () => {
       await expect(api.uploadPhoto(file)).rejects.toThrow('Server error');
     });
 
-    it('redirects to /login and clears token on uploadPhoto 401', async () => {
+    it('redirects to /login on uploadPhoto 401', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 401,
@@ -748,7 +685,6 @@ describe('ApiClient', () => {
 
       const file = new File(['test'], 'photo.jpg', { type: 'image/jpeg' });
       await expect(api.uploadPhoto(file)).rejects.toThrow();
-      expect(api.getToken()).toBeNull();
       expect(window.location.href).toBe('/login');
     });
 
@@ -764,7 +700,6 @@ describe('ApiClient', () => {
     });
 
     it('uses fallback message when uploadPhoto error has no detail', async () => {
-      api.setToken('token');
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 500,
@@ -775,8 +710,7 @@ describe('ApiClient', () => {
       await expect(api.uploadPhoto(file)).rejects.toThrow('Failed to upload photo');
     });
 
-    it('omits Authorization header when no token for uploadPhoto', async () => {
-      api.setToken(null);
+    it('uploadPhoto sends credentials and no Authorization header', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
@@ -787,15 +721,12 @@ describe('ApiClient', () => {
       await api.uploadPhoto(file);
 
       const [, options] = mockFetch.mock.calls[0];
+      expect(options.credentials).toBe('include');
       expect(options.headers['Authorization']).toBeUndefined();
     });
   });
 
   describe('Error Detail Edge Cases', () => {
-    beforeEach(() => {
-      api.setToken('valid-token');
-    });
-
     it('falls back to "Validation error" when detail is empty array', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
@@ -842,10 +773,6 @@ describe('ApiClient', () => {
   });
 
   describe('Results Endpoint', () => {
-    beforeEach(() => {
-      api.setToken('valid-token');
-    });
-
     it('getResult fetches /projects/:id/result', async () => {
       const result = { best_compromise: { lower: 30, peak: 50, upper: 70 } };
       mockFetch.mockResolvedValueOnce({
@@ -876,10 +803,6 @@ describe('ApiClient', () => {
   });
 
   describe('Result Export Endpoint', () => {
-    beforeEach(() => {
-      api.setToken('valid-token');
-    });
-
     it('fetches the export endpoint with format and lang query params', async () => {
       const blob = new Blob(['data'], { type: 'text/csv' });
       mockFetch.mockResolvedValueOnce({
@@ -892,9 +815,7 @@ describe('ApiClient', () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining('/projects/proj-1/result/export?format=csv&lang=cs'),
-        expect.objectContaining({
-          headers: expect.objectContaining({ Authorization: 'Bearer valid-token' }),
-        })
+        expect.objectContaining({ credentials: 'include' })
       );
       expect(result).toBe(blob);
     });
@@ -911,7 +832,7 @@ describe('ApiClient', () => {
       );
     });
 
-    it('redirects to /login and clears the token on 401', async () => {
+    it('redirects to /login on export 401', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 401,
@@ -919,7 +840,6 @@ describe('ApiClient', () => {
       });
 
       await expect(api.exportProjectResult('proj-1', 'pdf', 'en')).rejects.toThrow();
-      expect(api.getToken()).toBeNull();
       expect(window.location.href).toBe('/login');
     });
 
@@ -935,10 +855,6 @@ describe('ApiClient', () => {
   });
 
   describe('Request ID and Logging', () => {
-    beforeEach(() => {
-      api.setToken('valid-token');
-    });
-
     it('adds an X-Request-ID header to requests', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/frontend/tests/mocks/api.ts
+++ b/frontend/tests/mocks/api.ts
@@ -6,13 +6,10 @@ import { vi } from 'vitest';
  */
 export function createMockApi(overrides: Record<string, unknown> = {}) {
   return {
-    getToken: vi.fn().mockReturnValue(null),
-    setToken: vi.fn(),
-
     // Auth
     register: vi.fn().mockResolvedValue({ id: '1', email: 'test@example.com' }),
     login: vi.fn().mockResolvedValue({ access_token: 'mock-token', token_type: 'bearer' }),
-    logout: vi.fn(),
+    logout: vi.fn().mockResolvedValue(undefined),
 
     // Users
     getCurrentUser: vi.fn().mockResolvedValue(null),

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -31,14 +31,29 @@ def api_url():
     pytest.skip("API server not running at localhost:8000")
 
 
+class _HeaderOnlyClient(httpx.Client):
+    """httpx client that drops response cookies after each request.
+
+    The E2E suite authenticates with the Authorization header; discarding the session
+    cookies the app now sets keeps a valid ambient cookie from overriding a Bearer token
+    or tripping the CSRF check. A cookie-flow E2E test, if added, should use a plain
+    ``httpx.Client`` instead.
+    """
+
+    def request(self, *args, **kwargs):
+        response = super().request(*args, **kwargs)
+        self.cookies.clear()
+        return response
+
+
 @pytest.fixture
 def http_client(api_url):
-    """Create httpx client scoped to a single test.
+    """Create a header-auth httpx client scoped to a single test (cookies not retained).
 
     :param api_url: Base API URL from session fixture
     :return: httpx.Client instance
     """
-    with httpx.Client(base_url=api_url, timeout=10) as client:
+    with _HeaderOnlyClient(base_url=api_url, timeout=10) as client:
         yield client
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -74,6 +74,9 @@ def register_user(client: httpx.Client, email: str) -> str:
         data={"username": email, "password": DEFAULT_PASSWORD},
     )
     response.raise_for_status()
+    # Drop the session cookies the login set, so header-based tests authenticate purely
+    # via the returned token and no ambient cookie overrides an explicit Authorization.
+    client.cookies.clear()
     return response.json()["access_token"]
 
 
@@ -167,6 +170,9 @@ def register_user_with_name(
         data={"username": email, "password": DEFAULT_PASSWORD},
     )
     response.raise_for_status()
+    # Drop the session cookies the login set, so header-based tests authenticate purely
+    # via the returned token and no ambient cookie overrides an explicit Authorization.
+    client.cookies.clear()
     return response.json()["access_token"]
 
 

--- a/tests/integration/api/auth/test_auth.py
+++ b/tests/integration/api/auth/test_auth.py
@@ -998,13 +998,13 @@ class TestLogout:
 
 
 class TestCookieAuth:
-    """Login issues session cookies; the access cookie authenticates without a Bearer header."""
+    """Login issues session cookies; the cookie authenticates and CSRF guards mutations."""
 
     PASSWORD = "SecurePass123!"
 
-    def _register_and_login(self, client, email="cookie@example.com"):
+    def _register_and_login(self, cookie_client, email="cookie@example.com"):
         """Register a user and log in, leaving the session cookies in the client jar."""
-        client.post(
+        cookie_client.post(
             "/api/v1/auth/register",
             json={
                 "email": email,
@@ -1013,14 +1013,18 @@ class TestCookieAuth:
                 "last_name": "User",
             },
         )
-        return client.post(
+        return cookie_client.post(
             "/api/v1/auth/login",
             data={"username": email, "password": self.PASSWORD},
         )
 
-    def test_login_sets_httponly_session_cookies(self, client):
+    def _csrf_header(self, cookie_client):
+        """Echo the readable csrf_token cookie back as the X-CSRF-Token header."""
+        return {"X-CSRF-Token": cookie_client.cookies.get("csrf_token")}
+
+    def test_login_sets_httponly_session_cookies(self, cookie_client):
         """Login sets access/refresh/csrf cookies; token cookies are HttpOnly + SameSite=Strict."""
-        resp = self._register_and_login(client)
+        resp = self._register_and_login(cookie_client)
 
         assert resp.status_code == 200
         assert "access_token" in resp.cookies
@@ -1030,21 +1034,52 @@ class TestCookieAuth:
         assert "httponly" in raw
         assert "samesite=strict" in raw
 
-    def test_access_cookie_authenticates_without_bearer(self, client):
+    def test_access_cookie_authenticates_without_bearer(self, cookie_client):
         """A request carrying only the session cookie (no Authorization header) authenticates."""
-        self._register_and_login(client)  # the client jar now holds the session cookies
+        self._register_and_login(cookie_client)  # the jar now holds the session cookies
 
-        resp = client.get("/api/v1/auth/me")
+        resp = cookie_client.get("/api/v1/auth/me")
 
         assert resp.status_code == 200
         assert resp.json()["email"] == "cookie@example.com"
 
-    def test_logout_clears_cookies(self, client):
-        """Logout instructs the browser to delete the session cookies."""
-        self._register_and_login(client)  # authenticated via the ambient cookie
+    def test_logout_with_csrf_clears_cookies(self, cookie_client):
+        """A logout carrying the CSRF header succeeds and clears the session cookies."""
+        self._register_and_login(cookie_client)
 
-        resp = client.post("/api/v1/auth/logout")
+        resp = cookie_client.post("/api/v1/auth/logout", headers=self._csrf_header(cookie_client))
 
         assert resp.status_code == 204
         raw = " ".join(resp.headers.get_list("set-cookie")).lower()
         assert "access_token=" in raw
+
+    def test_cookie_mutation_without_csrf_header_is_rejected(self, cookie_client):
+        """A cookie-authenticated mutation without the CSRF header is rejected with 403."""
+        self._register_and_login(cookie_client)
+
+        resp = cookie_client.post("/api/v1/auth/logout")
+
+        assert resp.status_code == 403
+
+    def test_cookie_mutation_with_wrong_csrf_header_is_rejected(self, cookie_client):
+        """A cookie-authenticated mutation with a mismatched CSRF token is rejected with 403."""
+        self._register_and_login(cookie_client)
+
+        resp = cookie_client.post("/api/v1/auth/logout", headers={"X-CSRF-Token": "wrong"})
+
+        assert resp.status_code == 403
+
+    def test_refresh_via_cookie_without_body(self, cookie_client):
+        """The SPA refreshes using only the refresh cookie (no body) plus the CSRF header."""
+        self._register_and_login(cookie_client)
+
+        resp = cookie_client.post("/api/v1/auth/refresh", headers=self._csrf_header(cookie_client))
+
+        assert resp.status_code == 200
+        assert resp.json()["access_token"]
+
+    def test_refresh_without_cookie_or_body_is_unauthorized(self, client):
+        """A refresh with neither the refresh cookie nor a body token is rejected with 401."""
+        resp = client.post("/api/v1/auth/refresh")
+
+        assert resp.status_code == 401

--- a/tests/integration/api/auth/test_auth.py
+++ b/tests/integration/api/auth/test_auth.py
@@ -995,3 +995,56 @@ class TestLogout:
             json={"refresh_token": refresh_token},
         )
         assert refresh_response.status_code == 401
+
+
+class TestCookieAuth:
+    """Login issues session cookies; the access cookie authenticates without a Bearer header."""
+
+    PASSWORD = "SecurePass123!"
+
+    def _register_and_login(self, client, email="cookie@example.com"):
+        """Register a user and log in, leaving the session cookies in the client jar."""
+        client.post(
+            "/api/v1/auth/register",
+            json={
+                "email": email,
+                "password": self.PASSWORD,
+                "first_name": "Cookie",
+                "last_name": "User",
+            },
+        )
+        return client.post(
+            "/api/v1/auth/login",
+            data={"username": email, "password": self.PASSWORD},
+        )
+
+    def test_login_sets_httponly_session_cookies(self, client):
+        """Login sets access/refresh/csrf cookies; token cookies are HttpOnly + SameSite=Strict."""
+        resp = self._register_and_login(client)
+
+        assert resp.status_code == 200
+        assert "access_token" in resp.cookies
+        assert "refresh_token" in resp.cookies
+        assert "csrf_token" in resp.cookies
+        raw = " ".join(resp.headers.get_list("set-cookie")).lower()
+        assert "httponly" in raw
+        assert "samesite=strict" in raw
+
+    def test_access_cookie_authenticates_without_bearer(self, client):
+        """A request carrying only the session cookie (no Authorization header) authenticates."""
+        self._register_and_login(client)  # the client jar now holds the session cookies
+
+        resp = client.get("/api/v1/auth/me")
+
+        assert resp.status_code == 200
+        assert resp.json()["email"] == "cookie@example.com"
+
+    def test_logout_clears_cookies(self, client):
+        """Logout instructs the browser to delete the session cookies."""
+        self._register_and_login(client)  # authenticated via the ambient cookie
+
+        resp = client.post("/api/v1/auth/logout")
+
+        assert resp.status_code == 204
+        raw = " ".join(resp.headers.get_list("set-cookie")).lower()
+        assert "access_token=" in raw

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -26,6 +26,7 @@ from api.db.models import (  # noqa: F401 - models required for SQLModel.metadat
     User,
 )
 from api.db.session import get_session
+from api.middleware.csrf import CSRFMiddleware
 from api.middleware.exception_handlers import register_exception_handlers
 from api.middleware.rate_limit import limiter
 from api.routes import auth, calculate, health, invitations, opinions, projects, users
@@ -50,6 +51,9 @@ def create_test_app() -> FastAPI:
     # Rate limiting setup (required for auth routes)
     app.state.limiter = limiter
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[arg-type]
+
+    # CSRF double-submit guard (dormant unless the request carries the csrf_token cookie).
+    app.add_middleware(CSRFMiddleware)
 
     # Register exception handlers (OCP: centralized error handling)
     register_exception_handlers(app)
@@ -182,9 +186,39 @@ def _reset_auth_throttles():
     get_reset_email_throttle.cache_clear()
 
 
+class _HeaderOnlyClient(TestClient):
+    """Test client that discards response cookies after each request.
+
+    Existing tests authenticate with an explicit Authorization header. Dropping the
+    session cookies the app now sets keeps them isolated from cookie/CSRF behaviour: no
+    ambient cookie overrides the header, and the CSRF check stays dormant. The cookie and
+    CSRF flow is exercised through the plain ``cookie_client`` fixture instead.
+    """
+
+    def request(self, *args, **kwargs):
+        response = super().request(*args, **kwargs)
+        self.cookies.clear()
+        return response
+
+
 @pytest.fixture
 def client(test_engine):
-    """Create test client with in-memory database."""
+    """Create a header-auth test client (session cookies are not retained)."""
+    test_app = create_test_app()
+
+    def override_get_session():
+        with Session(test_engine) as session:
+            yield session
+
+    test_app.dependency_overrides[get_session] = override_get_session
+
+    with _HeaderOnlyClient(test_app) as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def cookie_client(test_engine):
+    """Create a cookie-retaining test client for the cookie + CSRF session flow."""
     test_app = create_test_app()
 
     def override_get_session():
@@ -214,5 +248,5 @@ def client_with_session(test_engine):
 
         test_app.dependency_overrides[get_session] = override_get_session
 
-        with TestClient(test_app) as test_client:
+        with _HeaderOnlyClient(test_app) as test_client:
             yield test_client, session

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -84,6 +84,10 @@ def register_and_login(client: TestClient, email: str = "test@example.com") -> s
         "/api/v1/auth/login",
         data={"username": email, "password": DEFAULT_TEST_PASSWORD},
     )
+    # Drop the session cookies the login set, so header-based tests authenticate purely
+    # via the returned token; otherwise an ambient cookie would override an explicit
+    # Authorization header (e.g. a later login as another user).
+    client.cookies.clear()
     return response.json()["access_token"]
 
 

--- a/tests/unit/api/auth/test_cookies.py
+++ b/tests/unit/api/auth/test_cookies.py
@@ -1,0 +1,34 @@
+"""Tests for the auth-cookie Secure-flag policy."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from api.auth import cookies
+from api.config import Environment
+
+
+def _request(scheme: str) -> MagicMock:
+    """Build a stand-in request whose only relevant attribute is the URL scheme."""
+    return MagicMock(url=SimpleNamespace(scheme=scheme))
+
+
+class TestCookiesSecure:
+    """cookies_secure is on in production and otherwise follows the request scheme."""
+
+    def test_secure_in_production_regardless_of_scheme(self):
+        with patch.object(
+            cookies, "get_settings", return_value=SimpleNamespace(environment=Environment.PROD)
+        ):
+            assert cookies.cookies_secure(_request("http")) is True
+
+    def test_not_secure_over_http_outside_production(self):
+        with patch.object(
+            cookies, "get_settings", return_value=SimpleNamespace(environment=Environment.TEST)
+        ):
+            assert cookies.cookies_secure(_request("http")) is False
+
+    def test_secure_over_https_outside_production(self):
+        with patch.object(
+            cookies, "get_settings", return_value=SimpleNamespace(environment=Environment.DEV)
+        ):
+            assert cookies.cookies_secure(_request("https")) is True


### PR DESCRIPTION
## Summary

Moves session auth from a JS-readable bearer token in `localStorage` to `Secure; HttpOnly; SameSite=Strict` cookies plus a double-submit CSRF check, so an access token can no longer be stolen via XSS. The backend keeps the `Authorization: Bearer` path as a fallback for programmatic clients and the test suite, so `/api/v1` stays backward compatible. No DB schema change.

## Backend

- Login and refresh set the access and refresh tokens as HttpOnly cookies (the refresh cookie is scoped to `/api/v1/auth`) plus a readable `csrf_token` cookie; logout clears them. The tokens are still returned in the response body.
- Token extraction is cookie-first with a Bearer-header fallback (`api/auth/cookies.py`, `api/auth/dependencies.py`).
- `CSRFMiddleware` (double-submit): a cookie-authenticated mutating request (POST/PUT/PATCH/DELETE) must send an `X-CSRF-Token` header matching the `csrf_token` cookie, else 403. Bearer-header clients and safe methods are exempt; `SameSite=Strict` already blocks cross-site sends, so this is defense-in-depth.
- `/auth/refresh` reads the refresh token from the cookie (which the SPA cannot read into a body) or the request body.
- `X-CSRF-Token` added to the CORS `allow_headers`.

## Frontend

- `api.ts`: `credentials: 'include'` on every request; the token is no longer kept in `localStorage`; the `csrf_token` cookie is echoed as `X-CSRF-Token` on mutations; `logout()` calls the server to revoke the session and clear the cookies.
- `AuthContext`: the mount-time session probe hits `/users/me` over the cookie and stays silent on 401, so an anonymous visitor on a public page is not bounced to login; `logout` is async.

## Testing

- Backend: full suite passes; the new `api/auth/cookies.py` and `api/middleware/csrf.py` are covered 100%. Covers cookie login, CSRF rejection (missing/mismatched token -> 403), cookie-only refresh, and the surviving Bearer fallback.
- Frontend: vitest and eslint pass; the api-client and `AuthContext` tests were rewritten for the cookie model.

## Migrations

None -- cookies and CSRF are stateless; nothing touches the database schema.

## Not in this PR

The browser e2e (Playwright) cookie/CSRF walkthrough -- the behaviour is covered by backend integration tests plus frontend unit tests, and the e2e pass can follow.
