### PR TITLE
perf: reduce Railway backend resource usage

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -7,6 +7,7 @@ This module provides:
 
 import logging
 from enum import StrEnum
+from functools import lru_cache
 from typing import Annotated
 from uuid import UUID
 
@@ -132,8 +133,14 @@ def get_email_service() -> EmailSender:
     return ConsoleEmailSender(settings)
 
 
+@lru_cache(maxsize=1)
 def get_storage_service() -> StorageService | None:
     """Create the storage service when bucket storage is configured.
+
+    Cached as a process singleton: configuration is fixed for the process, so the
+    underlying boto3 S3 client is built once and reused instead of being rebuilt on
+    every request (the public avatar endpoint is hit frequently). The boto3 client
+    is thread-safe, so sharing it across the threadpool is safe.
 
     Returns None when storage is not configured or initialization fails,
     which disables photo upload while leaving the rest of the API working.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,11 @@ RUN uv sync --locked --no-dev --extra api
 # ============================================
 # Stage 2: Runtime
 # ============================================
-FROM python:3.13 AS runtime
+# Slim base: the runtime only needs the prebuilt venv plus libpq5, so the full
+# Debian image is unnecessary. Slim maps fewer shared libraries and produces a
+# much smaller image (lower disk + slightly lower resident memory on Railway).
+# The builder above stays full so psycopg2 still compiles.
+FROM python:3.13-slim AS runtime
 
 WORKDIR /app
 
@@ -79,9 +83,11 @@ ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 
 # Default worker count (can be overridden via environment)
-# Railway: set to 1 (horizontal scaling via Railway replicas)
-# Local/self-hosted: set to 4 or more
-ENV UVICORN_WORKERS=4
+# Railway: 1 is the intended value (scale horizontally via Railway replicas, not
+# in-container workers). Each extra worker is a full interpreter holding a copy of
+# the app; Redis-backed auth state (throttle/revocation) is shared, so 1 is safe.
+# Local/self-hosted may override to 4 or more.
+ENV UVICORN_WORKERS=1
 
 # Expose port
 EXPOSE 8000

--- a/railway.toml
+++ b/railway.toml
@@ -11,3 +11,7 @@ healthcheckTimeout = 30
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3
 region = "europe-west4"
+# Pin to a single replica: scale intentionally, never accidentally. One uvicorn
+# worker per replica (see UVICORN_WORKERS in docker/Dockerfile) keeps the memory
+# footprint predictable and bounded on Railway.
+numReplicas = 1

--- a/tests/unit/api/test_dependencies.py
+++ b/tests/unit/api/test_dependencies.py
@@ -24,6 +24,17 @@ from api.services.storage.railway_bucket_storage_service import RailwayBucketSto
 class TestGetStorageService:
     """Tests for the get_storage_service factory function."""
 
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        """Reset the cached singleton so each case exercises the factory fresh.
+
+        get_storage_service is an ``lru_cache`` process singleton; without this
+        the first call's result would be reused by the others.
+        """
+        get_storage_service.cache_clear()
+        yield
+        get_storage_service.cache_clear()
+
     def test_returns_none_when_storage_disabled(self):
         """
         GIVEN bucket storage is not configured


### PR DESCRIPTION
## What

Trims the backend's memory/CPU footprint on Railway. No functional change — only deploy-time and per-request efficiency.

## Changes

- **`docker/Dockerfile`**
  - Default `UVICORN_WORKERS` 4 → 1. Each worker is a full interpreter holding a copy of the app; scaling is meant to happen via Railway replicas, not in-container workers. Auth state (login/reset throttle, token revocation) lives in Redis and is shared across processes, so a single worker is safe. (Override still available via the env var for local/self-hosted.)
  - Runtime stage base `python:3.13` → `python:3.13-slim`. Only the prebuilt venv + `libpq5` are needed at runtime; slim maps fewer shared libraries and produces a much smaller image. The builder stage stays full so `psycopg2` still compiles.
- **`railway.toml`** — pin `numReplicas = 1` so scaling is intentional and the footprint is bounded.
- **`api/dependencies.py`** — cache `get_storage_service` with `@lru_cache`, matching the existing `get_engine`/`get_settings` pattern. The boto3 S3 client is now built once per process instead of on every request to the public avatar endpoint (`GET /users/{id}/photo`). Adds a cache-clearing fixture to the affected unit tests.

