### PR TITLE
style: align font weights after the visual design review

### DIFF
--- a/frontend/src/components/project/MemberProfileDialog.tsx
+++ b/frontend/src/components/project/MemberProfileDialog.tsx
@@ -40,7 +40,7 @@ export const MemberProfileDialog = ({
             )}
             <AvatarFallback className="text-xl">{initials}</AvatarFallback>
           </Avatar>
-          <DialogTitle className="text-xl font-light">{fullName}</DialogTitle>
+          <DialogTitle className="text-xl font-normal">{fullName}</DialogTitle>
           <div className="flex flex-col items-center gap-1">
             <Badge
               variant={member.role === "admin" ? "default" : "secondary"}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -21,7 +21,8 @@
 
   --text-display-1: 3rem;
   --text-display-1--line-height: 1.1;
-  --text-display-1--font-weight: 300;
+  /* Playfair Display has no 300 weight; 400 is its lightest cut */
+  --text-display-1--font-weight: 400;
   --text-display-2: 2rem;
   --text-display-2--line-height: 1.2;
   --text-display-2--font-weight: 400;
@@ -358,7 +359,7 @@
   
   /* Heading Styles */
   h1, .h1 {
-    @apply font-display text-5xl font-light tracking-tight;
+    @apply font-display text-5xl font-normal tracking-tight;
   }
   
   h2, .h2 {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,6 +12,7 @@ import "@fontsource/playfair-display/500.css";
 import "@fontsource/playfair-display/600.css";
 import "@fontsource/jetbrains-mono/400.css";
 import "@fontsource/jetbrains-mono/500.css";
+import "@fontsource/jetbrains-mono/700.css";
 import "./index.css";
 
 if (import.meta.env.VITE_SENTRY_DSN) {

--- a/frontend/src/pages/CaseStudy.tsx
+++ b/frontend/src/pages/CaseStudy.tsx
@@ -35,7 +35,7 @@ const CaseStudy = () => {
       <div className="min-h-screen bg-background">
         <Navbar />
         <div className="container mx-auto px-6 py-20 text-center">
-          <h1 className="font-display text-3xl md:text-4xl font-light mb-4">
+          <h1 className="font-display text-3xl md:text-4xl font-normal mb-4">
             {tCommon("notFound.title")}
           </h1>
           <Button variant="outline" asChild>

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -58,7 +58,7 @@ const Landing = () => {
             variants={stagger}
           >
             <motion.h1
-              className="font-display text-4xl md:text-6xl lg:text-7xl font-light tracking-tight mb-6"
+              className="font-display text-4xl md:text-6xl lg:text-7xl font-normal tracking-tight mb-6"
               variants={fadeInUp}
             >
               {t("hero.title1")}

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -20,7 +20,7 @@ const NotFound = () => {
       <Navbar />
       <main id="main-content" className="flex min-h-[calc(100vh-4rem)] items-center justify-center">
         <div className="text-center">
-          <h1 className="font-display text-4xl font-light tracking-tight mb-4">{t("notFound.code")}</h1>
+          <h1 className="font-display text-4xl font-normal tracking-tight mb-4">{t("notFound.code")}</h1>
           <p className="mb-4 text-xl text-muted-foreground">
             {t("notFound.description")}
           </p>

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -287,7 +287,7 @@ const Profile = () => {
                 )}
               </div>
             </div>
-            <h1 className="font-display text-3xl font-light">
+            <h1 className="font-display text-3xl font-normal">
               {user.first_name} {user.last_name}
             </h1>
             <p className="text-muted-foreground">{user.email}</p>

--- a/frontend/src/pages/ProjectDetail.tsx
+++ b/frontend/src/pages/ProjectDetail.tsx
@@ -275,7 +275,7 @@ const ProjectDetail = () => {
           animate={{ opacity: 1, y: 0 }}
           className="mb-8"
         >
-          <h1 className="font-display text-3xl md:text-4xl font-light mb-2">
+          <h1 className="font-display text-3xl md:text-4xl font-normal mb-2">
             {project.name}
           </h1>
           {project.description && (


### PR DESCRIPTION
Supersedes #272 (linear rebuild on top of develop so rebase-and-merge works).

## Summary

Follow-up from a visual design review of the whole app (9 pages, light/dark themes, desktop and 390px mobile widths, screenshot pass via Playwright).

The review confirmed the design system holds up well; the only real defect was typography honesty:

- `font-light` on Playfair Display headings asked for a 300 weight the family does not ship, so browsers silently rendered 400. Headings now say `font-normal`, matching what users actually see. The `--text-display-1` token weight is corrected the same way.
- Numeric stats set in `font-mono font-bold` were rendered as synthetic (faux) bold because only JetBrains Mono 400/500 were loaded. The real 700 cut is now loaded instead.

No layout or color changes; visual-regression snapshots and the WCAG audit (14/14) pass.

## Testing

- `npx vitest run` — 780 tests green.
- `npx playwright test --project=wcag-audit` and regenerated visual-regression snapshots.
