### PR TITLE
perf: propagate Railway resource opt to staging (#282)

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -7,6 +7,7 @@ This module provides:
 
 import logging
 from enum import StrEnum
+from functools import lru_cache
 from typing import Annotated
 from uuid import UUID
 
@@ -132,8 +133,14 @@ def get_email_service() -> EmailSender:
     return ConsoleEmailSender(settings)
 
 
+@lru_cache(maxsize=1)
 def get_storage_service() -> StorageService | None:
     """Create the storage service when bucket storage is configured.
+
+    Cached as a process singleton: configuration is fixed for the process, so the
+    underlying boto3 S3 client is built once and reused instead of being rebuilt on
+    every request (the public avatar endpoint is hit frequently). The boto3 client
+    is thread-safe, so sharing it across the threadpool is safe.
 
     Returns None when storage is not configured or initialization fails,
     which disables photo upload while leaving the rest of the API working.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,11 @@ RUN uv sync --locked --no-dev --extra api
 # ============================================
 # Stage 2: Runtime
 # ============================================
-FROM python:3.13 AS runtime
+# Slim base: the runtime only needs the prebuilt venv plus libpq5, so the full
+# Debian image is unnecessary. Slim maps fewer shared libraries and produces a
+# much smaller image (lower disk + slightly lower resident memory on Railway).
+# The builder above stays full so psycopg2 still compiles.
+FROM python:3.13-slim AS runtime
 
 WORKDIR /app
 
@@ -79,9 +83,11 @@ ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 
 # Default worker count (can be overridden via environment)
-# Railway: set to 1 (horizontal scaling via Railway replicas)
-# Local/self-hosted: set to 4 or more
-ENV UVICORN_WORKERS=4
+# Railway: 1 is the intended value (scale horizontally via Railway replicas, not
+# in-container workers). Each extra worker is a full interpreter holding a copy of
+# the app; Redis-backed auth state (throttle/revocation) is shared, so 1 is safe.
+# Local/self-hosted may override to 4 or more.
+ENV UVICORN_WORKERS=1
 
 # Expose port
 EXPOSE 8000

--- a/railway.toml
+++ b/railway.toml
@@ -11,3 +11,7 @@ healthcheckTimeout = 30
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3
 region = "europe-west4"
+# Pin to a single replica: scale intentionally, never accidentally. One uvicorn
+# worker per replica (see UVICORN_WORKERS in docker/Dockerfile) keeps the memory
+# footprint predictable and bounded on Railway.
+numReplicas = 1

--- a/tests/unit/api/test_dependencies.py
+++ b/tests/unit/api/test_dependencies.py
@@ -24,6 +24,17 @@ from api.services.storage.railway_bucket_storage_service import RailwayBucketSto
 class TestGetStorageService:
     """Tests for the get_storage_service factory function."""
 
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        """Reset the cached singleton so each case exercises the factory fresh.
+
+        get_storage_service is an ``lru_cache`` process singleton; without this
+        the first call's result would be reused by the others.
+        """
+        get_storage_service.cache_clear()
+        yield
+        get_storage_service.cache_clear()
+
     def test_returns_none_when_storage_disabled(self):
         """
         GIVEN bucket storage is not configured


### PR DESCRIPTION
Propagates the Railway resource optimization from #282 (merged to `main`) into this branch so dev/staging deploy with the same config.

Brings in the single commit `main` has that this branch lacks:
- `docker/Dockerfile`: `UVICORN_WORKERS` 4→1 default + `python:3.13-slim` runtime
- `railway.toml`: `numReplicas = 1`
- `api/dependencies.py`: `@lru_cache` on `get_storage_service` (boto3 client reuse)

Note: dev/staging backends already have `UVICORN_WORKERS=1` set as an env var, so the worker change is already effective; this lands the source-level defaults + slim image + boto3 fix for consistency. No functional change.