### PR TITLE
feat: guided account erasure with owned-project handover

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -268,14 +268,14 @@
         "filename": "frontend/tests/pages/Profile.test.tsx",
         "hashed_secret": "813ab7bae6589d4b36cb7450559baac29add9e19",
         "is_verified": false,
-        "line_number": 210
+        "line_number": 213
       },
       {
         "type": "Secret Keyword",
         "filename": "frontend/tests/pages/Profile.test.tsx",
         "hashed_secret": "3d2ce02098f0ef75d0c680ff6e4d9a478d6c1c8f",
         "is_verified": false,
-        "line_number": 211
+        "line_number": 214
       }
     ],
     "scripts/ci/e2e-local.sh": [
@@ -600,7 +600,7 @@
         "filename": "tests/integration/api/routes/test_users.py",
         "hashed_secret": "4d81c30a1e76bc8adbbb6af9fc64162241e13f34",
         "is_verified": false,
-        "line_number": 135
+        "line_number": 272
       }
     ],
     "tests/shared/helpers.py": [
@@ -990,5 +990,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-04T21:51:01Z"
+  "generated_at": "2026-07-05T09:39:23Z"
 }

--- a/api/README.md
+++ b/api/README.md
@@ -98,7 +98,21 @@ and logout revokes the session and clears the cookies.
 | PUT | `/api/v1/users/me/password` | Change password |
 | POST | `/api/v1/users/me/photo` | Upload photo |
 | DELETE | `/api/v1/users/me/photo` | Delete photo |
-| DELETE | `/api/v1/users/me` | Delete account (409 while you still admin any project) |
+| DELETE | `/api/v1/users/me` | Delete account, handling each owned project (GDPR Art. 17) |
+
+Deleting the account (`DELETE /api/v1/users/me`) accepts an optional body that says what
+to do with every project the user still admins -- `transfer` it to another member or
+`delete` it -- so erasure never silently drops other experts' contributions:
+
+```json
+{ "project_dispositions": [
+  { "project_id": "<uuid>", "action": "transfer", "new_admin_id": "<member-uuid>" },
+  { "project_id": "<uuid>", "action": "delete" }
+] }
+```
+
+An owned project left without a disposition returns `409`; a transfer to a non-member
+returns `422`. The profile photo blob is removed from object storage as part of erasure.
 
 ### Projects
 

--- a/api/exceptions.py
+++ b/api/exceptions.py
@@ -48,6 +48,10 @@ class AccountHasOwnedProjectsError(BeCoMeAPIError):
     """Raised when account deletion is blocked because the user still owns projects."""
 
 
+class InvalidProjectDispositionError(ValidationError):
+    """Raised when an account-deletion project disposition is invalid (bad transfer target)."""
+
+
 # Project-related exceptions
 class ProjectNotFoundError(NotFoundError):
     """Raised when project is not found."""

--- a/api/middleware/csrf.py
+++ b/api/middleware/csrf.py
@@ -2,7 +2,9 @@
 
 The check is enforced only when the request carries the readable ``csrf_token`` cookie,
 i.e. a cookie-based browser client. Programmatic clients that authenticate with a Bearer
-header (and requests made before login) send no such cookie and are unaffected.
+header send no such cookie and are unaffected. Pre-session auth endpoints (login,
+register, refresh, password reset) are always exempt, so a stale cookie left by a revoked
+session (e.g. after a password change) cannot block re-authentication.
 
 ``SameSite=Strict`` already stops the session cookies from being sent on cross-site
 requests; this double-submit check is defense-in-depth: an attacker who cannot read the
@@ -22,6 +24,18 @@ from api.auth.cookies import CSRF_COOKIE, CSRF_HEADER
 # working, since a cross-origin preflight carries no cookies or custom headers).
 _SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
 
+# Pre-session auth endpoints must work without a CSRF token: a client can hold a stale
+# ``csrf_token`` cookie from a revoked session, and these requests establish or refresh a
+# session rather than act on one. Logout is excluded -- it acts on a live session and the
+# browser client sends the matching token.
+_AUTH_PREFIX = "/api/v1/auth/"
+_CSRF_PROTECTED_AUTH_PATHS = frozenset({"/api/v1/auth/logout"})
+
+
+def _csrf_exempt(path: str) -> bool:
+    """Return whether a path is a pre-session auth endpoint exempt from the CSRF check."""
+    return path.startswith(_AUTH_PREFIX) and path not in _CSRF_PROTECTED_AUTH_PATHS
+
 
 class CSRFMiddleware(BaseHTTPMiddleware):
     """Reject cookie-authenticated mutating requests that lack a matching CSRF token."""
