### PR TITLE
fix: make the median independent of the expert input order

### DIFF
--- a/src/calculators/become_calculator.py
+++ b/src/calculators/become_calculator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import statistics
 from typing import TYPE_CHECKING
 
 from src.calculators.base_calculator import BaseAggregationCalculator
@@ -69,6 +68,10 @@ class BeCoMeCalculator(BaseAggregationCalculator):
         - Odd (M = 2n + 1): middle element after sorting by centroid
         - Even (M = 2n): average of two middle elements after sorting
 
+        The middle elements are taken by position from the canonically sorted
+        list, so the result does not depend on the input order even when
+        several opinions share a centroid.
+
         :param opinions: List of expert opinions as fuzzy triangular numbers
         :return: Median as FuzzyTriangleNumber(rho, omega, sigma)
         :raises EmptyOpinionsError: If opinions list is empty
@@ -78,14 +81,11 @@ class BeCoMeCalculator(BaseAggregationCalculator):
         sorted_opinions: list[ExpertOpinion] = self.sort_by_centroid(opinions)
         m: int = len(sorted_opinions)
 
-        centroids = [op.centroid for op in sorted_opinions]
-        median_centroid = statistics.median(centroids)
-
         strategy: MedianCalculationStrategy = (
             OddMedianStrategy() if m % 2 == 1 else EvenMedianStrategy()
         )
 
-        return strategy.calculate(sorted_opinions, median_centroid)
+        return strategy.calculate(sorted_opinions)
 
     def calculate_compromise(self, opinions: list[ExpertOpinion]) -> BeCoMeResult:
         """
@@ -113,9 +113,19 @@ class BeCoMeCalculator(BaseAggregationCalculator):
         """
         Sort expert opinions by centroid values in ascending order.
 
-        Sorting is stable and maintains original order for equal centroids.
+        Equal centroids are ordered by the triangle bounds (lower, peak,
+        upper), which makes the order canonical: it depends only on the
+        opinion values, never on the order they arrived in.
 
         :param opinions: List of expert opinions to sort
         :return: New list of opinions sorted by ascending centroid
         """
-        return sorted(opinions, key=lambda op: op.centroid)
+        return sorted(
+            opinions,
+            key=lambda op: (
+                op.centroid,
+                op.opinion.lower_bound,
+                op.opinion.peak,
+                op.opinion.upper_bound,
+            ),
+        )

--- a/src/calculators/median_strategies.py
+++ b/src/calculators/median_strategies.py
@@ -14,34 +14,18 @@ class MedianCalculationStrategy(ABC):
     """
     Abstract base class for median calculation strategies.
 
-    Different strategies handle odd vs even number of expert opinions.
+    Different strategies handle odd vs even number of expert opinions. Both
+    read the middle of the canonically sorted list by position, so the result
+    never depends on the order the opinions arrived in.
     """
 
-    @staticmethod
-    def _find_closest_opinion(
-        opinions: list[ExpertOpinion],
-        target_centroid: float,
-    ) -> ExpertOpinion:
-        """
-        Find opinion with centroid closest to target centroid.
-
-        :param opinions: List of expert opinions to search
-        :param target_centroid: Target centroid value to match
-        :return: ExpertOpinion with centroid closest to target
-        """
-        return min(opinions, key=lambda op: abs(op.centroid - target_centroid))
-
     @abstractmethod
-    def calculate(
-        self,
-        sorted_opinions: list[ExpertOpinion],
-        median_centroid: float,
-    ) -> FuzzyTriangleNumber:
+    def calculate(self, sorted_opinions: list[ExpertOpinion]) -> FuzzyTriangleNumber:
         """
         Calculate median using specific strategy.
 
-        :param sorted_opinions: Expert opinions sorted by centroid (ascending)
-        :param median_centroid: Median centroid value
+        :param sorted_opinions: Expert opinions in canonical order (ascending
+            centroid, ties broken by the triangle bounds)
         :return: Median as FuzzyTriangleNumber(rho, omega, sigma)
         """
         pass  # pragma: no cover
@@ -55,21 +39,14 @@ class OddMedianStrategy(MedianCalculationStrategy):
     after sorting by centroid.
     """
 
-    def calculate(
-        self,
-        sorted_opinions: list[ExpertOpinion],
-        median_centroid: float,
-    ) -> FuzzyTriangleNumber:
+    def calculate(self, sorted_opinions: list[ExpertOpinion]) -> FuzzyTriangleNumber:
         """
         Calculate median for odd number of experts.
 
-        :param sorted_opinions: Expert opinions sorted by centroid
-        :param median_centroid: Median centroid value
+        :param sorted_opinions: Expert opinions in canonical order
         :return: Fuzzy number of the middle expert opinion
         """
