### PR TITLE
refactor: adopt react-query for page data fetching

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,13 +3,14 @@ import { useTranslation } from "react-i18next";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { MotionConfig } from "framer-motion";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { RouteAnnouncer } from "@/components/RouteAnnouncer";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { createQueryClient } from "@/lib/queryClient";
 import { Loader2 } from "lucide-react";
 
 const Landing = lazy(() => import("./pages/Landing"));
@@ -28,7 +29,7 @@ const FaqPage = lazy(() => import("./pages/FAQ"));
 const Onboarding = lazy(() => import("./pages/Onboarding"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 
-const queryClient = new QueryClient();
+const queryClient = createQueryClient();
 
 function PageLoader() {
   const { t } = useTranslation();

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -1,0 +1,21 @@
+import { QueryClient } from "@tanstack/react-query";
+
+import { HttpError } from "@/lib/api";
+
+/**
+ * 4xx responses will not succeed on retry, and the ApiClient already
+ * redirects to /login on 401 before throwing. Transient 5xx and network
+ * failures get two extra attempts.
+ */
+export const shouldRetryQuery = (failureCount: number, error: Error): boolean =>
+  !(error instanceof HttpError && error.status < 500) && failureCount < 2;
+
+export const createQueryClient = (): QueryClient =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30_000,
+        retry: shouldRetryQuery,
+      },
+    },
+  });

--- a/frontend/src/lib/queryKeys.ts
+++ b/frontend/src/lib/queryKeys.ts
@@ -1,0 +1,13 @@
+/**
+ * Central react-query key registry. Project-scoped mutations invalidate the
+ * `project(id)` prefix, which covers every sub-resource key below it.
+ */
+export const queryKeys = {
+  projects: ["projects"] as const,
+  project: (id: string) => ["projects", id] as const,
+  projectOpinions: (id: string) => ["projects", id, "opinions"] as const,
+  projectResult: (id: string) => ["projects", id, "result"] as const,
+  projectMembers: (id: string) => ["projects", id, "members"] as const,
+  projectInvitations: (id: string) => ["projects", id, "invitations"] as const,
+  invitations: ["invitations"] as const,
+};