@@ -34,7 +48,7 @@ class CSRFMiddleware(BaseHTTPMiddleware):
         :return: A 403 response when the CSRF token is missing or wrong, else the
             downstream response.
         """
-        if request.method not in _SAFE_METHODS:
+        if request.method not in _SAFE_METHODS and not _csrf_exempt(request.url.path):
             cookie = request.cookies.get(CSRF_COOKIE)
             if cookie is not None:
                 header = request.headers.get(CSRF_HEADER)

--- a/api/routes/users.py
+++ b/api/routes/users.py
@@ -10,13 +10,15 @@ from fastapi import APIRouter, Depends, File, HTTPException, Request, Response, 
 from api.auth.dependencies import CurrentUser
 from api.auth.logging import log_account_deletion, log_data_export, log_password_change
 from api.auth.revocation_store import RevocationStore, get_revocation_store
+from api.db.models import Project
 from api.dependencies import (
     get_data_export_service,
+    get_project_membership_service,
     get_project_service,
     get_storage_service,
     get_user_service,
 )
-from api.exceptions import AccountHasOwnedProjectsError
+from api.exceptions import AccountHasOwnedProjectsError, InvalidProjectDispositionError
 from api.middleware.rate_limit import (
     LIMIT_PHOTO,
     LIMIT_PWD_RESET,
@@ -24,9 +26,15 @@ from api.middleware.rate_limit import (
     LIMIT_UPLOAD,
     limiter,
 )
-from api.schemas.auth import ChangePasswordRequest, UpdateUserRequest, UserResponse
+from api.schemas.auth import (
+    ChangePasswordRequest,
+    DeleteAccountRequest,
+    UpdateUserRequest,
+    UserResponse,
+)
 from api.schemas.data_export import DataExportResponse
 from api.services.data_export_service import DataExportService
+from api.services.project_membership_service import ProjectMembershipService
 from api.services.project_service import ProjectService
 from api.services.storage import validation
 from api.services.storage.base import StorageService
@@ -139,24 +147,61 @@ def delete_current_user(
     current_user: CurrentUser,
     service: Annotated[UserService, Depends(get_user_service)],
     project_service: Annotated[ProjectService, Depends(get_project_service)],
+    membership_service: Annotated[
+        ProjectMembershipService, Depends(get_project_membership_service)
+    ],
     storage_service: Annotated[StorageService | None, Depends(get_storage_service)],
+    data: DeleteAccountRequest | None = None,
 ) -> None:
-    """Delete the authenticated user's account.
+    """Delete the authenticated user's account (GDPR Article 17, right to erasure).
 
-    Rejected with 409 while the user is the admin of any project, so erasure never
-    silently cascades away other experts' contributions; the user must transfer
-    ownership or delete those projects first. The profile photo blob is removed from
-    object storage as well, so erasure also covers stored media (GDPR Article 17).
+    Every project the user still admins must be handled first via ``data``: transfer it
+    to another member, or delete it (its opinions and invitations cascade away). This
+    keeps erasure from silently destroying other experts' contributions while still
+    letting the user leave. The profile photo blob is removed from object storage too.
 
     :param request: FastAPI request (for logging)
     :param current_user: User from JWT token
     :param service: User service
-    :param project_service: Project service for the ownership check
+    :param project_service: Project service (ownership handling)
+    :param membership_service: Membership service (validates transfer targets)
     :param storage_service: Storage service (None when not configured)
-    :raises AccountHasOwnedProjectsError: If the user still admins a project
+    :param data: Per-owned-project dispositions (transfer or delete)
+    :raises AccountHasOwnedProjectsError: If an owned project has no disposition
+    :raises InvalidProjectDispositionError: If a transfer target is not another member
     """
-    if project_service.get_owned_projects(current_user.id):
-        raise AccountHasOwnedProjectsError("Account still owns one or more projects.")
+    dispositions = data.project_dispositions if data else []
+    owned_by_id = {p.id: p for p in project_service.get_owned_projects(current_user.id)}
+
+    # Each owned project must be handled exactly once; no disposition may name a project
+    # the user does not own.
+    if {d.project_id for d in dispositions} != set(owned_by_id) or len(dispositions) != len(
+        owned_by_id
+    ):
+        raise AccountHasOwnedProjectsError(
+            "Provide a disposition (transfer or delete) for each project you own."
+        )
+
+    # Validate everything before mutating anything, so a bad disposition cannot leave the
+    # account half-erased.
+    transfers: list[tuple[Project, UUID]] = []
+    deletes: list[UUID] = []
+    for d in dispositions:
+        if d.action == "delete":
+            deletes.append(d.project_id)
+        elif d.new_admin_id is None or d.new_admin_id == current_user.id:
+            raise InvalidProjectDispositionError(
+                "A transfer must name another member as the new admin."
+            )
+        elif not membership_service.is_member(d.project_id, d.new_admin_id):
+            raise InvalidProjectDispositionError("The new admin must be a member of the project.")
+        else:
+            transfers.append((owned_by_id[d.project_id], d.new_admin_id))
+
+    for project, new_admin_id in transfers:
+        project_service.transfer_ownership(project, new_admin_id)
+    for project_id in deletes:
+        project_service.delete_project(project_id)
 
     user_id = current_user.id
     email = current_user.email

--- a/api/schemas/auth.py
+++ b/api/schemas/auth.py
@@ -1,7 +1,8 @@
 """Authentication schemas."""
 
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
+from uuid import UUID
 
 import regex
 from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
