### PR TITLE
chore: add branch-flow guard workflow

### DIFF
--- a/.github/workflows/branch-flow-guard.yml
+++ b/.github/workflows/branch-flow-guard.yml
@@ -1,0 +1,43 @@
+name: Branch Flow Guard
+
+# Enforces the promotion chain: feature/fix -> develop -> staging -> main.
+#
+# GitHub branch protection cannot restrict a PR's SOURCE branch natively, so this
+# required check fails any PR into `staging` or `main` that does not come from the
+# allowed upstream branch. Feature/fix PRs into `develop` are unrestricted.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - staging
+
+permissions:
+  contents: read
+
+jobs:
+  enforce-flow:
+    name: Enforce promotion chain
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check base/head branch pair
+        env:
+          BASE: ${{ github.base_ref }}
+          HEAD: ${{ github.head_ref }}
+        run: |
+          echo "PR: $HEAD -> $BASE"
+          case "$BASE" in
+            main)
+              if [ "$HEAD" != "staging" ]; then
+                echo "::error::PRs into 'main' (production) must come from 'staging'. Got '$HEAD'. Allowed flow: develop -> staging -> main."
+                exit 1
+              fi
+              ;;
+            staging)
+              if [ "$HEAD" != "develop" ]; then
+                echo "::error::PRs into 'staging' (test) must come from 'develop'. Got '$HEAD'. Allowed flow: develop -> staging -> main."
+                exit 1
+              fi
+              ;;
+          esac
+          echo "Promotion chain respected."


### PR DESCRIPTION
Enforces the promotion chain on GitHub itself: **feature/fix → develop → staging → main**.

GitHub branch protection cannot natively restrict a PR's *source* branch, so this adds a required-check workflow (`.github/workflows/branch-flow-guard.yml`) that **fails**:
- any PR into `main` whose head is not `staging`
- any PR into `staging` whose head is not `develop`

PRs into `develop` are unrestricted (that's the entry point for features).

## Activation (bootstrap)
The workflow guards a branch only once it exists on that branch. After this lands on `develop`, promote it through the chain (`develop → staging → main`) so it reaches `staging` and `main`. Then add **"Enforce promotion chain"** as a required status check on the `main` and `staging` branch protections to complete enforcement.

Safe pattern: `github.base_ref`/`github.head_ref` are read via `env:` (no shell injection).