-        median_opinion = self._find_closest_opinion(sorted_opinions, median_centroid)
-
-        return median_opinion.opinion
+        return sorted_opinions[len(sorted_opinions) // 2].opinion
 
 
 class EvenMedianStrategy(MedianCalculationStrategy):
@@ -78,34 +55,25 @@ class EvenMedianStrategy(MedianCalculationStrategy):
 
     For even number (M = 2n), median is the average of the two middle
     opinions after sorting by centroid.
+
+    Formula:
+        rho = (A1 + A2) / 2
+        omega = (C1 + C2) / 2
+        sigma = (B1 + B2) / 2
     """
 
-    def calculate(
-        self,
-        sorted_opinions: list[ExpertOpinion],
-        median_centroid: float,
-    ) -> FuzzyTriangleNumber:
+    def calculate(self, sorted_opinions: list[ExpertOpinion]) -> FuzzyTriangleNumber:
         """
         Calculate median for even number of experts.
 
-        Averages the two middle opinions (those closest to median centroid).
+        Averages the two middle opinions of the sorted list.
 
-        Formula:
-            rho = (A1 + A2) / 2
-            omega = (C1 + C2) / 2
-            sigma = (B1 + B2) / 2
-
-        :param sorted_opinions: Expert opinions sorted by centroid
-        :param median_centroid: Median centroid value
+        :param sorted_opinions: Expert opinions in canonical order
         :return: Average of the two middle opinions as FuzzyTriangleNumber
         """
         from src.models.fuzzy_number import FuzzyTriangleNumber
 
-        first_median_opinion = self._find_closest_opinion(sorted_opinions, median_centroid)
-
-        remaining_opinions = [op for op in sorted_opinions if op != first_median_opinion]
-        second_median_opinion = self._find_closest_opinion(remaining_opinions, median_centroid)
-
+        upper_middle = len(sorted_opinions) // 2
         return FuzzyTriangleNumber.average(
-            [first_median_opinion.opinion, second_median_opinion.opinion]
+            [sorted_opinions[upper_middle - 1].opinion, sorted_opinions[upper_middle].opinion]
         )

--- a/tests/unit/calculators/test_median.py
+++ b/tests/unit/calculators/test_median.py
@@ -1,5 +1,7 @@
 """Unit tests for median calculation in BeCoMeCalculator."""
 
+from itertools import permutations
+
 import pytest
 
 from src.exceptions import EmptyOpinionsError
@@ -239,3 +241,64 @@ class TestBeCoMeCalculatorMedian:
         assert result.lower_bound == 9.0
         assert result.peak == 12.0
         assert result.upper_bound == 15.0
+
+
+class TestMedianOrderIndependence:
+    """Tied centroids and duplicate opinions must not make the result order-dependent."""
+
+    def test_odd_median_with_tied_centroids_is_input_order_independent(self, calculator):
+        """Every input ordering yields the same median when centroids tie."""
+        # GIVEN - X and Y share centroid 2.0 with different triangles; Z sits far away
+        x = ExpertOpinion("X", FuzzyTriangleNumber(lower_bound=0.0, peak=3.0, upper_bound=3.0))
+        y = ExpertOpinion("Y", FuzzyTriangleNumber(lower_bound=1.0, peak=2.0, upper_bound=3.0))
+        z = ExpertOpinion("Z", FuzzyTriangleNumber(lower_bound=10.0, peak=10.0, upper_bound=10.0))
+
+        # WHEN - the median is computed for every permutation of the input
+        medians = {
+            (m.lower_bound, m.peak, m.upper_bound)
+            for perm in permutations([x, y, z])
+            for m in [calculator.calculate_median(list(perm))]
+        }
+
+        # THEN - all orderings agree, and ties resolve canonically (by triangle bounds)
+        assert medians == {(1.0, 2.0, 3.0)}
+
+    def test_compromise_with_tied_centroids_is_input_order_independent(self, calculator):
+        """The full compromise result is identical for every input ordering."""
+        # GIVEN - two opinions tie on centroid with different triangles
+        x = ExpertOpinion("X", FuzzyTriangleNumber(lower_bound=0.0, peak=3.0, upper_bound=3.0))
+        y = ExpertOpinion("Y", FuzzyTriangleNumber(lower_bound=1.0, peak=2.0, upper_bound=3.0))
+        z = ExpertOpinion("Z", FuzzyTriangleNumber(lower_bound=10.0, peak=10.0, upper_bound=10.0))
+
+        # WHEN
+        results = {
+            (
+                r.best_compromise.lower_bound,
+                r.best_compromise.peak,
+                r.best_compromise.upper_bound,
+                r.max_error,
+            )
+            for perm in permutations([x, y, z])
+            for r in [calculator.calculate_compromise(list(perm))]
+        }
+
+        # THEN
+        assert len(results) == 1
+
+    def test_even_median_with_identical_middle_duplicates(self, calculator):
+        """Two identical middle opinions average to themselves, not to a neighbour."""
+        # GIVEN - the two middle opinions are exact duplicates (same id, same triangle)
+        opinions = [
+            ExpertOpinion("L", FuzzyTriangleNumber(lower_bound=1.0, peak=1.0, upper_bound=1.0)),
+            ExpertOpinion("M", FuzzyTriangleNumber(lower_bound=4.0, peak=5.0, upper_bound=6.0)),
+            ExpertOpinion("M", FuzzyTriangleNumber(lower_bound=4.0, peak=5.0, upper_bound=6.0)),
+            ExpertOpinion("H", FuzzyTriangleNumber(lower_bound=9.0, peak=9.0, upper_bound=9.0)),
+        ]
+
+        # WHEN
+        result = calculator.calculate_median(opinions)
+
+        # THEN - the median is exactly the duplicated middle triangle
+        assert result.lower_bound == 4.0
+        assert result.peak == 5.0
+        assert result.upper_bound == 6.0

--- a/tests/unit/calculators/test_median_strategies.py
+++ b/tests/unit/calculators/test_median_strategies.py
@@ -162,12 +162,9 @@ class TestOddMedianStrategy:
 
     def test_odd_strategy_with_single_expert(self, one_expert_for_odd_strategy):
         """Test odd median strategy with single expert returns unchanged opinion."""
-        # GIVEN
-        median_centroid = 10.0
-
         # WHEN
         strategy = OddMedianStrategy()
-        result = strategy.calculate(one_expert_for_odd_strategy, median_centroid)
+        result = strategy.calculate(one_expert_for_odd_strategy)
 
         # THEN
         assert result.lower_bound == 5.0
@@ -176,12 +173,9 @@ class TestOddMedianStrategy:
 
     def test_odd_strategy_with_three_experts(self, three_experts_for_odd_strategy):
         """Test odd median strategy with three experts returns middle element."""
-        # GIVEN
-        median_centroid = 9.0
-
         # WHEN
         strategy = OddMedianStrategy()
-        result = strategy.calculate(three_experts_for_odd_strategy, median_centroid)
+        result = strategy.calculate(three_experts_for_odd_strategy)
 
         # THEN
         assert result.lower_bound == 6.0
@@ -190,12 +184,9 @@ class TestOddMedianStrategy:
 
     def test_odd_strategy_with_five_experts(self, five_experts_for_odd_strategy):
         """Test odd median strategy with five experts returns middle element."""
-        # GIVEN
-        median_centroid = 8.0
-
         # WHEN
         strategy = OddMedianStrategy()
-        result = strategy.calculate(five_experts_for_odd_strategy, median_centroid)
+        result = strategy.calculate(five_experts_for_odd_strategy)
 
         # THEN
         assert result.lower_bound == 5.0
@@ -208,12 +199,9 @@ class TestEvenMedianStrategy:
 
     def test_even_strategy_with_two_experts(self, two_experts_for_even_strategy):
         """Test even median strategy with two experts returns average."""
-        # GIVEN
-        median_centroid = 9.0
-
         # WHEN
         strategy = EvenMedianStrategy()
-        result = strategy.calculate(two_experts_for_even_strategy, median_centroid)
+        result = strategy.calculate(two_experts_for_even_strategy)
 
         # THEN
         assert result.lower_bound == 6.0
@@ -222,12 +210,9 @@ class TestEvenMedianStrategy:
 
     def test_even_strategy_with_four_experts(self, four_experts_for_even_strategy):
         """Test even median strategy with four experts returns average of middle two."""
-        # GIVEN
-        median_centroid = 8.5
-
         # WHEN
         strategy = EvenMedianStrategy()
-        result = strategy.calculate(four_experts_for_even_strategy, median_centroid)
+        result = strategy.calculate(four_experts_for_even_strategy)
 
         # THEN
         assert result.lower_bound == 5.0
@@ -236,12 +221,9 @@ class TestEvenMedianStrategy:
 
     def test_even_strategy_with_six_experts(self, six_experts_for_even_strategy):
         """Test even median strategy with six experts returns average of middle two."""
-        # GIVEN
-        median_centroid = 9.5
-
         # WHEN
         strategy = EvenMedianStrategy()
-        result = strategy.calculate(six_experts_for_even_strategy, median_centroid)
+        result = strategy.calculate(six_experts_for_even_strategy)
 
         # THEN
         assert result.lower_bound == 6.0
@@ -268,7 +250,7 @@ class TestEvenMedianStrategyEdgeCases:
         strategy = EvenMedianStrategy()
 
         # WHEN
-        result = strategy.calculate(opinions, median_centroid=10.0)
+        result = strategy.calculate(opinions)
 
         # THEN - average of (5,10,15) and (8,10,12) = (6.5, 10, 13.5)
         assert result.lower_bound == 6.5
@@ -299,7 +281,7 @@ class TestEvenMedianStrategyEdgeCases:
         strategy = EvenMedianStrategy()
 
         # WHEN
-        result = strategy.calculate(opinions, median_centroid=10.0)
+        result = strategy.calculate(opinions)
 
         # THEN - both middle elements have centroid=10, averages E2 and E3
         assert result.lower_bound == 6.5
@@ -330,11 +312,12 @@ class TestEvenMedianStrategyEdgeCases:
         strategy = EvenMedianStrategy()
 
         # WHEN
-        result = strategy.calculate(opinions, median_centroid=10.0)
+        result = strategy.calculate(opinions)
 
-        # THEN - strategy picks first two closest (E1 and E2 due to list order)
-        # Result is average of two opinions picked by _find_closest_opinion
+        # THEN - the two middle opinions of the list (E2 and E3) are averaged
+        assert result.lower_bound == 7.5
         assert result.peak == 10.0
+        assert result.upper_bound == 12.5
 
     def test_clustered_centroids_near_median(self):
         """Multiple opinions clustered near median centroid."""
@@ -368,10 +351,12 @@ class TestEvenMedianStrategyEdgeCases:
         strategy = EvenMedianStrategy()
 
         # WHEN
-        result = strategy.calculate(opinions, median_centroid=10.0)
+        result = strategy.calculate(opinions)
 
-        # THEN - peak is always 10.0 since all middle opinions have centroid=10
+        # THEN - the two middle opinions (E3 and E4) are averaged
+        assert result.lower_bound == 9.65
         assert result.peak == 10.0
+        assert result.upper_bound == 10.35
 
 
 class TestOddMedianStrategyEdgeCases:
@@ -397,9 +382,9 @@ class TestOddMedianStrategyEdgeCases:
         strategy = OddMedianStrategy()
 
         # WHEN
-        result = strategy.calculate(opinions, median_centroid=10.0)
+        result = strategy.calculate(opinions)
 
-        # THEN - _find_closest_opinion returns first match (E1)
+        # THEN - the middle element of the list (E2) is the median
+        assert result.lower_bound == 7.0
         assert result.peak == 10.0
-        assert result.lower_bound == 5.0
-        assert result.upper_bound == 15.0
+        assert result.upper_bound == 13.0


### PR DESCRIPTION
## Summary

Fixes a pre-existing core bug: `calculate_compromise` could return different results for
the same set of expert opinions depending on the order they were passed in. Flagged in the
2026-07-02 audit ("calculate_compromise is input-order dependent").

## Root cause

Two defects in the median step:

- The middle opinions were selected as "closest to the median centroid" via `min()`, whose
  first-wins tie-breaking sits on top of a stable sort. When two opinions share a centroid
  but have different triangles, whichever arrived first won — so the median (and with it
  the best compromise and max error) changed with the input order.
- The even strategy removed the first middle opinion with a value-equality filter
  (`op != first`). When the two middle opinions were exact duplicates, both were removed
  and the second pick fell on a neighbour: `[(1,1,1), (4,5,6), (4,5,6), (9,9,9)]` produced
  `(2.5, 3, 3.5)` instead of `(4, 5, 6)`.

The existing property-based order-independence tests never caught either case because
hypothesis-generated floats essentially never tie exactly.

## Fix

The paper's definition, applied literally: opinions are sorted by a canonical key
(centroid, then the triangle bounds as tie-break), and the strategies take the middle by
position — odd: `sorted[m // 2]`; even: the average of `sorted[m // 2 - 1]` and
`sorted[m // 2]`. The `_find_closest_opinion` helper and the `median_centroid` parameter
are gone. The result now depends only on the opinion values, never on their order.

## Testing

- Three new regression tests: median and full-compromise invariance across all
  permutations of a tied-centroid input, and the identical-duplicate-middles case. Red
  before the fix, green after.
- The Excel reference tests for all three case studies pass unchanged — the published
  results are intact.
- Full backend suite: 1193 passed; mypy clean; all case-study examples run.
