### PR TITLE
docs: refresh stale counts, invariants, and module maps across the docs

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -53,7 +53,8 @@ The parts of BeCoMe most worth probing:
 
 ## Related documentation
 
-The database security posture — least-privilege roles, network isolation, audit logging, and
-secret rotation — is written up in [`docs/security.md`](../docs/security.md). Deployment
-topology and per-environment configuration live in
-[`docs/environments.md`](../docs/environments.md).
+The application security posture — authentication and session transport, tenant isolation,
+rate limiting, GDPR handling, and the database layer (least-privilege roles, network
+isolation, audit logging, secret rotation) — is written up in
+[`docs/security.md`](../docs/security.md). Deployment topology and per-environment
+configuration live in [`docs/environments.md`](../docs/environments.md).

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -187,7 +187,7 @@
       {
         "type": "Secret Keyword",
         "filename": "README.md",
-        "hashed_secret": "9e24c14b4305e7d5aac399db20e698838e8d039d",
+        "hashed_secret": "01322ecad0021d9f499b85bdf70abd97e0b8b14f",
         "is_verified": false,
         "line_number": 130
       }
@@ -198,7 +198,7 @@
         "filename": "api/db/README.md",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 102
+        "line_number": 106
       }
     ],
     "api/middleware/rate_limit.py": [
@@ -990,5 +990,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-05T09:39:23Z"
+  "generated_at": "2026-07-05T14:02:30Z"
 }

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Full-stack web application for group decision-making under fuzzy uncertainty usi
 ![TypeScript](https://img.shields.io/badge/typescript-5.0+-blue.svg)
 ![FastAPI](https://img.shields.io/badge/fastapi-0.115+-green.svg)
 ![React](https://img.shields.io/badge/react-18+-blue.svg)
-![Tests](https://img.shields.io/badge/tests-953%20passed-brightgreen)
-![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)
+![Tests](https://img.shields.io/badge/tests-1982%20passed-brightgreen)
+![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen)
 
 ## Table of Contents
 
@@ -57,7 +57,7 @@ Validated on three Czech case studies (COVID-19 budget allocation, flood prevent
 - **Likert Scale Support**: Ordinal data as special case of fuzzy numbers
 
 ### Quality
-- **100% Test Coverage**: 950+ tests for API, frontend, and core library
+- **100% Test Coverage**: 1,980+ tests for API, frontend, and core library
 - **Type Safety**: mypy strict mode, TypeScript strict
 - **Three Case Studies**: COVID-19 budget, flood prevention, cross-border travel
 
@@ -75,7 +75,7 @@ The project includes a full-stack web application for collaborative decision-mak
 
 ### Key Features
 
-- **User Authentication**: JWT-based auth with refresh tokens
+- **User Authentication**: JWT auth with rotating refresh tokens, delivered as HttpOnly session cookies with CSRF protection
 - **Project Management**: Create projects with custom scales, invite experts by email
 - **Opinion Collection**: Experts submit fuzzy triangular numbers (lower, peak, upper)
 - **Automatic Calculation**: BeCoMe result computed when opinions are submitted
@@ -123,11 +123,11 @@ APP_ENV=dev uv run uvicorn api.main:app --reload
 APP_ENV=prod uv run uvicorn api.main:app
 ```
 
-The `prod` profile refuses to start with a default or empty `SECRET_KEY` or a SQLite `DATABASE_URL`, so a misconfigured deployment fails immediately at startup.
+Both deployed profiles (`test`, `prod`) refuse to start misconfigured: a weak or default `SECRET_KEY`, a SQLite `DATABASE_URL`, a missing `REDIS_URL`, or localhost-only `CORS_ORIGINS` fails startup immediately. Production additionally requires `CLOUDFLARE_ORIGIN_SECRET`.
 
-The `TESTING` flag is separate from the profile. The test suite sets `APP_ENV=test` together with `TESTING=1`; `TESTING` disables rate limiting and is never set on a deployed profile, so staging keeps the same limits as production.
+The `TESTING` flag is separate from the profile. The test suite sets `APP_ENV=test` together with `TESTING=1`; `TESTING` disables rate limiting and the deploy startup checks, and is never set on a deployed profile, so staging keeps the same limits as production.
 
-On Railway, set the profile and secrets as service variables per environment: `APP_ENV`, `SECRET_KEY`, `DATABASE_URL`, `CORS_ORIGINS`, `DEBUG`. The staging service uses `APP_ENV=test`; production uses `APP_ENV=prod`. The frontend reads its API URL from `VITE_API_URL`, injected at build time (see the frontend Dockerfile), so staging and production differ only by that value.
+On Railway, set the profile and secrets as service variables per environment: `APP_ENV`, `SECRET_KEY`, `DATABASE_URL`, `REDIS_URL`, `CORS_ORIGINS`, `DEBUG`. The staging service uses `APP_ENV=test`; production uses `APP_ENV=prod`. The frontend reads its API URL from `VITE_API_URL`, injected at build time (see the frontend Dockerfile), so staging and production differ only by that value.
 
 See [docs/environments.md](docs/environments.md) for the full reference: per-profile details, Railway variables, and current deployment status.
 
@@ -331,8 +331,9 @@ See [src/README.md](src/README.md) for API documentation.
 ```text
 BeCoMe/
 ├── api/                    # REST API (FastAPI)
-│   ├── auth/                   # Authentication (JWT, passwords)
+│   ├── auth/                   # Authentication (JWT, passwords, session cookies, throttles)
 │   ├── db/                     # Database models (SQLModel)
+│   ├── middleware/             # Rate limit, CSRF, body size, security headers, logging
 │   ├── routes/                 # HTTP endpoints
 │   ├── schemas/                # Pydantic DTOs
 │   ├── services/               # Business logic
@@ -348,7 +349,7 @@ BeCoMe/
 │   ├── models/                 # Fuzzy number, expert opinion
 │   ├── calculators/            # BeCoMe algorithm
 │   └── interpreters/           # Likert scale support
-├── tests/                  # Test suite (950+ tests)
+├── tests/                  # Test suite (1,200+ backend tests)
 │   ├── unit/                   # Unit tests (models, calculators, API)
 │   ├── integration/            # Integration tests (Excel validation, API routes, DB)
 │   ├── e2e/                    # End-to-end API tests
@@ -379,9 +380,9 @@ uv run pytest tests/unit/models/       # Model tests only
 
 ### Test Coverage
 
-Current test coverage: **100%** (all source code lines covered).
+Current test coverage: **100%** on the core library (`src/`) and **99%** across the backend overall — the remaining lines are Redis-backed store variants exercised against a live Redis rather than in the unit suite.
 
-The test suite contains 571 unit tests (models, calculators, interpreters, utilities, API) and 329 integration tests (Excel validation, API routes, database). Another 53 end-to-end tests cover full API workflows. Edge cases like single expert, identical opinions, and extreme values are covered. Property-based tests verify fuzzy number arithmetic.
+The test suite contains 797 unit tests (models, calculators, interpreters, utilities, API) and 393 integration tests (Excel validation, API routes, database). Another 59 end-to-end tests cover full API workflows, and the frontend adds 733 Vitest tests plus 76 Playwright browser scenarios. Edge cases like single expert, identical opinions, and extreme values are covered. Property-based tests verify fuzzy number arithmetic.
 
 See [Quality Report](docs/quality-report.md) for detailed metrics.
 
@@ -414,6 +415,8 @@ Documentation is available in the `docs/` directory:
 | [Method Description](docs/method-description.md) | Mathematical foundation with formulas and worked examples |
 | [UML Diagrams](docs/uml-diagrams/README.md) | Visual architecture (class, sequence, activity diagrams) |
 | [Quality Report](docs/quality-report.md) | Code quality metrics and test coverage details |
+| [Security](docs/security.md) | Application and database security posture |
+| [Environments](docs/environments.md) | dev/test/prod profiles and Railway deployment |
 | [Source Code](src/README.md) | API documentation and module descriptions |
 
 ## Architecture

--- a/api/README.md
+++ b/api/README.md
@@ -18,10 +18,13 @@ The API runs at `http://localhost:8000`. Interactive documentation:
 ```text
 api/
 ├── auth/               # Authentication & authorization
-│   ├── jwt.py              # Token creation/validation
+│   ├── jwt.py              # Token creation/validation (rotation family / sid)
 │   ├── password.py         # Password hashing (bcrypt)
-│   ├── dependencies.py     # CurrentUser dependency
+│   ├── cookies.py          # HttpOnly session cookies + CSRF token helpers
+│   ├── dependencies.py     # CurrentUser dependency (cookie or Bearer)
 │   ├── revocation_store.py # Token revocation store (in-memory / Redis)
+│   ├── login_throttle.py   # Per-account lockout after failed logins
+│   ├── reset_throttle.py   # Per-email cooldown for password-reset emails
 │   └── logging.py          # Auth event logging
 ├── db/                 # Database layer
 │   ├── models.py           # SQLModel entities
@@ -30,6 +33,8 @@ api/
 │   └── utils.py            # UTC helpers, email regex
 ├── middleware/         # Request processing
 │   ├── rate_limit.py       # SlowAPI rate limiting (logs violations)
+│   ├── csrf.py             # Double-submit CSRF check on cookie mutations
+│   ├── body_size.py        # Request body size limit (413)
 │   ├── security_headers.py # Security response headers
 │   ├── request_logging.py  # Request/response logging + X-Request-ID
 │   └── exception_handlers.py  # Centralized errors + catch-all 500
@@ -50,14 +55,22 @@ api/
 │   └── ...
 ├── services/           # Business logic
 │   ├── user_service.py
-│   ├── project_service.py
+│   ├── project_service.py         # + membership / query services
 │   ├── opinion_service.py
 │   ├── invitation_service.py
 │   ├── calculation_service.py
+│   ├── password_reset_service.py
+│   ├── data_export_service.py     # GDPR export
+│   ├── email/              # Email delivery (console / HTTP provider)
+│   ├── export/             # Result export renderers
 │   └── storage/            # File storage (Railway bucket, S3)
 ├── utils/              # Utilities
-│   └── sanitization.py     # HTML sanitization
-├── config.py           # Settings (Pydantic Settings)
+│   ├── sanitization.py     # HTML sanitization
+│   ├── client_ip.py        # Real client IP behind trusted proxies
+│   ├── upload.py           # Size-capped streaming reads
+│   └── photo_links.py      # Photo proxy URL builder
+├── config.py           # Settings (Pydantic Settings) + deploy invariants
+├── pagination.py       # Shared limit/offset params (cap 100)
 ├── logging_config.py   # Centralized logging + JSON formatter (test/prod)
 ├── logging_context.py  # Request-scoped correlation (request_id/user_id) via contextvars
 ├── dependencies.py     # DI factories + authorization
@@ -157,13 +170,18 @@ returns `422`. The profile photo blob is removed from object storage as part of 
 |--------|----------|-------------|
 | GET | `/api/v1/health` | API health check |
 
+**Pagination.** List endpoints (projects, opinions, members, invitations) accept optional
+`limit`/`offset` query parameters; `limit` is capped at 100 and defaults to the first page,
+so responses stay bounded. The GDPR export is the one exception -- it always returns the
+full dataset.
+
 ## Configuration
 
 Environment variables (can use `.env` file):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `APP_ENV` | `dev` | Deployment profile: `dev`, `test`, or `prod`. Selects the `.env.<APP_ENV>` overlay; `prod` rejects a default secret or SQLite. See the root README "Environment profiles". |
+| `APP_ENV` | `dev` | Deployment profile: `dev`, `test`, or `prod`. Selects the `.env.<APP_ENV>` overlay; deployed profiles reject a weak secret, SQLite, a missing Redis, or localhost CORS at startup. See the root README "Environment profiles". |
 | `DATABASE_URL` | `sqlite:///./become.db` | Database connection string. On deployed environments this is the least-privilege `become_app` role. |
 | `MIGRATION_DATABASE_URL` | *optional* | Privileged connection used only by Alembic migrations (DDL); falls back to `DATABASE_URL` when unset. |
 | `SECRET_KEY` | *required* | JWT signing key (generate with `openssl rand -hex 32`) |
@@ -172,6 +190,10 @@ Environment variables (can use `.env` file):
 | `DEBUG` | `false` | Debug mode |
 | `API_VERSION` | `1.0.0b1` | API version (auto-read from pyproject.toml) |
 | `CORS_ORIGINS` | `http://localhost:3000,http://localhost:8080` | Allowed CORS origins |
+| `REDIS_URL` | *required when deployed* | Redis for rate limiting, token revocation, and auth throttles |
+| `CLOUDFLARE_ORIGIN_SECRET` | *required in prod* | Shared secret proving the request came through Cloudflare |
+| `EMAIL_PROVIDER` | `console` | Password-reset email delivery: `console` (log) or `http` (Resend) |
+| `EMAIL_API_KEY` | *optional* | API key for the `http` email provider |
 | `API_PUBLIC_URL` | `http://localhost:8000` | Public base URL of this API, used to build profile photo proxy links |
 | `BUCKET_NAME` | *optional* | Railway Storage Bucket name (auto-injected when a bucket is attached) |
 | `BUCKET_ENDPOINT` | *optional* | S3-compatible bucket endpoint |
@@ -207,5 +229,6 @@ uv run pytest tests/unit/api/ tests/integration/api/ --cov=api --cov-report=term
 ## Related Documentation
 
 - [Main README](../README.md) — project overview
+- [docs/security.md](../docs/security.md) — application and database security posture
 - [docs/environments.md](../docs/environments.md) — dev/test/prod profiles, Railway deployment, database topology
 - [CLAUDE.md](../CLAUDE.md) — development guidelines

--- a/api/db/README.md
+++ b/api/db/README.md
@@ -40,7 +40,11 @@ from api.db.engine import create_db_and_tables
 create_db_and_tables()
 ```
 
-Tables are created automatically on application startup via FastAPI lifespan.
+On SQLite (local development and the test suite) tables are created automatically on
+application startup via FastAPI lifespan. Deployed PostgreSQL schemas are managed by
+Alembic instead: migrations live in `migrations/` and run before each Railway deploy, and
+`create_db_and_tables()` is a no-op there. See
+[docs/environments.md](../../docs/environments.md) for the full schema-management story.
 
 ### Session Dependency
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -16,8 +16,8 @@ The backend runs under one of three profiles, chosen by the `APP_ENV` variable: 
 
 `APP_ENV` and `TESTING` answer different questions and never substitute for each other.
 
-- **`APP_ENV`** (`dev` / `test` / `prod`) is the deployment profile. It drives debug output, CORS origins, the database that is expected, and the production startup guard.
-- **`TESTING`** (`1`/`true`) marks an automated test run. Only pytest and CI set it. It disables rate limiting and is never present on a deployed service.
+- **`APP_ENV`** (`dev` / `test` / `prod`) is the deployment profile. It drives debug output, CORS origins, the database that is expected, and the deploy startup guard.
+- **`TESTING`** (`1`/`true`) marks an automated test run. Only pytest and CI set it. It disables rate limiting and the deploy startup checks, and is never present on a deployed service.
 
 This separation is what lets staging be realistic. A staging deploy sets `APP_ENV=test` with no `TESTING`, so its rate limits match production. The pytest suite sets `APP_ENV=test` together with `TESTING=1`, which keeps tests fast and lets them use in-memory SQLite.
 
@@ -33,11 +33,11 @@ uv run uvicorn api.main:app --reload
 
 ### test (staging and the test suite)
 
-Two consumers share this profile. A deployed staging service uses PostgreSQL with debug off and rate limiting on, which mirrors production for manual QA. The automated suite runs the same profile but adds `TESTING=1`, so it uses in-memory SQLite and turns rate limiting off. The test conftests set both variables before any `api` import.
+Two consumers share this profile. A deployed staging service uses PostgreSQL with debug off and rate limiting on, which mirrors production for manual QA -- and it is held to the same startup invariants as production (strong secret, PostgreSQL, Redis, non-localhost CORS). The automated suite runs the same profile but adds `TESTING=1`, so it uses in-memory SQLite, turns rate limiting off, and skips the startup guard. The test conftests set both variables before any `api` import.
 
 ### prod
 
-PostgreSQL, debug off. The profile adds a startup guard: it rejects an empty or default `SECRET_KEY` and any `sqlite` `DATABASE_URL`. A misconfigured deploy fails immediately at startup instead of running with insecure defaults.
+PostgreSQL, debug off. Both deployed profiles run a startup guard (`_validate_deploy_invariants` in `api/config.py`): a weak or default `SECRET_KEY`, a `sqlite` `DATABASE_URL`, a missing `REDIS_URL`, or localhost-only `CORS_ORIGINS` fails startup immediately instead of running with insecure defaults. Production additionally requires `CLOUDFLARE_ORIGIN_SECRET`, which proves requests came through the Cloudflare edge.
 
 ## Configuration files
 
@@ -99,12 +99,14 @@ The root `railway.toml` carries the API build and deploy settings: it points at 
 | `DATABASE_URL` | staging `become_app` role | production `become_app` role |
 | `MIGRATION_DATABASE_URL` | privileged role, Alembic only | privileged role, Alembic only |
 | `CORS_ORIGINS` | staging origin(s) | production origin(s) |
+| `REDIS_URL` | staging Redis | production Redis |
+| `CLOUDFLARE_ORIGIN_SECRET` | — | shared secret matching the Cloudflare Transform Rule |
 | `DEBUG` | `false` | `false` |
 | `API_PUBLIC_URL` | staging API URL | production API URL |
 | `VITE_API_URL` (frontend build arg) | staging API URL | production API URL |
 | `BUCKET_NAME` / `BUCKET_ENDPOINT` / `BUCKET_ACCESS_KEY_ID` / `BUCKET_SECRET_ACCESS_KEY` | injected from `test-photos` | injected from `prod-photos` |
 
-If `APP_ENV` is left unset on a deployed service, it falls back to dev, which turns debug on and opens CORS. Production must set `APP_ENV=prod` so the startup guard runs.
+If `APP_ENV` is left unset on a deployed service, it falls back to dev, which turns debug on and opens CORS. Every deployed service must set its profile explicitly (`test` or `prod`) so the startup guard runs.
 
 ## Database schema and access
 
@@ -128,4 +130,4 @@ All three environments run entirely on Railway, each with its own isolated Postg
 
 ## Where the code lives
 
-The selector and guard are in `api/config.py`: `Environment` (the enum), `_resolve_environment()` (reads `APP_ENV`), `_env_files_for()` (builds the `.env` plus `.env.<stage>` list), and the `_validate_production_invariants` model validator (the prod guard). Rate limiting reads `settings.testing` in `api/middleware/rate_limit.py`.
+The selector and guard are in `api/config.py`: `Environment` (the enum), `_resolve_environment()` (reads `APP_ENV`), `_env_files_for()` (builds the `.env` plus `.env.<stage>` list), and the `_validate_deploy_invariants` model validator (the deploy guard, applied to `prod` and to a deployed `test`). Rate limiting reads `settings.testing` in `api/middleware/rate_limit.py`.

--- a/docs/quality-report.md
+++ b/docs/quality-report.md
@@ -4,11 +4,11 @@
 
 | Check | Status | Result |
 |-------|--------|--------|
-| mypy (strict) | Pass | No errors in 28 files |
+| mypy (strict) | Pass | No errors (28 files in `src/`+`examples/`, 83 in `api/`) |
 | ruff check | Pass | No issues |
 | ruff format | Pass | All files formatted |
-| pytest | Pass | 1112 tests passed |
-| coverage | Pass | 100% on `src/` |
+| pytest | Pass | 1249 tests passed |
+| coverage | Pass | 100% on `src/`, 99% on `src/`+`api/` overall |
 
 ## Running Checks
 
@@ -41,7 +41,7 @@ HTML report: `uv run pytest --cov=src --cov-report=html` generates `htmlcov/inde
 
 ## Test Breakdown
 
-Unit tests (694) cover models, calculators, interpreters, utilities, and API components (auth, schemas, services, middleware, logging). Integration tests (359) validate core calculations against Excel reference data for all three case studies and test API routes with a real database. End-to-end tests (59) exercise full API workflows. Edge cases include single expert, identical opinions, empty lists, and boundary values.
+Unit tests (797) cover models, calculators, interpreters, utilities, and API components (auth, schemas, services, middleware, logging). Integration tests (393) validate core calculations against Excel reference data for all three case studies and test API routes with a real database. End-to-end tests (59) exercise full API workflows. The frontend adds 733 Vitest tests and 76 Playwright scenarios run on three browsers. Edge cases include single expert, identical opinions, empty lists, and boundary values.
 
 ## Mutation Testing
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # BeCoMe Test Suite
 
-Tests for the BeCoMe implementation: 953 tests total, 100% code coverage.
+Tests for the BeCoMe implementation: 1,249 backend tests, 100% coverage on the core library and 99% overall.
 
 ## Overview
 
@@ -23,7 +23,7 @@ uv run pytest --cov=src --cov-report=term-missing
 uv run pytest --cov=src --cov-report=html          # generates htmlcov/
 ```
 
-Current coverage: 100% (all statements and branches).
+Current coverage: 100% on `src/`, 99% across `src/`+`api/` overall (the gap is Redis-backed store variants that need a live Redis).
 
 ## Test Structure
 
@@ -55,7 +55,7 @@ tests/
     └── pendlers_case.py  # 22 experts, Likert scale
 ```
 
-**Unit tests** (571) check individual components in isolation, including API auth, schemas, services, and middleware. **Integration tests** (329) validate core calculations against Excel results (tolerance: 0.001) and test API routes with a real database. **End-to-end tests** (53) exercise complete API workflows including auth, projects, and invitations. **Reference data** contains expected values from the original Excel implementation.
+**Unit tests** (797) check individual components in isolation, including API auth, schemas, services, and middleware. **Integration tests** (393) validate core calculations against Excel results (tolerance: 0.001) and test API routes with a real database. **End-to-end tests** (59) exercise complete API workflows including auth, projects, and invitations. **Reference data** contains expected values from the original Excel implementation.
 
 ## Writing Tests
 


### PR DESCRIPTION
## Summary

Refreshes the documentation that had gone stale after the security series
(#256, #260, #261, #262): real test counts, verified coverage numbers, the deploy
invariants, and module maps that now match the tree on disk.

## Changes

- **README.md** — badges and counts reflect reality (1,982 tests: 797 unit + 393
  integration + 59 e2e backend, 733 frontend, plus 76 Playwright scenarios; coverage
  99% overall). The auth feature line mentions the HttpOnly-cookie session, the
  environment-profiles section describes the deploy guard for both deployed profiles,
  the project tree gains `api/middleware/`, and the docs table links `security.md`
  and `environments.md`.
- **api/README.md** — the module map catches up with the code
  (`auth/cookies.py`, both throttles, `middleware/csrf.py`, `middleware/body_size.py`,
  `pagination.py`, the fuller `services/` and `utils/` listings); the configuration
  table adds `REDIS_URL`, `CLOUDFLARE_ORIGIN_SECRET`, and the email-provider
  variables; a pagination note documents the `limit`/`offset` cap.
- **docs/environments.md** — the startup guard is described as it now works
  (`_validate_deploy_invariants`, applied to both deployed profiles), and the Railway
  variables table adds the Redis and Cloudflare rows.
- **docs/quality-report.md / tests/README.md** — counts and coverage updated after
  actually running the suite: 100% on `src/`, 99% on `src/`+`api/` overall (the gap
  is Redis-backed store variants that need a live Redis).
- **.github/SECURITY.md** — the related-documentation pointer now describes
  `docs/security.md` as the application-wide posture document.
- **api/db/README.md** — table creation is documented per environment: `create_all`
  for SQLite/tests, Alembic for deployed PostgreSQL.
- **.secrets.baseline** — one new allowlist entry for a README line that names
  environment variables (`SECRET_KEY` as a variable name tripped the keyword
  detector; false positive).