## Verification

- `ruff` + `mypy` clean on changed files.
- `pytest tests/unit/api/test_dependencies.py` — 11 passed.
- Built the `-slim` runtime image and ran it: `api.main` + `redis` + `reportlab` + `psycopg2` import cleanly, and a reportlab PDF renders (the export path). Image size ~443 MB.

## Context

Part of a Railway cost pass. The bigger wins (App Sleep on dev/staging, prod region co-located with its DB, `UVICORN_WORKERS=1` set on the live service) were applied directly to the environments; this PR lands the matching source-level defaults so a fresh deploy keeps them.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces Railway backend resource usage through three coordinated changes: slimming the Docker runtime image (`python:3.13-slim`), reducing the default in-container worker count to 1, and pinning replicas to 1 in `railway.toml`. It also caches the `get_storage_service` factory as an `lru_cache` process singleton to avoid rebuilding the boto3 S3 client on every avatar request.

- **`docker/Dockerfile`**: Runtime base switched to `python:3.13-slim` with `libpq5` explicitly installed; `UVICORN_WORKERS` default dropped 4→1. Builder stage stays on the full image so `psycopg2` compiles cleanly.
- **`api/dependencies.py`**: `@lru_cache(maxsize=1)` added to `get_storage_service()`; the function takes no arguments so the singleton pattern is correct, and the boto3 client's thread-safety is documented.
- **`tests/unit/api/test_dependencies.py`**: `autouse` `_clear_cache` fixture properly flushes the cache before and after each `TestGetStorageService` case, preventing cross-test pollution.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all four changed files make intentional, well-scoped infrastructure adjustments with no functional regressions.

The lru_cache pattern is applied correctly to a no-argument factory; test isolation is handled with a proper autouse fixture; the slim Docker base is verified working with all required runtime libraries; and the worker/replica count changes are consistent with Railway's horizontal-scaling model. No correctness issues found across any changed file.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/dependencies.py | Added @lru_cache(maxsize=1) to get_storage_service(); correct no-arg singleton pattern with documented thread-safety rationale and matching test teardown. |
| docker/Dockerfile | Runtime base changed to python:3.13-slim (libpq5 installed explicitly); UVICORN_WORKERS reduced 4→1 for Railway horizontal-scaling model. Builder stage stays full for psycopg2 compilation. |
| railway.toml | numReplicas = 1 added to pin replica count, preventing accidental auto-scaling; comment explains the intent clearly. |
| tests/unit/api/test_dependencies.py | autouse _clear_cache fixture correctly calls cache_clear() before and after each test in TestGetStorageService, ensuring lru_cache doesn't bleed across cases. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Request] --> B[FastAPI calls Depends get_storage_service]
    B --> C{lru_cache hit?}
    C -- Yes --> D[Return cached StorageService or None]
    C -- No, first call only --> E[Execute function body]
    E --> F[get_settings]
    F --> G{storage_enabled?}
    G -- No --> H[Cache None and Return None]
    G -- Yes --> I[RailwayBucketStorageService constructor]
    I -- Success --> J[Cache instance and Return StorageService]
    I -- StorageConfigurationError --> K[Cache None and Return None]
    D --> L[Route handler checks for None]
    J --> L
    H --> L
    K --> L
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Incoming Request] --> B[FastAPI calls Depends get_storage_service]
    B --> C{lru_cache hit?}
    C -- Yes --> D[Return cached StorageService or None]
    C -- No, first call only --> E[Execute function body]
    E --> F[get_settings]
    F --> G{storage_enabled?}
    G -- No --> H[Cache None and Return None]
    G -- Yes --> I[RailwayBucketStorageService constructor]
    I -- Success --> J[Cache instance and Return StorageService]
    I -- StorageConfigurationError --> K[Cache None and Return None]
    D --> L[Route handler checks for None]
    J --> L
    H --> L
    K --> L
```

</a>

<sub>Reviews (1): Last reviewed commit: ["perf: reduce railway backend resource us..."](https://github.com/caitlon/become/commit/3fc74ca61c232c4ad8d4a7d13617baeb695abac6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42875804)</sub>

<!-- /greptile_comment -->