@@ -194,3 +195,23 @@ class ResetPasswordRequest(BaseModel):
     def password_strength(cls, v: str) -> str:
         """Validate password strength."""
         return validate_password_strength(v)
+
+
+class ProjectDisposition(BaseModel):
+    """How to handle one project the departing user still owns (GDPR Art. 17)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    project_id: UUID
+    action: Literal["transfer", "delete"]
+    new_admin_id: UUID | None = Field(
+        None, description="Member to promote to admin; required when action is 'transfer'"
+    )
+
+
+class DeleteAccountRequest(BaseModel):
+    """Account-deletion payload: a disposition for each project the user still owns."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    project_dispositions: list[ProjectDisposition] = Field(default_factory=list)

--- a/frontend/e2e/profile-flow.spec.ts
+++ b/frontend/e2e/profile-flow.spec.ts
@@ -69,8 +69,10 @@ test.describe.serial('Profile Page Flow', () => {
     await expect(dialog).toBeVisible();
     await expect(dialog.getByText('Delete Account?')).toBeVisible();
 
-    // Confirm deletion
-    await dialog.getByRole('button', { name: 'Delete My Account' }).click();
+    // Confirm deletion (wait for the dialog to finish loading owned projects)
+    const confirmButton = dialog.getByRole('button', { name: 'Delete My Account' });
+    await expect(confirmButton).toBeEnabled();
+    await confirmButton.click();
 
     // Redirected to login page after account deletion
     await expect(page).toHaveURL('/login', { timeout: 10000 });

--- a/frontend/e2e/profile-flow.spec.ts
+++ b/frontend/e2e/profile-flow.spec.ts
@@ -61,6 +61,16 @@ test.describe.serial('Profile Page Flow', () => {
   });
 
   test('delete account redirects to home', async () => {
+    // The password change above revoked the session, so log back in for a clean flow --
+    // the deletion dialog loads the owned projects and needs a live session.
+    await page.goto('/login');
+    await page.getByPlaceholder('you@example.com').fill(testEmail);
+    await page.getByPlaceholder('Enter your password').fill(NEW_PASSWORD);
+    await page.getByRole('button', { name: /sign in/i }).click();
+    await expect(page).toHaveURL('/projects', { timeout: 15000 });
+
+    await page.goto('/profile');
+
     // Click delete button in Danger Zone
     await page.getByRole('button', { name: 'Delete Account' }).click();
 
@@ -74,7 +84,7 @@ test.describe.serial('Profile Page Flow', () => {
     await expect(confirmButton).toBeEnabled();
     await confirmButton.click();
 
-    // Redirected to login page after account deletion
-    await expect(page).toHaveURL('/login', { timeout: 10000 });
+    // After erasure the user is logged out and returned to the public landing page.
+    await expect(page).toHaveURL(/\/(login)?$/, { timeout: 10000 });
   });
 });

--- a/frontend/src/components/modals/DeleteAccountDialog.tsx
+++ b/frontend/src/components/modals/DeleteAccountDialog.tsx
@@ -1,0 +1,193 @@
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { AlertTriangle, Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/forms";
+import { api } from "@/lib/api";
+import { logger } from "@/lib/logger";
+import type { Member, ProjectDisposition, ProjectWithRole } from "@/types/api";
+
+const DELETE_VALUE = "delete";
+const TRANSFER_PREFIX = "transfer:";
+
+interface DeleteAccountDialogProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly currentUserId: string;
+  readonly onConfirmed: () => Promise<void>;
+}
+
+/**
+ * Account-deletion dialog. Each project the user still owns must be handled first:
+ * deleted, or transferred to another member (GDPR Art. 17 right to erasure).
+ */
+export function DeleteAccountDialog({
+  open,
+  onOpenChange,
+  currentUserId,
+  onConfirmed,
+}: DeleteAccountDialogProps) {
+  const { t } = useTranslation("profile");
+  const { t: tCommon } = useTranslation("common");
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [ownedProjects, setOwnedProjects] = useState<ProjectWithRole[]>([]);
+  const [membersByProject, setMembersByProject] = useState<Record<string, Member[]>>({});
+  const [choices, setChoices] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  const loadOwnedProjects = useCallback(async () => {
+    setLoading(true);
+    setLoadError(false);
+    try {
+      const projects = await api.getProjects();
+      const owned = projects.filter((p) => p.role === "admin");
+      const entries = await Promise.all(
+        owned.map(
+          async (p) =>
+            [p.id, (await api.getMembers(p.id)).filter((m) => m.user_id !== currentUserId)] as const
+        )
+      );
+      setOwnedProjects(owned);
+      setMembersByProject(Object.fromEntries(entries));
+    } catch (err) {
+      logger.error("Failed to load owned projects for deletion", { error: String(err) });
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [currentUserId]);
+
+  useEffect(() => {
+    if (!open) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- load owned projects on open
+    loadOwnedProjects();
+  }, [open, loadOwnedProjects]);
+
+  const choiceFor = (id: string) => choices[id] ?? DELETE_VALUE;
+
+  const buildDispositions = (): ProjectDisposition[] =>
+    ownedProjects.map((p) => {
+      const choice = choiceFor(p.id);
+      if (choice.startsWith(TRANSFER_PREFIX)) {
+        return {
+          project_id: p.id,
+          action: "transfer",
+          new_admin_id: choice.slice(TRANSFER_PREFIX.length),
+        };
+      }
+      return { project_id: p.id, action: "delete" };
+    });
+
+  const handleConfirm = async () => {
+    setSubmitting(true);
+    setFailed(false);
+    try {
+      await api.deleteAccount(buildDispositions());
+      await onConfirmed();
+    } catch (err) {
+      logger.error("Account deletion failed", { error: String(err) });
+      setFailed(true);
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-destructive">
+            <AlertTriangle className="h-5 w-5" />
+            {t("deleteModal.title")}
+          </DialogTitle>
+          <DialogDescription className="text-muted-foreground">
+            {ownedProjects.length > 0 ? t("deleteAccount.ownedIntro") : t("deleteModal.description")}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="py-2">
+          {loading ? (
+            <div
+              className="flex justify-center py-6"
+              role="status"
+              aria-label={tCommon("aria.loading")}
+            >
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : (
+            <>
+              {ownedProjects.length > 0 && (
+                <div className="space-y-3 mb-4">
+                  {ownedProjects.map((p) => (
+                    <div key={p.id} className="flex items-center justify-between gap-3">
+                      <span className="text-sm font-medium truncate">{p.name}</span>
+                      <Select
+                        value={choiceFor(p.id)}
+                        onValueChange={(v) => setChoices((c) => ({ ...c, [p.id]: v }))}
+                      >
+                        <SelectTrigger className="w-56 shrink-0">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value={DELETE_VALUE}>
+                            {t("deleteAccount.deleteProject")}
+                          </SelectItem>
+                          {(membersByProject[p.id] ?? []).map((m) => (
+                            <SelectItem key={m.user_id} value={`${TRANSFER_PREFIX}${m.user_id}`}>
+                              {t("deleteAccount.transferTo", {
+                                name: `${m.first_name} ${m.last_name ?? ""}`.trim(),
+                              })}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  ))}
+                </div>
+              )}
+              <p className="text-sm font-medium text-destructive">
+                {t("deleteModal.details.noUndo")}
+              </p>
+              {(loadError || failed) && (
+                <p className="text-sm text-destructive mt-2" role="alert">
+                  {loadError ? t("deleteAccount.loadFailed") : t("deleteAccount.failed")}
+                </p>
+              )}
+            </>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-3">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            {tCommon("cancel")}
+          </Button>
+          <SubmitButton
+            type="button"
+            variant="destructive"
+            onClick={handleConfirm}
+            isLoading={submitting}
+            disabled={loading || loadError}
+            loadingText={t("deleteModal.deleting")}
+          >
+            {t("deleteModal.confirm")}
+          </SubmitButton>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/i18n/locales/cs/profile.json
+++ b/frontend/src/i18n/locales/cs/profile.json
@@ -37,6 +37,13 @@
     "confirm": "Smazat můj účet",
     "deleting": "Mazání..."
   },
+  "deleteAccount": {
+    "ownedIntro": "Stále vlastníte níže uvedené projekty. Před smazáním účtu zvolte, co se s každým z nich stane.",
+    "deleteProject": "Smazat tento projekt",
+    "transferTo": "Převést na {{name}}",
+    "loadFailed": "Vaše projekty se nepodařilo načíst. Zkuste to prosím znovu.",
+    "failed": "Smazání účtu se nepodařilo. Zkuste to prosím znovu."
+  },
   "photo": {
     "label": "Profilová fotka",
     "upload": "Nahrát fotku",

--- a/frontend/src/i18n/locales/en/profile.json
+++ b/frontend/src/i18n/locales/en/profile.json
@@ -37,6 +37,13 @@
     "confirm": "Delete My Account",
     "deleting": "Deleting..."
   },
+  "deleteAccount": {
+    "ownedIntro": "You still own the projects below. Choose what happens to each one before your account is deleted.",
+    "deleteProject": "Delete this project",
+    "transferTo": "Transfer to {{name}}",
+    "loadFailed": "Could not load your projects. Please try again.",
+    "failed": "Account deletion failed. Please try again."
+  },
   "photo": {
     "label": "Profile photo",
     "upload": "Upload photo",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8,6 +8,7 @@ import {
   Invitation,
   Member,
   ProjectInvitation,
+  ProjectDisposition,
   CreateProjectInput,
   UpdateProjectInput,
   CreateOpinionInput,
@@ -177,9 +178,10 @@ class ApiClient {
     });
   }
 
-  async deleteAccount(): Promise<void> {
+  async deleteAccount(dispositions: ProjectDisposition[] = []): Promise<void> {
     return this.request<void>('/users/me', {
       method: 'DELETE',
+      body: JSON.stringify({ project_dispositions: dispositions }),
     });
   }
 

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -10,10 +10,10 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Navbar } from "@/components/layout/Navbar";
-import { DeleteConfirmModal } from "@/components/modals/DeleteConfirmModal";
+import { DeleteAccountDialog } from "@/components/modals/DeleteAccountDialog";
 import { ValidationChecklist } from "@/components/forms";
 import { useAuth } from "@/contexts/AuthContext";
-import { api, HttpError } from "@/lib/api";
+import { api } from "@/lib/api";
 import { downloadJson } from "@/lib/download";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
@@ -217,25 +217,10 @@ const Profile = () => {
     }
   };
 
-  const handleDeleteAccount = async () => {
-    try {
-      await api.deleteAccount();
-      await logout();
-      navigate("/");
-      toast({ title: t("toast.accountDeleted") });
-    } catch (error) {
-      const description =
-        error instanceof HttpError && error.status === 409
-          ? t("dangerZone.ownsProjects")
-          : error instanceof Error
-            ? error.message
-            : t("toast.deleteFailed");
-      toast({
-        title: t("toast.error"),
-        description,
-        variant: "destructive",
-      });
-    }
+  const handleAccountDeleted = async () => {
+    await logout();
+    navigate("/");
+    toast({ title: t("toast.accountDeleted") });
   };
 
   if (!user) {
@@ -478,19 +463,11 @@ const Profile = () => {
         </motion.div>
       </main>
 
-      <DeleteConfirmModal
+      <DeleteAccountDialog
         open={deleteModalOpen}
         onOpenChange={setDeleteModalOpen}
-        title={t("deleteModal.title")}
-        description={t("deleteModal.description")}
-        details={[
-          t("deleteModal.details.projects"),
-          t("deleteModal.details.opinions"),
-          t("deleteModal.details.noUndo"),
-        ]}
-        onConfirm={handleDeleteAccount}
-        confirmText={t("deleteModal.confirm")}
-        loadingText={t("deleteModal.deleting")}
+        currentUserId={user.id}
+        onConfirmed={handleAccountDeleted}
       />
     </div>
   );

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -95,6 +95,12 @@ export interface ProjectWithRole extends Project {
   role: 'admin' | 'expert';
 }
 
+export interface ProjectDisposition {
+  project_id: string;
+  action: 'transfer' | 'delete';
+  new_admin_id?: string;
+}
+
 export interface CreateProjectInput {
   name: string;
   description?: string;

--- a/frontend/tests/components/DeleteAccountDialog.test.tsx
+++ b/frontend/tests/components/DeleteAccountDialog.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '@tests/utils';
+import { DeleteAccountDialog } from '@/components/modals/DeleteAccountDialog';
+import type { Member, ProjectWithRole } from '@/types/api';
+
+const mockApi = {
+  getProjects: vi.fn(),
+  getMembers: vi.fn(),
+  deleteAccount: vi.fn(),
+};
+vi.mock('@/lib/api', () => ({
+  api: {
+    getProjects: () => mockApi.getProjects(),
+    getMembers: (id: string) => mockApi.getMembers(id),
+    deleteAccount: (dispositions: unknown) => mockApi.deleteAccount(dispositions),
+  },
+}));
+
+const CURRENT_USER_ID = 'owner-1';
+
+function ownedProject(overrides: Partial<ProjectWithRole> = {}): ProjectWithRole {
+  return {
+    id: 'proj-1',
+    name: 'Owned Project',
+    description: null,
+    scale_min: 0,
+    scale_max: 100,
+    scale_unit: '',
+    admin_id: CURRENT_USER_ID,
+    created_at: '2026-01-01T00:00:00Z',
+    member_count: 2,
+    role: 'admin',
+    ...overrides,
+  };
+}
+
+function member(overrides: Partial<Member> = {}): Member {
+  return {
+    user_id: 'member-1',
+    email: 'jane@example.com',
+    first_name: 'Jane',
+    last_name: 'Roe',
+    photo_url: null,
+    role: 'expert',
+    joined_at: '2026-01-02T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderDialog(onConfirmed = vi.fn().mockResolvedValue(undefined)) {
+  render(
+    <DeleteAccountDialog
+      open
+      onOpenChange={vi.fn()}
+      currentUserId={CURRENT_USER_ID}
+      onConfirmed={onConfirmed}
+    />
+  );
+  return { onConfirmed };
+}
+
+describe('DeleteAccountDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.getProjects.mockResolvedValue([]);
+    mockApi.getMembers.mockResolvedValue([]);
+    mockApi.deleteAccount.mockResolvedValue(undefined);
+  });
+
+  it('deletes with no dispositions when the user owns nothing', async () => {
+    const user = userEvent.setup();
+    const { onConfirmed } = renderDialog();
+
+    const confirm = await screen.findByRole('button', { name: 'Delete My Account' });
+    await waitFor(() => expect(confirm).toBeEnabled());
+    await user.click(confirm);
+
+    await waitFor(() => {
+      expect(mockApi.deleteAccount).toHaveBeenCalledWith([]);
+      expect(onConfirmed).toHaveBeenCalled();
+    });
+  });
+
+  it('lists an owned project and deletes it by default', async () => {
+    mockApi.getProjects.mockResolvedValue([ownedProject()]);
+    mockApi.getMembers.mockResolvedValue([member()]);
+    const user = userEvent.setup();
+    renderDialog();
+
+    expect(await screen.findByText('Owned Project')).toBeInTheDocument();
+
+    const confirm = screen.getByRole('button', { name: 'Delete My Account' });
+    await waitFor(() => expect(confirm).toBeEnabled());
+    await user.click(confirm);
+
+    await waitFor(() => {
+      expect(mockApi.deleteAccount).toHaveBeenCalledWith([
+        { project_id: 'proj-1', action: 'delete' },
+      ]);
+    });
+  });
+
+  it('shows an inline error and keeps the user when deletion fails', async () => {
+    mockApi.deleteAccount.mockRejectedValueOnce(new Error('boom'));
+    const user = userEvent.setup();
+    const { onConfirmed } = renderDialog();
+
+    const confirm = await screen.findByRole('button', { name: 'Delete My Account' });
+    await waitFor(() => expect(confirm).toBeEnabled());
+    await user.click(confirm);
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(onConfirmed).not.toHaveBeenCalled();
+  });
+
+  it('reports a load error and blocks deletion when projects fail to load', async () => {
+    mockApi.getProjects.mockRejectedValueOnce(new Error('offline'));
+    renderDialog();
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete My Account' })).toBeDisabled();
+    expect(mockApi.deleteAccount).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/pages/Profile.test.tsx
+++ b/frontend/tests/pages/Profile.test.tsx
@@ -3,7 +3,6 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render, framerMotionMock } from '@tests/utils';
 import Profile from '@/pages/Profile';
-import { HttpError } from '@/lib/api';
 import { createUser } from '@tests/factories/user';
 
 // Mock useNavigate
@@ -21,6 +20,8 @@ const mockApi = {
   updateCurrentUser: vi.fn(),
   changePassword: vi.fn(),
   deleteAccount: vi.fn(),
+  getProjects: vi.fn(),
+  getMembers: vi.fn(),
   uploadPhoto: vi.fn(),
   deletePhoto: vi.fn(),
   exportData: vi.fn(),
@@ -32,7 +33,9 @@ vi.mock('@/lib/api', async (importActual) => {
     api: {
       updateCurrentUser: (data: unknown) => mockApi.updateCurrentUser(data),
       changePassword: (data: unknown) => mockApi.changePassword(data),
-      deleteAccount: () => mockApi.deleteAccount(),
+      deleteAccount: (dispositions: unknown) => mockApi.deleteAccount(dispositions),
+      getProjects: () => mockApi.getProjects(),
+      getMembers: (projectId: string) => mockApi.getMembers(projectId),
       uploadPhoto: (file: File) => mockApi.uploadPhoto(file),
       deletePhoto: () => mockApi.deletePhoto(),
       exportData: () => mockApi.exportData(),
@@ -278,6 +281,8 @@ describe('Profile - Photo Buttons a11y', () => {
 describe('Profile - Delete Account', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockApi.getProjects.mockResolvedValue([]);
+    mockApi.getMembers.mockResolvedValue([]);
   });
 
   it('opens delete confirmation modal', async () => {
@@ -293,98 +298,21 @@ describe('Profile - Delete Account', () => {
 
   it('calls api.deleteAccount and navigates to home on confirm', async () => {
     const user = userEvent.setup();
-    mockApi.deleteAccount.mockResolvedValueOnce({});
+    mockApi.deleteAccount.mockResolvedValueOnce(undefined);
 
     render(<Profile />);
 
     await user.click(screen.getByRole('button', { name: 'Delete Account' }));
 
-    await waitFor(() => {
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByRole('button', { name: 'Delete My Account' }));
+    const confirm = await screen.findByRole('button', { name: 'Delete My Account' });
+    await waitFor(() => expect(confirm).toBeEnabled());
+    await user.click(confirm);
 
     await waitFor(() => {
-      expect(mockApi.deleteAccount).toHaveBeenCalled();
+      expect(mockApi.deleteAccount).toHaveBeenCalledWith([]);
       expect(mockLogout).toHaveBeenCalled();
       expect(mockNavigate).toHaveBeenCalledWith('/');
     });
-  });
-
-  it('shows error toast when deleteAccount fails', async () => {
-    const user = userEvent.setup();
-    mockApi.deleteAccount.mockRejectedValueOnce(new Error('Server error'));
-
-    render(<Profile />);
-
-    await user.click(screen.getByRole('button', { name: 'Delete Account' }));
-
-    await waitFor(() => {
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByRole('button', { name: 'Delete My Account' }));
-
-    await waitFor(() => {
-      expect(mockToast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          title: 'Error',
-          description: 'Server error',
-          variant: 'destructive',
-        })
-      );
-    });
-  });
-
-  it('shows fallback error toast when deleteAccount throws non-Error', async () => {
-    const user = userEvent.setup();
-    mockApi.deleteAccount.mockRejectedValueOnce('unknown');
-
-    render(<Profile />);
-
-    await user.click(screen.getByRole('button', { name: 'Delete Account' }));
-
-    await waitFor(() => {
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByRole('button', { name: 'Delete My Account' }));
-
-    await waitFor(() => {
-      expect(mockToast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          title: 'Error',
-          description: 'Failed to delete account',
-          variant: 'destructive',
-        })
-      );
-    });
-  });
-
-  it('shows ownership warning when deletion is blocked by owned projects (409)', async () => {
-    const user = userEvent.setup();
-    mockApi.deleteAccount.mockRejectedValueOnce(new HttpError('conflict', 409));
-
-    render(<Profile />);
-
-    await user.click(screen.getByRole('button', { name: 'Delete Account' }));
-
-    await waitFor(() => {
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByRole('button', { name: 'Delete My Account' }));
-
-    await waitFor(() => {
-      expect(mockToast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          variant: 'destructive',
-          description: expect.stringContaining('still admin'),
-        })
-      );
-    });
-    expect(mockLogout).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/integration/api/auth/test_auth.py
+++ b/tests/integration/api/auth/test_auth.py
@@ -1083,3 +1083,17 @@ class TestCookieAuth:
         resp = client.post("/api/v1/auth/refresh")
 
         assert resp.status_code == 401
+
+    def test_login_is_csrf_exempt_with_stale_cookie(self, cookie_client):
+        """Re-login succeeds despite a stale csrf_token cookie and no header (post-revocation)."""
+        self._register_and_login(cookie_client)
+        # A revoked session can leave a stale csrf cookie behind with no matching header; the
+        # login endpoint must still let the user re-authenticate rather than answer 403.
+        cookie_client.cookies.set("csrf_token", "stale-value")
+
+        resp = cookie_client.post(
+            "/api/v1/auth/login",
+            data={"username": "cookie@example.com", "password": self.PASSWORD},
+        )
+
+        assert resp.status_code == 200

--- a/tests/integration/api/routes/test_users.py
+++ b/tests/integration/api/routes/test_users.py
@@ -2,7 +2,28 @@
 
 from fastapi import status
 
-from tests.integration.api.conftest import DEFAULT_TEST_PASSWORD, auth_header, register_and_login
+from tests.integration.api.conftest import (
+    DEFAULT_TEST_PASSWORD,
+    auth_header,
+    create_project,
+    register_and_login,
+)
+
+
+def _add_expert(client, owner_token, project_id, email):
+    """Invite an expert into the project, accept, and return (token, user_id)."""
+    expert_token = register_and_login(client, email)
+    client.post(
+        f"/api/v1/projects/{project_id}/invite",
+        json={"email": email},
+        headers=auth_header(owner_token),
+    )
+    invitations = client.get("/api/v1/invitations", headers=auth_header(expert_token)).json()
+    accept = client.post(
+        f"/api/v1/invitations/{invitations[0]['id']}/accept",
+        headers=auth_header(expert_token),
+    )
+    return expert_token, accept.json()["user_id"]
 
 
 class TestDeleteAccount:
@@ -117,6 +138,122 @@ class TestDeleteAccountWithOwnedProjects:
 
         # THEN
         assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+class TestDeleteAccountDispositions:
+    """Guided erasure: each owned project is transferred or deleted (GDPR Art. 17)."""
+
+    def test_transfer_owned_project_then_delete_account(self, client):
+        """Owner transfers a project to a member, then the account is erased."""
+        # GIVEN an owner, a member, and an owned project
+        owner = register_and_login(client, "leaving-owner@example.com")
+        project = create_project(client, owner, "Handover")
+        project_id = project["id"]
+        expert_token, expert_id = _add_expert(client, owner, project_id, "heir@example.com")
+
+        # WHEN the owner deletes their account, transferring the project to the member
+        response = client.request(
+            "DELETE",
+            "/api/v1/users/me",
+            json={
+                "project_dispositions": [
+                    {"project_id": project_id, "action": "transfer", "new_admin_id": expert_id}
+                ]
+            },
+            headers=auth_header(owner),
+        )
+
+        # THEN the account is gone but the project survives under the new admin
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        fetched = client.get(f"/api/v1/projects/{project_id}", headers=auth_header(expert_token))
+        assert fetched.status_code == status.HTTP_200_OK
+        assert fetched.json()["admin_id"] == expert_id
+
+    def test_delete_owned_project_then_delete_account(self, client):
+        """Owner deletes their project as part of erasing the account."""
+        # GIVEN an owner with an owned project
+        owner = register_and_login(client, "purging-owner@example.com")
+        project = create_project(client, owner, "Doomed")
+
+        # WHEN the owner deletes their account, deleting the project too
+        response = client.request(
+            "DELETE",
+            "/api/v1/users/me",
+            json={"project_dispositions": [{"project_id": project["id"], "action": "delete"}]},
+            headers=auth_header(owner),
+        )
+
+        # THEN the account is erased
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    def test_deleting_project_cascades_opinions(self, client_with_session):
+        """Deleting an owned project during erasure removes its opinions (no orphans)."""
+        from sqlmodel import select
+
+        from api.db.models import ExpertOpinion
+
+        client, session = client_with_session
+        # GIVEN an owned project carrying an opinion
+        owner = register_and_login(client, "cascade-owner@example.com")
+        project = create_project(client, owner, "WithOpinion")
+        project_id = project["id"]
+        client.post(
+            f"/api/v1/projects/{project_id}/opinions",
+            json={"position": "Expert", "lower_bound": 40.0, "peak": 60.0, "upper_bound": 80.0},
+            headers=auth_header(owner),
+        )
+
+        # WHEN the account is erased, deleting the project
+        response = client.request(
+            "DELETE",
+            "/api/v1/users/me",
+            json={"project_dispositions": [{"project_id": project_id, "action": "delete"}]},
+            headers=auth_header(owner),
+        )
+
+        # THEN no opinions are left orphaned
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert session.exec(select(ExpertOpinion)).all() == []
+
+    def test_partial_dispositions_returns_409(self, client):
+        """An owned project left without a disposition blocks the deletion."""
+        # GIVEN an owner of two projects
+        owner = register_and_login(client, "two-projects@example.com")
+        create_project(client, owner, "First")
+        second = create_project(client, owner, "Second")
+
+        # WHEN only one project is given a disposition
+        response = client.request(
+            "DELETE",
+            "/api/v1/users/me",
+            json={"project_dispositions": [{"project_id": second["id"], "action": "delete"}]},
+            headers=auth_header(owner),
+        )
+
+        # THEN the deletion is rejected
+        assert response.status_code == status.HTTP_409_CONFLICT
+
+    def test_transfer_to_non_member_rejected(self, client):
+        """A transfer to someone who is not a project member is rejected."""
+        # GIVEN an owner of a project with no other members
+        owner = register_and_login(client, "solo-owner@example.com")
+        project = create_project(client, owner, "Solo")
+        stranger = "00000000-0000-0000-0000-000000000000"
+
+        # WHEN the owner tries to transfer to a non-member
+        response = client.request(
+            "DELETE",
+            "/api/v1/users/me",
+            json={
+                "project_dispositions": [
+                    {"project_id": project["id"], "action": "transfer", "new_admin_id": stranger}
+                ]
+            },
+            headers=auth_header(owner),
+        )
+
+        # THEN the disposition is rejected as invalid
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 class TestChangePasswordRevokesSessions:

--- a/tests/unit/api/middleware/test_csrf.py
+++ b/tests/unit/api/middleware/test_csrf.py
@@ -1,0 +1,19 @@
+"""Tests for the CSRF exempt-path policy."""
+
+from api.middleware.csrf import _csrf_exempt
+
+
+class TestCsrfExempt:
+    """Pre-session auth endpoints are exempt from CSRF; logout and app routes are not."""
+
+    def test_login_is_exempt(self):
+        assert _csrf_exempt("/api/v1/auth/login") is True
+
+    def test_refresh_is_exempt(self):
+        assert _csrf_exempt("/api/v1/auth/refresh") is True
+
+    def test_logout_is_not_exempt(self):
+        assert _csrf_exempt("/api/v1/auth/logout") is False
+
+    def test_app_route_is_not_exempt(self):
+        assert _csrf_exempt("/api/v1/projects") is False


### PR DESCRIPTION
## Summary

Implements the GDPR right to erasure (Art. 17). Account deletion now handles every project the departing user still admins instead of rejecting the request with a `409`. Each owned project is either transferred to another member or deleted, so erasure never silently destroys other experts' contributions.

## Backend

- `DELETE /api/v1/users/me` takes an optional `project_dispositions` body — one entry per owned project, each `transfer` (to a named member) or `delete`.
- The whole set is validated before anything is mutated: an owned project with no disposition returns `409`; a transfer to a non-member returns `422`.
- Reuses the existing `transfer_ownership` and `delete_project` service logic. A deleted project's opinions, memberships, and invitations cascade at the database level, so no migration is needed.
- The profile photo blob is removed from object storage as part of erasure.
- The contract is documented in `api/README.md`.

## Frontend

- New `DeleteAccountDialog` loads the user's owned projects and each project's members, and offers a per-project choice — delete the project, or transfer it to a specific member — before the deletion is confirmed.
- `Profile` is wired to the dialog; the API client sends the chosen dispositions.
- New strings added in both locales (`en`, `cs`).

## Security fix (surfaced by the e2e run)

Pre-session auth endpoints (`login`, `register`, `refresh`, password reset) are now exempt from the double-submit CSRF check. A revoked session — for example after a password change — can leave a stale `csrf_token` cookie in the browser, which previously made the CSRF guard answer `403` to a fresh login and blocked re-authentication. The deletion dialog loads owned projects on open, which is what exposed this; the old confirm-only modal made no API call and never hit it. Logout stays CSRF-protected.

## Testing

- Backend: guided-erasure integration tests (transfer, delete, opinion cascade, incomplete dispositions → `409`, non-member transfer → `422`) plus CSRF-exemption unit and integration tests.
- Frontend: `DeleteAccountDialog` unit tests and an updated profile e2e flow.
- Full suite green — 1190 backend, 733 frontend — with mypy and eslint clean.
