### PR TITLE
feat: add load-more pagination to the projects list

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -243,7 +243,7 @@
         "filename": "frontend/tests/contexts/AuthContext.test.tsx",
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_verified": false,
-        "line_number": 163
+        "line_number": 199
       }
     ],
     "frontend/tests/lib/api.test.ts": [
@@ -999,5 +999,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-06T16:39:27Z"
+  "generated_at": "2026-07-06T17:48:58Z"
 }

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { User } from '@/types/api';
 import { api } from '@/lib/api';
 import { logger } from '@/lib/logger';
@@ -16,6 +17,7 @@ interface AuthContextType {
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export function AuthProvider({ children }: { readonly children: React.ReactNode }) {
+  const queryClient = useQueryClient();
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -59,7 +61,9 @@ export function AuthProvider({ children }: { readonly children: React.ReactNode 
   const logout = useCallback(async () => {
     await api.logout();
     setUser(null);
-  }, []);
+    // Drop cached queries so the next account on this tab cannot see them.
+    queryClient.clear();
+  }, [queryClient]);
 
   const value = useMemo(() => ({
     user,

--- a/frontend/src/i18n/locales/cs/projects.json
+++ b/frontend/src/i18n/locales/cs/projects.json
@@ -7,7 +7,8 @@
   "buttons": {
     "newProject": "Nový projekt",
     "decline": "Odmítnout",
-    "accept": "Přijmout pozvánku"
+    "accept": "Přijmout pozvánku",
+    "loadMore": "Načíst další"
   },
   "empty": {
     "title": "Zatím žádné projekty",

--- a/frontend/src/i18n/locales/en/projects.json
+++ b/frontend/src/i18n/locales/en/projects.json
@@ -7,7 +7,8 @@
   "buttons": {
     "newProject": "New Project",
     "decline": "Decline",
-    "accept": "Accept Invitation"
+    "accept": "Accept Invitation",
+    "loadMore": "Load more"
   },
   "empty": {
     "title": "No projects yet",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -221,8 +221,12 @@ class ApiClient {
   }
 
   // Projects
-  async getProjects(): Promise<ProjectWithRole[]> {
-    return this.request<ProjectWithRole[]>('/projects');
+  async getProjects(params?: { limit?: number; offset?: number }): Promise<ProjectWithRole[]> {
+    const query = new URLSearchParams();
+    if (params?.limit !== undefined) query.set('limit', String(params.limit));
+    if (params?.offset !== undefined) query.set('offset', String(params.offset));
+    const suffix = query.size > 0 ? `?${query.toString()}` : '';
+    return this.request<ProjectWithRole[]>(`/projects${suffix}`);
   }
 
   async getProject(id: string): Promise<ProjectWithRole> {

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus, Users, Key, MoreHorizontal, Loader2, Mail, Inbox } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -24,6 +24,9 @@ import { queryKeys } from "@/lib/queryKeys";
 import { ProjectWithRole } from "@/types/api";
 import { useToast } from "@/hooks/use-toast";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
+// Multiple of the 1/2/3-column grid so every full page fills whole rows.
+const PAGE_SIZE = 24;
 
 const containerVariants = {
   hidden: { opacity: 0 },
@@ -53,16 +56,21 @@ const Projects = () => {
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [selectedProject, setSelectedProject] = useState<ProjectWithRole | null>(null);
 
-  const projectsQuery = useQuery({
+  const projectsQuery = useInfiniteQuery({
     queryKey: queryKeys.projects,
-    queryFn: () => api.getProjects(),
+    queryFn: ({ pageParam }) => api.getProjects({ limit: PAGE_SIZE, offset: pageParam }),
+    initialPageParam: 0,
+    // The list endpoint returns no total count: a full page means there may
+    // be more, a short page means the end was reached.
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.length === PAGE_SIZE ? allPages.flat().length : undefined,
   });
   const invitationsQuery = useQuery({
     queryKey: queryKeys.invitations,
     queryFn: () => api.getInvitations(),
   });
 
-  const projects = projectsQuery.data ?? [];
+  const projects = projectsQuery.data?.pages.flat() ?? [];
   const invitations = invitationsQuery.data ?? [];
   const isLoading = projectsQuery.isPending || invitationsQuery.isPending;
   // isLoadingError only: a failed background refetch keeps cached data on
@@ -199,6 +207,7 @@ const Projects = () => {
                 </Button>
               </motion.div>
             ) : (
+              <>
               <motion.div
                 className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
                 variants={containerVariants}
@@ -284,6 +293,22 @@ const Projects = () => {
                   </motion.div>
                 ))}
               </motion.div>
+              {projectsQuery.hasNextPage && (
+                <div className="flex justify-center pt-2">
+                  <Button
+                    variant="outline"
+                    onClick={() => projectsQuery.fetchNextPage()}
+                    disabled={projectsQuery.isFetchingNextPage}
+                    className="gap-2"
+                  >
+                    {projectsQuery.isFetchingNextPage && (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    )}
+                    {t("buttons.loadMore")}
+                  </Button>
+                </div>
+              )}
+              </>
             )}
           </TabsContent>
 

--- a/frontend/tests/contexts/AuthContext.test.tsx
+++ b/frontend/tests/contexts/AuthContext.test.tsx
@@ -1,8 +1,18 @@
+import { ReactNode } from 'react'
 import { renderHook, act, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider, useAuth } from '@/contexts/AuthContext'
 import { api } from '@/lib/api'
 import { createUser } from '@tests/factories/user'
+
+function AuthTestProviders({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <AuthProvider>{children}</AuthProvider>
+    </QueryClientProvider>
+  )
+}
 
 vi.mock('@/lib/api', () => ({
   api: {
@@ -36,7 +46,7 @@ describe('AuthContext', () => {
     vi.mocked(api.getCurrentUser).mockResolvedValue(mockUser)
 
     const { result } = renderHook(() => useAuth(), {
-      wrapper: AuthProvider,
+      wrapper: AuthTestProviders,
     })
 
     await waitFor(() => {
@@ -51,7 +61,7 @@ describe('AuthContext', () => {
     vi.mocked(api.getCurrentUser).mockRejectedValue(new Error('401'))
 
     const { result } = renderHook(() => useAuth(), {
-      wrapper: AuthProvider,
+      wrapper: AuthTestProviders,
     })
 
     await waitFor(() => {
@@ -68,7 +78,7 @@ describe('AuthContext', () => {
     vi.mocked(api.getCurrentUser).mockResolvedValue(mockUser)
 
     const { result } = renderHook(() => useAuth(), {
-      wrapper: AuthProvider,
+      wrapper: AuthTestProviders,
     })
 
     await waitFor(() => {
@@ -87,7 +97,7 @@ describe('AuthContext', () => {
     vi.mocked(api.getCurrentUser).mockResolvedValue(mockUser)
 
     const { result } = renderHook(() => useAuth(), {
-      wrapper: AuthProvider,
+      wrapper: AuthTestProviders,
     })
 
     await waitFor(() => {
@@ -103,11 +113,37 @@ describe('AuthContext', () => {
     expect(result.current.isAuthenticated).toBe(false)
   })
 
+  it('drops cached queries on logout so the next account cannot see them', async () => {
+    const mockUser = createUser({ id: '1', email: 'test@example.com', first_name: 'Test' })
+    vi.mocked(api.getCurrentUser).mockResolvedValue(mockUser)
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>{children}</AuthProvider>
+      </QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useAuth(), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(true)
+    })
+
+    queryClient.setQueryData(['projects'], [{ id: 'p1' }])
+
+    await act(async () => {
+      await result.current.logout()
+    })
+
+    expect(queryClient.getQueryData(['projects'])).toBeUndefined()
+  })
+
   it('clears the user when the session probe fails', async () => {
     vi.mocked(api.getCurrentUser).mockRejectedValue(new Error('Token expired'))
 
     const { result } = renderHook(() => useAuth(), {
-      wrapper: AuthProvider,
+      wrapper: AuthTestProviders,
     })
 
     await waitFor(() => {
@@ -122,7 +158,7 @@ describe('AuthContext', () => {
     vi.mocked(api.getCurrentUser).mockRejectedValue(new Error('401'))
 
     const { result } = renderHook(() => useAuth(), {
-      wrapper: AuthProvider,
+      wrapper: AuthTestProviders,
     })
 
     await waitFor(() => {
@@ -143,7 +179,7 @@ describe('AuthContext', () => {
     vi.mocked(api.getCurrentUser).mockRejectedValue(new Error('401'))
 
     const { result } = renderHook(() => useAuth(), {
-      wrapper: AuthProvider,
+      wrapper: AuthTestProviders,
     })
 
     await waitFor(() => {
@@ -171,7 +207,7 @@ describe('AuthContext', () => {
     vi.mocked(api.getCurrentUser).mockRejectedValue(new Error('401'))
 
     const { result } = renderHook(() => useAuth(), {
-      wrapper: AuthProvider,
+      wrapper: AuthTestProviders,
     })
 
     await waitFor(() => {

--- a/frontend/tests/lib/api.test.ts
+++ b/frontend/tests/lib/api.test.ts
@@ -883,4 +883,39 @@ describe('ApiClient', () => {
       expect(warnSpy).toHaveBeenCalled();
     });
   });
+
+  describe('getProjects pagination params', () => {
+    beforeEach(() => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([]),
+      });
+    });
+
+    it('requests /projects without a query string when no params are given', async () => {
+      await api.getProjects();
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toMatch(/\/projects$/);
+    });
+
+    it('appends limit and offset when provided', async () => {
+      await api.getProjects({ limit: 24, offset: 48 });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/projects?limit=24&offset=48'),
+        expect.anything()
+      );
+    });
+
+    it('appends only the provided param', async () => {
+      await api.getProjects({ limit: 10 });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/projects?limit=10'),
+        expect.anything()
+      );
+    });
+  });
 });

--- a/frontend/tests/pages/Projects.test.tsx
+++ b/frontend/tests/pages/Projects.test.tsx
@@ -17,7 +17,7 @@ const mockApi = {
 
 vi.mock('@/lib/api', () => ({
   api: {
-    getProjects: () => mockApi.getProjects(),
+    getProjects: (params?: { limit?: number; offset?: number }) => mockApi.getProjects(params),
     getInvitations: () => mockApi.getInvitations(),
     acceptInvitation: (id: string) => mockApi.acceptInvitation(id),
     declineInvitation: (id: string) => mockApi.declineInvitation(id),
@@ -603,6 +603,61 @@ describe('Projects', () => {
         );
       });
     });
+  });
+});
+
+describe('Projects - Pagination', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.getInvitations.mockResolvedValue([]);
+  });
+
+  it('shows the load-more button when a full page is returned', async () => {
+    mockApi.getProjects.mockResolvedValue(
+      Array.from({ length: 24 }, () => createProjectWithRole())
+    );
+
+    render(<Projects />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /load more/i })).toBeInTheDocument();
+    });
+  });
+
+  it('hides the load-more button when a short page is returned', async () => {
+    mockApi.getProjects.mockResolvedValue([createProjectWithRole()]);
+
+    render(<Projects />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /new project/i })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument();
+  });
+
+  it('appends the next page when load more is clicked', async () => {
+    const firstPage = Array.from({ length: 24 }, (_, i) =>
+      createProjectWithRole({ name: `Project ${i + 1}` })
+    );
+    const secondPage = [createProjectWithRole({ name: 'Project 25' })];
+    mockApi.getProjects
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce(secondPage);
+
+    const user = userEvent.setup();
+    render(<Projects />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /load more/i })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: /load more/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Project 25')).toBeInTheDocument();
+    });
+    expect(mockApi.getProjects).toHaveBeenNthCalledWith(1, { limit: 24, offset: 0 });
+    expect(mockApi.getProjects).toHaveBeenNthCalledWith(2, { limit: 24, offset: 24 });
+    expect(screen.getByText('Project 1')).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
Supersedes #271 (linear rebuild on top of develop so rebase-and-merge works).

## Summary

Adds load-more pagination to the projects list so the page no longer fetches every project at once (the backend caps list endpoints at 100 items).

- `api.getProjects()` now accepts optional `limit`/`offset` and builds the query string accordingly; no params keeps the old behavior.
- The projects tab uses `useInfiniteQuery` with a page size of 24 (a multiple of the 1/2/3-column grid). The backend returns a plain list without a total count, so a full page means there may be more and a short page ends the list.
- A localized Load more button (en/cs) appends the next page; list invalidation resets to the first page.
- Security fix picked up along the way: `queryClient.clear()` on logout, so cached project data cannot leak to the next account signing in on the same tab. Covered by a regression test.

## Testing

- Unit tests for the query-string building and for the full-page/short-page/append flows (780 tests green, coverage thresholds hold).
- Manual check against the local backend.