--- a/frontend/src/pages/ProjectDetail.tsx
+++ b/frontend/src/pages/ProjectDetail.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import { useParams, Link, useNavigate } from "react-router-dom";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { motion } from "framer-motion";
 import {
@@ -34,7 +35,8 @@ import {
   useOpinionForm,
 } from "@/components/project";
 import { api, HttpError } from "@/lib/api";
-import { ProjectWithRole, Opinion, CalculationResult, Member, ProjectInvitation } from "@/types/api";
+import { queryKeys } from "@/lib/queryKeys";
+import { Member, ProjectInvitation } from "@/types/api";
 import { useAuth } from "@/contexts/AuthContext";
 import { useToast } from "@/hooks/use-toast";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
@@ -47,13 +49,7 @@ const ProjectDetail = () => {
   const { t } = useTranslation("projects");
   const { t: tCommon } = useTranslation();
 
-  const [project, setProject] = useState<ProjectWithRole | null>(null);
-  const [opinions, setOpinions] = useState<Opinion[]>([]);
-  const [result, setResult] = useState<CalculationResult | null>(null);
-  const [members, setMembers] = useState<Member[]>([]);
-  const [pendingInvitations, setPendingInvitations] = useState<ProjectInvitation[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isSavingOpinion, setIsSavingOpinion] = useState(false);
+  const queryClient = useQueryClient();
 
   const [inviteModalOpen, setInviteModalOpen] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
@@ -62,7 +58,73 @@ const ProjectDetail = () => {
   const [profileMember, setProfileMember] = useState<Member | null>(null);
 
   const [transferTarget, setTransferTarget] = useState<Member | null>(null);
+
+  /* v8 ignore next -- defensive fallback: id always provided by route params */
+  const projectId = id ?? "";
+
+  const projectQuery = useQuery({
+    queryKey: queryKeys.project(projectId),
+    queryFn: () => api.getProject(projectId),
+    enabled: !!id,
+  });
+  const opinionsQuery = useQuery({
+    queryKey: queryKeys.projectOpinions(projectId),
+    queryFn: () => api.getOpinions(projectId),
+    enabled: !!id,
+  });
+  const resultQuery = useQuery({
+    queryKey: queryKeys.projectResult(projectId),
+    queryFn: () => api.getResult(projectId),
+    enabled: !!id,
+  });
+  const membersQuery = useQuery({
+    queryKey: queryKeys.projectMembers(projectId),
+    queryFn: () => api.getMembers(projectId),
+    enabled: !!id,
+  });
+  const invitationsQuery = useQuery({
+    queryKey: queryKeys.projectInvitations(projectId),
+    queryFn: () =>
+      api.getProjectInvitations(projectId).catch((error: unknown) => {
+        // Experts may not list invitations; treat forbidden as "none".
+        if (error instanceof HttpError && error.status === 403) {
+          return [] as ProjectInvitation[];
+        }
+        throw error;
+      }),
+    enabled: !!id,
+  });
+
+  const project = projectQuery.data ?? null;
+  const opinions = opinionsQuery.data ?? [];
+  const result = resultQuery.data ?? null;
+  const members = membersQuery.data ?? [];
+  const pendingInvitations = invitationsQuery.data ?? [];
+  const isLoading =
+    projectQuery.isPending ||
+    opinionsQuery.isPending ||
+    resultQuery.isPending ||
+    membersQuery.isPending ||
+    invitationsQuery.isPending;
+  const hasLoadError =
+    projectQuery.isError ||
+    opinionsQuery.isError ||
+    resultQuery.isError ||
+    membersQuery.isError ||
+    invitationsQuery.isError;
+
   useDocumentTitle(project ? tCommon("pageTitle.projectDetail", { name: project.name }) : tCommon("common.loading"));
+
+  useEffect(() => {
+    if (hasLoadError) {
+      toast({
+        title: t("toast.error"),
+        description: t("toast.loadProjectFailed"),
+        variant: "destructive",
+      });
+      navigate("/projects");
+    }
+  }, [hasLoadError, toast, navigate, t]);
 
   const myOpinion = opinions.find((o) => o.user_id === user?.id);
   const opinionForm = useOpinionForm(project, myOpinion);
@@ -72,77 +134,41 @@ const ProjectDetail = () => {
     ? opinions.find((o) => o.user_id === profileMember.user_id) ?? null
     : null;
 
-  const fetchData = useCallback(async () => {
-    /* v8 ignore next -- defensive guard: id always provided by route params */
-    if (!id) return;
-    try {
-      const [projectData, opinionsData, resultData, membersData, invitationsData] =
-        await Promise.all([
-          api.getProject(id),
-          api.getOpinions(id),
-          api.getResult(id),
-          api.getMembers(id),
-          api.getProjectInvitations(id).catch((error: unknown) => {
-            if (error instanceof HttpError && error.status === 403) {
-              return [] as ProjectInvitation[];
-            }
-            throw error;
-          }),
-        ]);
-      setProject(projectData);
-      setOpinions(opinionsData);
-      setResult(resultData);
-      setMembers(membersData);
-      setPendingInvitations(invitationsData);
-    } catch {
-      toast({
-        title: t("toast.error"),
-        description: t("toast.loadProjectFailed"),
-        variant: "destructive",
-      });
-      navigate("/projects");
-    } finally {
-      setIsLoading(false);
-    }
-  }, [id, toast, navigate, t]);
+  const invalidateProject = () =>
+    queryClient.invalidateQueries({ queryKey: queryKeys.project(projectId) });
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial data load on mount
-    fetchData();
-  }, [fetchData]);
-
-  const handleSaveOpinion = async (values: OpinionFormOutput) => {
-    /* v8 ignore next -- defensive guard: id always provided by route params */
-    if (!id) return;
-
-    setIsSavingOpinion(true);
-    try {
-      await api.createOrUpdateOpinion(id, {
+  const saveOpinion = useMutation({
+    mutationFn: (values: OpinionFormOutput) =>
+      api.createOrUpdateOpinion(projectId, {
         position: values.position,
         lower_bound: values.lower,
         peak: values.peak,
         upper_bound: values.upper,
-      });
+      }),
+    onSuccess: () => {
       toast({ title: t("toast.opinionSaved") });
-      fetchData();
-    } catch (error) {
+      invalidateProject();
+    },
+    onError: (error) => {
       toast({
         title: t("toast.error"),
         description: error instanceof Error ? error.message : t("toast.saveFailed"),
         variant: "destructive",
       });
-    } finally {
-      setIsSavingOpinion(false);
-    }
+    },
+  });
+
+  const handleSaveOpinion = async (values: OpinionFormOutput) => {
+    await saveOpinion.mutateAsync(values).catch(() => {
+      // errors are surfaced via the mutation's onError toast
+    });
   };
 
   const handleDeleteOpinion = async () => {
-    /* v8 ignore next -- defensive guard: id always provided by route params */
-    if (!id) return;
     try {
-      await api.deleteOpinion(id);
+      await api.deleteOpinion(projectId);
       toast({ title: t("toast.opinionDeleted") });
-      fetchData();
+      invalidateProject();
     } catch {
       toast({
         title: t("toast.error"),
@@ -153,11 +179,11 @@ const ProjectDetail = () => {
   };
 
   const handleDeleteProject = async () => {
-    /* v8 ignore next -- defensive guard: id always provided by route params */
-    if (!id) return;
     try {
-      await api.deleteProject(id);
+      await api.deleteProject(projectId);
       toast({ title: t("toast.projectDeleted") });
+      queryClient.removeQueries({ queryKey: queryKeys.project(projectId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.projects, exact: true });
       navigate("/projects");
     } catch {
       toast({
@@ -169,12 +195,10 @@ const ProjectDetail = () => {
   };
 
   const handleRemoveMember = async (userId: string) => {
-    /* v8 ignore next -- defensive guard: id always provided by route params */
-    if (!id) return;
     try {
-      await api.removeMember(id, userId);
+      await api.removeMember(projectId, userId);
       toast({ title: t("toast.memberRemoved") });
-      fetchData();
+      invalidateProject();
     } catch {
       toast({
         title: t("toast.error"),
@@ -185,13 +209,13 @@ const ProjectDetail = () => {
   };
 
   const handleTransferOwnership = async () => {
-    /* v8 ignore next -- defensive guard: id and target are always set when invoked */
-    if (!id || !transferTarget) return;
+    /* v8 ignore next -- defensive guard: target is always set when invoked */
+    if (!transferTarget) return;
     try {
-      await api.transferOwnership(id, transferTarget.user_id);
+      await api.transferOwnership(projectId, transferTarget.user_id);
       toast({ title: t("toast.ownershipTransferred") });
       setTransferTarget(null);
-      fetchData();
+      invalidateProject();
     } catch {
       toast({
         title: t("toast.error"),
@@ -296,7 +320,7 @@ const ProjectDetail = () => {
               form={opinionForm}
               project={project}
               myOpinion={myOpinion}
-              isSaving={isSavingOpinion}
+              isSaving={saveOpinion.isPending}
               onSubmit={handleSaveOpinion}
               onDelete={handleDeleteOpinion}
             />
@@ -338,7 +362,7 @@ const ProjectDetail = () => {
                 form={opinionForm}
                 project={project}
                 myOpinion={myOpinion}
-                isSaving={isSavingOpinion}
+                isSaving={saveOpinion.isPending}
                 onSubmit={handleSaveOpinion}
                 onDelete={handleDeleteOpinion}
               />

--- a/frontend/src/pages/ProjectDetail.tsx
+++ b/frontend/src/pages/ProjectDetail.tsx
@@ -106,12 +106,14 @@ const ProjectDetail = () => {
     resultQuery.isPending ||
     membersQuery.isPending ||
     invitationsQuery.isPending;
+  // isLoadingError only: a failed background refetch keeps cached data on
+  // screen and must not eject the user from the page.
   const hasLoadError =
-    projectQuery.isError ||
-    opinionsQuery.isError ||
-    resultQuery.isError ||
-    membersQuery.isError ||
-    invitationsQuery.isError;
+    projectQuery.isLoadingError ||
+    opinionsQuery.isLoadingError ||
+    resultQuery.isLoadingError ||
+    membersQuery.isLoadingError ||
+    invitationsQuery.isLoadingError;
 
   useDocumentTitle(project ? tCommon("pageTitle.projectDetail", { name: project.name }) : tCommon("common.loading"));
 

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus, Users, Key, MoreHorizontal, Loader2, Mail, Inbox } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -19,7 +20,8 @@ import { CreateProjectModal } from "@/components/modals/CreateProjectModal";
 import { InviteExpertModal } from "@/components/modals/InviteExpertModal";
 import { DeleteConfirmModal } from "@/components/modals/DeleteConfirmModal";
 import { api } from "@/lib/api";
-import { ProjectWithRole, Invitation } from "@/types/api";
+import { queryKeys } from "@/lib/queryKeys";
+import { ProjectWithRole } from "@/types/api";
 import { useToast } from "@/hooks/use-toast";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
@@ -45,82 +47,94 @@ const Projects = () => {
   const { t: tCommon } = useTranslation();
   const { toast } = useToast();
   useDocumentTitle(tCommon("pageTitle.projects"));
-  const [projects, setProjects] = useState<ProjectWithRole[]>([]);
-  const [invitations, setInvitations] = useState<Invitation[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const queryClient = useQueryClient();
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [inviteModalOpen, setInviteModalOpen] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [selectedProject, setSelectedProject] = useState<ProjectWithRole | null>(null);
 
-  const fetchData = useCallback(async () => {
-    try {
-      const [projectsData, invitationsData] = await Promise.all([
-        api.getProjects(),
-        api.getInvitations(),
-      ]);
-      setProjects(projectsData);
-      setInvitations(invitationsData);
-    } catch {
+  const projectsQuery = useQuery({
+    queryKey: queryKeys.projects,
+    queryFn: () => api.getProjects(),
+  });
+  const invitationsQuery = useQuery({
+    queryKey: queryKeys.invitations,
+    queryFn: () => api.getInvitations(),
+  });
+
+  const projects = projectsQuery.data ?? [];
+  const invitations = invitationsQuery.data ?? [];
+  const isLoading = projectsQuery.isPending || invitationsQuery.isPending;
+  const hasLoadError = projectsQuery.isError || invitationsQuery.isError;
+
+  useEffect(() => {
+    if (hasLoadError) {
       toast({
         title: t("toast.error"),
         description: t("toast.loadFailed"),
         variant: "destructive",
       });
-    } finally {
-      setIsLoading(false);
     }
-  }, [toast, t]);
+  }, [hasLoadError, toast, t]);
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial data load on mount
-    fetchData();
-  }, [fetchData]);
+  const invalidateLists = () => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.projects });
+    queryClient.invalidateQueries({ queryKey: queryKeys.invitations });
+  };
 
-  const handleAcceptInvitation = async (invitationId: string) => {
-    try {
-      await api.acceptInvitation(invitationId);
+  const acceptInvitation = useMutation({
+    mutationFn: (invitationId: string) => api.acceptInvitation(invitationId),
+    onSuccess: () => {
       toast({ title: t("toast.invitationAccepted") });
-      fetchData();
-    } catch (error) {
+      invalidateLists();
+    },
+    onError: (error) => {
       toast({
         title: t("toast.error"),
         description: error instanceof Error ? error.message : t("toast.acceptFailed"),
         variant: "destructive",
       });
-    }
-  };
+    },
+  });
 
-  const handleDeclineInvitation = async (invitationId: string) => {
-    try {
-      await api.declineInvitation(invitationId);
+  const declineInvitation = useMutation({
+    mutationFn: (invitationId: string) => api.declineInvitation(invitationId),
+    onSuccess: () => {
       toast({ title: t("toast.invitationDeclined") });
-      fetchData();
-    } catch (error) {
+      invalidateLists();
+    },
+    onError: (error) => {
       toast({
         title: t("toast.error"),
         description: error instanceof Error ? error.message : t("toast.declineFailed"),
         variant: "destructive",
       });
-    }
-  };
+    },
+  });
 
-  const handleDeleteProject = async () => {
-    /* v8 ignore next */
-    if (!selectedProject) return;
-    try {
-      await api.deleteProject(selectedProject.id);
+  const deleteProject = useMutation({
+    mutationFn: (projectId: string) => api.deleteProject(projectId),
+    onSuccess: () => {
       toast({ title: t("toast.projectDeleted") });
       setDeleteModalOpen(false);
       setSelectedProject(null);
-      fetchData();
-    } catch (error) {
+      queryClient.invalidateQueries({ queryKey: queryKeys.projects });
+    },
+    onError: (error) => {
       toast({
         title: t("toast.error"),
         description: error instanceof Error ? error.message : t("toast.deleteFailed"),
         variant: "destructive",
       });
-    }
+    },
+  });
+
+  const handleDeleteProject = async () => {
+    /* v8 ignore next */
+    if (!selectedProject) return;
+    await deleteProject.mutateAsync(selectedProject.id).catch(() => {
+      // errors are surfaced via the mutation's onError toast
+    });
   };
 
   if (isLoading) {
@@ -338,13 +352,13 @@ const Projects = () => {
                               <Button
                                 variant="outline"
                                 size="sm"
-                                onClick={() => handleDeclineInvitation(invitation.id)}
+                                onClick={() => declineInvitation.mutate(invitation.id)}
                               >
                                 {t("buttons.decline")}
                               </Button>
                               <Button
                                 size="sm"
-                                onClick={() => handleAcceptInvitation(invitation.id)}
+                                onClick={() => acceptInvitation.mutate(invitation.id)}
                               >
                                 {t("buttons.accept")}
                               </Button>
@@ -364,7 +378,7 @@ const Projects = () => {
       <CreateProjectModal
         open={createModalOpen}
         onOpenChange={setCreateModalOpen}
-        onSuccess={fetchData}
+        onSuccess={() => queryClient.invalidateQueries({ queryKey: queryKeys.projects })}
       />
 
       <InviteExpertModal

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -65,7 +65,9 @@ const Projects = () => {
   const projects = projectsQuery.data ?? [];
   const invitations = invitationsQuery.data ?? [];
   const isLoading = projectsQuery.isPending || invitationsQuery.isPending;
-  const hasLoadError = projectsQuery.isError || invitationsQuery.isError;
+  // isLoadingError only: a failed background refetch keeps cached data on
+  // screen and should not surface a destructive toast over an intact page.
+  const hasLoadError = projectsQuery.isLoadingError || invitationsQuery.isLoadingError;
 
   useEffect(() => {
     if (hasLoadError) {

--- a/frontend/tests/lib/queryClient.test.ts
+++ b/frontend/tests/lib/queryClient.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { createQueryClient, shouldRetryQuery } from '@/lib/queryClient';
+import { HttpError } from '@/lib/api';
+
+describe('shouldRetryQuery', () => {
+  it('does not retry 4xx responses', () => {
+    expect(shouldRetryQuery(0, new HttpError('Not found', 404))).toBe(false);
+  });
+
+  it('does not retry 401 responses', () => {
+    expect(shouldRetryQuery(0, new HttpError('Unauthorized', 401))).toBe(false);
+  });
+
+  it('retries 5xx responses up to two times', () => {
+    const error = new HttpError('Server error', 500);
+    expect(shouldRetryQuery(0, error)).toBe(true);
+    expect(shouldRetryQuery(1, error)).toBe(true);
+    expect(shouldRetryQuery(2, error)).toBe(false);
+  });
+
+  it('retries network errors up to two times', () => {
+    const error = new Error('Network failure');
+    expect(shouldRetryQuery(0, error)).toBe(true);
+    expect(shouldRetryQuery(1, error)).toBe(true);
+    expect(shouldRetryQuery(2, error)).toBe(false);
+  });
+});
+
+describe('createQueryClient', () => {
+  it('configures staleTime and the retry policy', () => {
+    const client = createQueryClient();
+    const defaults = client.getDefaultOptions().queries;
+
+    expect(defaults?.staleTime).toBe(30_000);
+    expect(defaults?.retry).toBe(shouldRetryQuery);
+  });
+});

--- a/frontend/tests/pages/Projects.test.tsx
+++ b/frontend/tests/pages/Projects.test.tsx
@@ -12,6 +12,7 @@ const mockApi = {
   acceptInvitation: vi.fn(),
   declineInvitation: vi.fn(),
   deleteProject: vi.fn(),
+  createProject: vi.fn(),
 };
 
 vi.mock('@/lib/api', () => ({
@@ -21,6 +22,7 @@ vi.mock('@/lib/api', () => ({
     acceptInvitation: (id: string) => mockApi.acceptInvitation(id),
     declineInvitation: (id: string) => mockApi.declineInvitation(id),
     deleteProject: (id: string) => mockApi.deleteProject(id),
+    createProject: (data: unknown) => mockApi.createProject(data),
   },
 }));
 
@@ -600,6 +602,36 @@ describe('Projects', () => {
           })
         );
       });
+    });
+  });
+});
+
+describe('Projects - Create Project', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.getProjects.mockResolvedValue([]);
+    mockApi.getInvitations.mockResolvedValue([]);
+    mockApi.createProject.mockResolvedValue({});
+  });
+
+  it('refetches the project list after creating a project', async () => {
+    const user = userEvent.setup();
+    render(<Projects />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /new project/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /new project/i }));
+    await user.type(screen.getByLabelText(/project name/i), 'My Project');
+    await user.type(screen.getByLabelText(/unit/i), '%');
+    await user.click(screen.getByRole('button', { name: 'Create Project' }));
+
+    await waitFor(() => {
+      expect(mockApi.createProject).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(mockApi.getProjects).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/frontend/tests/utils.tsx
+++ b/frontend/tests/utils.tsx
@@ -1,9 +1,21 @@
-import { ReactElement, ReactNode } from 'react'
+import { ReactElement, ReactNode, useState } from 'react'
 import { render, RenderOptions, screen } from '@testing-library/react'
 import { MemoryRouter, MemoryRouterProps } from 'react-router-dom'
 import { I18nextProvider } from 'react-i18next'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import i18n from '@/i18n'
 import { User } from '@/types/api'
+
+/**
+ * Fresh client per render: a shared client would leak cached data between
+ * tests. Retries are off so error paths fail fast instead of timing out.
+ */
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+    },
+  })
 
 /**
  * Mock AuthContext value for testing.
@@ -28,12 +40,15 @@ export interface CustomRenderOptions extends Omit<RenderOptions, 'wrapper'> {
 }
 
 function AllTheProviders({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(createTestQueryClient)
   return (
-    <MemoryRouter>
-      <I18nextProvider i18n={i18n}>
-        {children}
-      </I18nextProvider>
-    </MemoryRouter>
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <I18nextProvider i18n={i18n}>
+          {children}
+        </I18nextProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
   )
 }
 
@@ -42,12 +57,15 @@ function AllTheProviders({ children }: { children: ReactNode }) {
  */
 function createWrapper(initialEntries?: MemoryRouterProps['initialEntries']) {
   return function Wrapper({ children }: { children: ReactNode }) {
+    const [queryClient] = useState(createTestQueryClient)
     return (
-      <MemoryRouter initialEntries={initialEntries}>
-        <I18nextProvider i18n={i18n}>
-          {children}
-        </I18nextProvider>
-      </MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={initialEntries}>
+          <I18nextProvider i18n={i18n}>
+            {children}
+          </I18nextProvider>
+        </MemoryRouter>
+      </QueryClientProvider>
     )
   }
 }


### PR DESCRIPTION
Supersedes #270 (linear rebuild on top of develop so rebase-and-merge works). Includes the fixes for both Greptile findings from #270: error effects now key off isLoadingError, so background refetch failures keep the page intact.