### PR TITLE
feat: cache the per-request user lookup in Redis

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -471,6 +471,15 @@
         "line_number": 881
       }
     ],
+    "tests/integration/api/auth/test_current_user_cache.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/integration/api/auth/test_current_user_cache.py",
+        "hashed_secret": "6318553899daae2941718c02508aeee938af1a1c",
+        "is_verified": false,
+        "line_number": 87
+      }
+    ],
     "tests/integration/api/auth/test_password_reset.py": [
       {
         "type": "Secret Keyword",
@@ -610,6 +619,15 @@
         "hashed_secret": "4d81c30a1e76bc8adbbb6af9fc64162241e13f34",
         "is_verified": false,
         "line_number": 272
+      }
+    ],
+    "tests/integration/api/services/test_user_cache_invalidation.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/integration/api/services/test_user_cache_invalidation.py",
+        "hashed_secret": "ebd00879a677aa4e07356a534517eb899d14f722",
+        "is_verified": false,
+        "line_number": 11
       }
     ],
     "tests/shared/helpers.py": [
@@ -929,6 +947,15 @@
         "line_number": 489
       }
     ],
+    "tests/unit/api/services/test_user_cache.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/api/services/test_user_cache.py",
+        "hashed_secret": "96f685e470b5304f2a4b776b519e9390f6d60f5b",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
     "tests/unit/api/test_config.py": [
       {
         "type": "Secret Keyword",
@@ -999,5 +1026,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-09T14:47:58Z"
+  "generated_at": "2026-07-09T20:32:24Z"
 }

--- a/api/auth/dependencies.py
+++ b/api/auth/dependencies.py
@@ -5,6 +5,7 @@ the Dependency Inversion Principle (DIP). The Session dependency is
 injected, and UserService is created with this injected dependency.
 """
 
+import logging
 from typing import Annotated
 
 from fastapi import Cookie, Depends, HTTPException, status
@@ -21,6 +22,8 @@ from api.db.session import get_session
 from api.logging_context import set_user_id
 from api.services.user_cache import CachedUserData, UserCacheStore, get_user_cache
 from api.services.user_service import UserService
+
+logger = logging.getLogger("api.security")
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login", auto_error=False)
 
@@ -80,6 +83,12 @@ async def get_current_user(
         raise credentials_exception from e
 
     cached = cache.get(user_id)
+    if cached is not None and cached.id != user_id:
+        logger.warning(
+            "user cache id mismatch; treating as miss",
+            extra={"event": "user_cache_id_mismatch", "user_id": str(user_id)},
+        )
+        cached = None
     if cached is not None:
         user = cached.to_user()
     else:

--- a/api/auth/dependencies.py
+++ b/api/auth/dependencies.py
@@ -15,9 +15,11 @@ from sqlmodel import Session
 from api.auth.cookies import ACCESS_COOKIE
 from api.auth.jwt import TokenError, TokenPayload, decode_access_token, decode_token
 from api.auth.revocation_store import RevocationStore, get_revocation_store
+from api.config import get_settings
 from api.db.models import User
 from api.db.session import get_session
 from api.logging_context import set_user_id
+from api.services.user_cache import CachedUserData, UserCacheStore, get_user_cache
 from api.services.user_service import UserService
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login", auto_error=False)
@@ -51,21 +53,65 @@ async def get_current_user(
     token: Annotated[str, Depends(_get_access_token)],
     session: Annotated[Session, Depends(get_session)],
     store: Annotated[RevocationStore, Depends(get_revocation_store)],
+    cache: Annotated[UserCacheStore, Depends(get_user_cache)],
 ) -> User:
-    """Extract and validate current user from JWT token.
+    """Return the authenticated user, served from cache when possible.
 
-    Session is injected via DI, UserService is created with the injected session
-    (following DIP). The dependency is async so that ``set_user_id`` binds the
-    acting user in the event-loop context: sync endpoints and services run in a
-    threadpool that copies that context, so their logs carry the user ID too. The
-    blocking DB lookup is offloaded with ``run_in_threadpool`` so it never stalls
-    the event loop under concurrent load.
+    On a cache hit a transient ``User`` is rebuilt from the cached snapshot and
+    the database is not touched. On a miss the user is loaded from the DB and the
+    snapshot is cached. Revocation checks run *before* the cache, so token
+    invalidation is unaffected.
 
-    :param token: JWT access token from Authorization header
-    :param session: Injected database session
-    :param store: Revocation store consulted during token validation
-    :return: Authenticated User
-    :raises HTTPException: 401 if token invalid or user not found
+    :param token: JWT access token.
+    :param session: Injected database session (used only on a miss).
+    :param store: Revocation store consulted during token validation.
+    :param cache: User profile cache.
+    :return: Authenticated ``User`` (transient on a hit, session-bound on a miss).
+    :raises HTTPException: 401 if the token is invalid or the user is not found.
+    """
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        user_id = decode_access_token(token, store)
+    except TokenError as e:
+        raise credentials_exception from e
+
+    cached = cache.get(user_id)
+    if cached is not None:
+        user = cached.to_user()
+    else:
+        user_service = UserService(session)
+        loaded = await run_in_threadpool(user_service.get_by_id, user_id)
+        if loaded is None:
+            raise credentials_exception
+        cache.set(CachedUserData.from_user(loaded), get_settings().user_cache_ttl_seconds)
+        user = loaded
+
+    set_user_id(str(user.id))
+    return user
+
+
+CurrentUser = Annotated[User, Depends(get_current_user)]
+
+
+async def get_current_user_fresh(
+    token: Annotated[str, Depends(_get_access_token)],
+    session: Annotated[Session, Depends(get_session)],
+    store: Annotated[RevocationStore, Depends(get_revocation_store)],
+) -> User:
+    """Return the authenticated user always loaded fresh from the DB (no cache).
+
+    Used by mutating endpoints: they need a session-bound ``User`` to modify and
+    the real ``hashed_password``, neither of which the cache provides.
+
+    :param token: JWT access token.
+    :param session: Injected database session.
+    :param store: Revocation store consulted during token validation.
+    :return: Session-bound authenticated ``User``.
+    :raises HTTPException: 401 if the token is invalid or the user is not found.
     """
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
@@ -85,7 +131,7 @@ async def get_current_user(
     return user
 
 
-CurrentUser = Annotated[User, Depends(get_current_user)]
+CurrentUserFresh = Annotated[User, Depends(get_current_user_fresh)]
 
 
 def get_current_token_payload(

--- a/api/config.py
+++ b/api/config.py
@@ -153,6 +153,10 @@ class Settings(BaseSettings):
     # Shared revocation / rate-limit store. Empty -> in-memory (dev/test); required in prod.
     redis_url: str = ""
 
+    # TTL for the cached user-profile snapshot; a short value bounds the cache-aside
+    # staleness window (see the user-caching spec).
+    user_cache_ttl_seconds: int = 60
+
     # Railway Storage Bucket (S3-compatible; photo upload disabled if not set).
     # Railway injects these when a bucket is attached to the service.
     bucket_name: str | None = None

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -33,6 +33,7 @@ from api.services.project_service import ProjectService
 from api.services.storage.base import StorageService
 from api.services.storage.exceptions import StorageConfigurationError
 from api.services.storage.railway_bucket_storage_service import RailwayBucketStorageService
+from api.services.user_cache import get_user_cache
 from api.services.user_service import UserService
 from src.calculators.become_calculator import BeCoMeCalculator
 
@@ -57,7 +58,7 @@ def get_calculator() -> BeCoMeCalculator:
 
 def get_user_service(session: Annotated[Session, Depends(get_session)]) -> UserService:
     """Create UserService instance."""
-    return UserService(session)
+    return UserService(session, get_user_cache())
 
 
 def get_project_service(session: Annotated[Session, Depends(get_session)]) -> ProjectService:
@@ -114,7 +115,7 @@ def get_password_reset_service(
     session: Annotated[Session, Depends(get_session)],
 ) -> PasswordResetService:
     """Create PasswordResetService instance."""
-    return PasswordResetService(session)
+    return PasswordResetService(session, get_user_cache())
 
 
 def get_email_service() -> EmailSender:

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -33,7 +33,7 @@ from api.services.project_service import ProjectService
 from api.services.storage.base import StorageService
 from api.services.storage.exceptions import StorageConfigurationError
 from api.services.storage.railway_bucket_storage_service import RailwayBucketStorageService
-from api.services.user_cache import get_user_cache
+from api.services.user_cache import UserCacheStore, get_user_cache
 from api.services.user_service import UserService
 from src.calculators.become_calculator import BeCoMeCalculator
 
@@ -56,9 +56,12 @@ def get_calculator() -> BeCoMeCalculator:
 # --- Service Factories ---
 
 
-def get_user_service(session: Annotated[Session, Depends(get_session)]) -> UserService:
+def get_user_service(
+    session: Annotated[Session, Depends(get_session)],
+    cache: Annotated[UserCacheStore, Depends(get_user_cache)],
+) -> UserService:
     """Create UserService instance."""
-    return UserService(session, get_user_cache())
+    return UserService(session, cache)
 
 
 def get_project_service(session: Annotated[Session, Depends(get_session)]) -> ProjectService:
@@ -113,9 +116,10 @@ def get_invitation_service(session: Annotated[Session, Depends(get_session)]) ->
 
 def get_password_reset_service(
     session: Annotated[Session, Depends(get_session)],
+    cache: Annotated[UserCacheStore, Depends(get_user_cache)],
 ) -> PasswordResetService:
     """Create PasswordResetService instance."""
-    return PasswordResetService(session, get_user_cache())
+    return PasswordResetService(session, cache)
 
 
 def get_email_service() -> EmailSender:

--- a/api/routes/users.py
+++ b/api/routes/users.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, HTTPException, Request, Response, UploadFile, status
 
-from api.auth.dependencies import CurrentUser
+from api.auth.dependencies import CurrentUser, CurrentUserFresh
 from api.auth.logging import log_account_deletion, log_data_export, log_password_change
 from api.auth.revocation_store import RevocationStore, get_revocation_store
 from api.db.models import Project
@@ -62,7 +62,7 @@ def get_current_user_profile(current_user: CurrentUser) -> UserResponse:
 @limiter.limit(LIMIT_STANDARD)
 def export_current_user_data(
     request: Request,
-    current_user: CurrentUser,
+    current_user: CurrentUserFresh,
     service: Annotated[DataExportService, Depends(get_data_export_service)],
 ) -> DataExportResponse:
     """Return all of the authenticated user's data in machine-readable form.
@@ -83,7 +83,7 @@ def export_current_user_data(
 
 @router.put("/me", summary="Update current user profile")
 def update_current_user(
-    current_user: CurrentUser,
+    current_user: CurrentUserFresh,
     request: UpdateUserRequest,
     service: Annotated[UserService, Depends(get_user_service)],
 ) -> UserResponse:
@@ -110,7 +110,7 @@ def update_current_user(
 @limiter.limit(LIMIT_PWD_RESET)
 def change_password(
     request: Request,
-    current_user: CurrentUser,
+    current_user: CurrentUserFresh,
     data: ChangePasswordRequest,
     service: Annotated[UserService, Depends(get_user_service)],
     store: Annotated[RevocationStore, Depends(get_revocation_store)],
@@ -144,13 +144,14 @@ def change_password(
 )
 def delete_current_user(
     request: Request,
-    current_user: CurrentUser,
+    current_user: CurrentUserFresh,
     service: Annotated[UserService, Depends(get_user_service)],
     project_service: Annotated[ProjectService, Depends(get_project_service)],
     membership_service: Annotated[
         ProjectMembershipService, Depends(get_project_membership_service)
     ],
     storage_service: Annotated[StorageService | None, Depends(get_storage_service)],
+    store: Annotated[RevocationStore, Depends(get_revocation_store)],
     data: DeleteAccountRequest | None = None,
 ) -> None:
     """Delete the authenticated user's account (GDPR Article 17, right to erasure).
@@ -159,6 +160,8 @@ def delete_current_user(
     to another member, or delete it (its opinions and invitations cascade away). This
     keeps erasure from silently destroying other experts' contributions while still
     letting the user leave. The profile photo blob is removed from object storage too.
+    Every token issued for this account is invalidated (M2), so a still-warm cache
+    entry cannot serve the deleted account past this request.
 
     :param request: FastAPI request (for logging)
     :param current_user: User from JWT token
@@ -166,6 +169,7 @@ def delete_current_user(
     :param project_service: Project service (ownership handling)
     :param membership_service: Membership service (validates transfer targets)
     :param storage_service: Storage service (None when not configured)
+    :param store: Revocation store (invalidates tokens issued before the deletion)
     :param data: Per-owned-project dispositions (transfer or delete)
     :raises AccountHasOwnedProjectsError: If an owned project has no disposition
     :raises InvalidProjectDispositionError: If a transfer target is not another member
@@ -213,6 +217,10 @@ def delete_current_user(
 
     service.delete_user(current_user)
 
+    # M2: revoke the deleted user's tokens so the account cannot outlive its data
+    # via a still-warm cache entry (decode rejects the token before the cache).
+    store.set_user_valid_after(user_id, datetime.now(UTC))
+
     log_account_deletion(user_id, email, request)
 
 
@@ -227,7 +235,7 @@ def delete_current_user(
 @limiter.limit(LIMIT_UPLOAD)
 async def upload_photo(
     request: Request,
-    current_user: CurrentUser,
+    current_user: CurrentUserFresh,
     file: Annotated[UploadFile, File(description="Profile photo (JPEG, PNG, GIF, WebP, max 5MB)")],
     user_service: Annotated[UserService, Depends(get_user_service)],
     storage_service: Annotated[StorageService | None, Depends(get_storage_service)],
@@ -297,7 +305,7 @@ async def upload_photo(
     summary="Delete profile photo",
 )
 def delete_photo(
-    current_user: CurrentUser,
+    current_user: CurrentUserFresh,
     user_service: Annotated[UserService, Depends(get_user_service)],
     storage_service: Annotated[StorageService | None, Depends(get_storage_service)],
 ) -> None:

--- a/api/services/password_reset_service.py
+++ b/api/services/password_reset_service.py
@@ -7,7 +7,7 @@ import logging
 import secrets
 from datetime import timedelta
 
-from sqlmodel import col, select
+from sqlmodel import Session, col, select
 
 from api.auth.password import hash_password
 from api.config import get_settings
@@ -15,6 +15,7 @@ from api.db.models import PasswordResetToken, User
 from api.db.utils import ensure_utc, utc_now
 from api.exceptions import InvalidResetTokenError, ResetTokenExpiredError
 from api.services.base import BaseService
+from api.services.user_cache import UserCacheStore
 
 logger = logging.getLogger("api.service.password_reset")
 
@@ -43,6 +44,15 @@ class PasswordResetService(BaseService):
     access tokens (the JTI blacklist has no per-user revoke); this is acceptable
     given the short access-token lifetime.
     """
+
+    def __init__(self, session: Session, user_cache: UserCacheStore | None = None) -> None:
+        """Initialize with a DB session and an optional user cache.
+
+        :param session: SQLModel session for database operations.
+        :param user_cache: Cache to invalidate after a password reset.
+        """
+        super().__init__(session)
+        self._user_cache = user_cache
 
     def create_reset_token(self, email: str) -> str | None:
         """Issue a reset token for the given email, if a matching user exists.
@@ -110,6 +120,9 @@ class PasswordResetService(BaseService):
         self._session.add(record)
         self._session.commit()
         self._session.refresh(user)
+
+        if self._user_cache is not None:
+            self._user_cache.invalidate(user.id)
 
         logger.info(
             "Password reset completed",

--- a/api/services/user_cache.py
+++ b/api/services/user_cache.py
@@ -205,6 +205,7 @@ class RedisUserCache:
         except redis.RedisError:
             logger.warning(
                 "user cache read failed",
+                exc_info=True,
                 extra={
                     "event": "user_cache_error",
                     "op": "get",
@@ -214,10 +215,10 @@ class RedisUserCache:
             return None
         if raw is None:
             return None
-        text = raw.decode() if isinstance(raw, bytes) else str(raw)
         try:
+            text = raw.decode() if isinstance(raw, bytes) else str(raw)
             return CachedUserData.from_json(text)
-        except (ValueError, KeyError):
+        except (ValueError, KeyError, TypeError):
             return None
 
     def set(self, data: CachedUserData, ttl_seconds: int) -> None:
@@ -231,6 +232,7 @@ class RedisUserCache:
         except redis.RedisError:
             logger.warning(
                 "user cache write failed",
+                exc_info=True,
                 extra={
                     "event": "user_cache_error",
                     "op": "set",
@@ -248,6 +250,7 @@ class RedisUserCache:
         except redis.RedisError:
             logger.warning(
                 "user cache invalidate failed",
+                exc_info=True,
                 extra={
                     "event": "user_cache_error",
                     "op": "invalidate",

--- a/api/services/user_cache.py
+++ b/api/services/user_cache.py
@@ -1,0 +1,95 @@
+"""Redis-backed cache for the per-request user lookup."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from api.db.models import User
+
+
+@dataclass(frozen=True)
+class CachedUserData:
+    """Serializable snapshot of a user's non-secret profile fields.
+
+    Deliberately not an ORM object and deliberately without ``hashed_password``:
+    it is what lives in Redis, and ``to_user`` rebuilds a transient ``User`` from it.
+    """
+
+    id: UUID
+    email: str
+    first_name: str
+    last_name: str
+    photo_url: str | None
+    created_at: datetime
+
+    @classmethod
+    def from_user(cls, user: User) -> CachedUserData:
+        """Build a snapshot from an ORM user.
+
+        :param user: The database user.
+        :return: A cacheable snapshot without the password hash.
+        """
+        return cls(
+            id=user.id,
+            email=user.email,
+            first_name=user.first_name,
+            last_name=user.last_name,
+            photo_url=user.photo_url,
+            created_at=user.created_at,
+        )
+
+    def to_json(self) -> str:
+        """Serialize to a JSON string for Redis.
+
+        :return: JSON text; ``hashed_password`` is never included.
+        """
+        return json.dumps(
+            {
+                "id": str(self.id),
+                "email": self.email,
+                "first_name": self.first_name,
+                "last_name": self.last_name,
+                "photo_url": self.photo_url,
+                "created_at": self.created_at.isoformat(),
+            }
+        )
+
+    @classmethod
+    def from_json(cls, raw: str) -> CachedUserData:
+        """Parse a JSON string produced by :meth:`to_json`.
+
+        :param raw: JSON text from Redis.
+        :return: The reconstructed snapshot.
+        :raises ValueError: If the text is not valid JSON for this shape.
+        :raises KeyError: If a required field is missing.
+        """
+        data = json.loads(raw)
+        return cls(
+            id=UUID(data["id"]),
+            email=data["email"],
+            first_name=data["first_name"],
+            last_name=data["last_name"],
+            photo_url=data["photo_url"],
+            created_at=datetime.fromisoformat(data["created_at"]),
+        )
+
+    def to_user(self) -> User:
+        """Rebuild a transient ``User`` (not bound to any session).
+
+        ``hashed_password`` is set to an empty string: read paths never read it,
+        and write paths take a fresh session-bound user instead.
+
+        :return: A transient ``User`` carrying the cached profile fields.
+        """
+        return User(
+            id=self.id,
+            email=self.email,
+            hashed_password="",
+            first_name=self.first_name,
+            last_name=self.last_name,
+            photo_url=self.photo_url,
+            created_at=self.created_at,
+        )

--- a/api/services/user_cache.py
+++ b/api/services/user_cache.py
@@ -3,13 +3,18 @@
 from __future__ import annotations
 
 import json
+import logging
 import threading
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Protocol, runtime_checkable
 from uuid import UUID
 
+import redis
+
 from api.db.models import User
+
+logger = logging.getLogger("api.service.user_cache")
 
 
 @dataclass(frozen=True)
@@ -173,3 +178,79 @@ class InMemoryUserCache:
         """
         with self._lock:
             self._entries.clear()
+
+
+class RedisUserCache:
+    """Redis-backed UserCacheStore shared across replicas.
+
+    Fail-open: a ``redis.RedisError`` is logged and swallowed so a degraded Redis
+    never fails a request (the request falls back to the database).
+    """
+
+    def __init__(self, client: redis.Redis) -> None:
+        self._client = client
+
+    @staticmethod
+    def _key(user_id: UUID) -> str:
+        return f"user:profile:v1:{user_id}"
+
+    def get(self, user_id: UUID) -> CachedUserData | None:
+        """Return the cached snapshot, or ``None`` on miss/error/corruption.
+
+        :param user_id: The user ID to look up.
+        :return: The cached snapshot or ``None`` if absent, expired, or on error.
+        """
+        try:
+            raw = self._client.get(self._key(user_id))
+        except redis.RedisError:
+            logger.warning(
+                "user cache read failed",
+                extra={
+                    "event": "user_cache_error",
+                    "op": "get",
+                    "user_id": str(user_id),
+                },
+            )
+            return None
+        if raw is None:
+            return None
+        text = raw.decode() if isinstance(raw, bytes) else str(raw)
+        try:
+            return CachedUserData.from_json(text)
+        except (ValueError, KeyError):
+            return None
+
+    def set(self, data: CachedUserData, ttl_seconds: int) -> None:
+        """Store the snapshot under its user id with a TTL; no-op on error.
+
+        :param data: The snapshot to cache.
+        :param ttl_seconds: Time to live in seconds.
+        """
+        try:
+            self._client.set(self._key(data.id), data.to_json(), ex=max(ttl_seconds, 1))
+        except redis.RedisError:
+            logger.warning(
+                "user cache write failed",
+                extra={
+                    "event": "user_cache_error",
+                    "op": "set",
+                    "user_id": str(data.id),
+                },
+            )
+
+    def invalidate(self, user_id: UUID) -> None:
+        """Delete the cached snapshot; no-op on error (TTL is the backstop).
+
+        :param user_id: The user ID to invalidate.
+        """
+        try:
+            self._client.delete(self._key(user_id))
+        except redis.RedisError:
+            logger.warning(
+                "user cache invalidate failed",
+                extra={
+                    "event": "user_cache_error",
+                    "op": "invalidate",
+                    "user_id": str(user_id),
+                },
+            )

--- a/api/services/user_cache.py
+++ b/api/services/user_cache.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import threading
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
+from typing import Protocol, runtime_checkable
 from uuid import UUID
 
 from api.db.models import User
@@ -93,3 +95,81 @@ class CachedUserData:
             photo_url=self.photo_url,
             created_at=self.created_at,
         )
+
+
+@runtime_checkable
+class UserCacheStore(Protocol):
+    """Cache backend for the per-request user profile lookup."""
+
+    def get(self, user_id: UUID) -> CachedUserData | None:
+        """Return the cached snapshot if present and unexpired, else ``None``.
+
+        :param user_id: The user ID to look up.
+        :return: The cached snapshot or ``None`` if absent or expired.
+        """
+        ...
+
+    def set(self, data: CachedUserData, ttl_seconds: int) -> None:
+        """Store ``data`` under its own id for ``ttl_seconds``.
+
+        :param data: The snapshot to cache.
+        :param ttl_seconds: Time to live in seconds.
+        """
+        ...
+
+    def invalidate(self, user_id: UUID) -> None:
+        """Drop the cached snapshot for ``user_id`` if any.
+
+        :param user_id: The user ID to invalidate.
+        """
+        ...
+
+
+class InMemoryUserCache:
+    """Process-local UserCacheStore for dev and tests (not shared across replicas)."""
+
+    def __init__(self) -> None:
+        self._entries: dict[UUID, tuple[CachedUserData, datetime]] = {}
+        self._lock = threading.Lock()
+
+    def get(self, user_id: UUID) -> CachedUserData | None:
+        """Return the cached snapshot if present and unexpired, else ``None``.
+
+        :param user_id: The user ID to look up.
+        :return: The cached snapshot or ``None`` if absent or expired.
+        """
+        with self._lock:
+            entry = self._entries.get(user_id)
+            if entry is None:
+                return None
+            data, expires_at = entry
+            if expires_at <= datetime.now(UTC):
+                del self._entries[user_id]
+                return None
+            return data
+
+    def set(self, data: CachedUserData, ttl_seconds: int) -> None:
+        """Store ``data`` under its own id for ``ttl_seconds``.
+
+        :param data: The snapshot to cache.
+        :param ttl_seconds: Time to live in seconds.
+        """
+        expires_at = datetime.now(UTC) + timedelta(seconds=max(ttl_seconds, 0))
+        with self._lock:
+            self._entries[data.id] = (data, expires_at)
+
+    def invalidate(self, user_id: UUID) -> None:
+        """Drop the cached snapshot for ``user_id`` if any.
+
+        :param user_id: The user ID to invalidate.
+        """
+        with self._lock:
+            self._entries.pop(user_id, None)
+
+    def clear(self) -> None:
+        """Drop all cached snapshots (test helper).
+
+        :return: None
+        """
+        with self._lock:
+            self._entries.clear()

--- a/api/services/user_cache.py
+++ b/api/services/user_cache.py
@@ -68,20 +68,27 @@ class CachedUserData:
     def from_json(cls, raw: str) -> CachedUserData:
         """Parse a JSON string produced by :meth:`to_json`.
 
+        This is the untrusted-input boundary: any malformed or wrong-typed
+        value raises ``ValueError`` so the caller can treat it as a cache miss.
+
         :param raw: JSON text from Redis.
         :return: The reconstructed snapshot.
-        :raises ValueError: If the text is not valid JSON for this shape.
-        :raises KeyError: If a required field is missing.
+        :raises ValueError: If the text is not a valid object for this shape.
         """
         data = json.loads(raw)
-        return cls(
-            id=UUID(data["id"]),
-            email=data["email"],
-            first_name=data["first_name"],
-            last_name=data["last_name"],
-            photo_url=data["photo_url"],
-            created_at=datetime.fromisoformat(data["created_at"]),
-        )
+        if not isinstance(data, dict):
+            raise ValueError("cached user data must be a JSON object")
+        try:
+            return cls(
+                id=UUID(data["id"]),
+                email=data["email"],
+                first_name=data["first_name"],
+                last_name=data["last_name"],
+                photo_url=data["photo_url"],
+                created_at=datetime.fromisoformat(data["created_at"]),
+            )
+        except (KeyError, TypeError, AttributeError) as e:
+            raise ValueError(f"invalid cached user data: {e}") from e
 
     def to_user(self) -> User:
         """Rebuild a transient ``User`` (not bound to any session).
@@ -218,7 +225,7 @@ class RedisUserCache:
         try:
             text = raw.decode() if isinstance(raw, bytes) else str(raw)
             return CachedUserData.from_json(text)
-        except (ValueError, KeyError, TypeError):
+        except ValueError:
             return None
 
     def set(self, data: CachedUserData, ttl_seconds: int) -> None:

--- a/api/services/user_cache.py
+++ b/api/services/user_cache.py
@@ -7,11 +7,13 @@ import logging
 import threading
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from functools import lru_cache
 from typing import Protocol, runtime_checkable
 from uuid import UUID
 
 import redis
 
+from api.config import get_settings
 from api.db.models import User
 
 logger = logging.getLogger("api.service.user_cache")
@@ -264,3 +266,19 @@ class RedisUserCache:
                     "user_id": str(user_id),
                 },
             )
+
+
+@lru_cache
+def get_user_cache() -> UserCacheStore:
+    """Return the process-wide user cache, Redis-backed when configured.
+
+    A ``RedisUserCache`` when ``redis_url`` is set (production), otherwise an
+    in-memory store for dev and tests. Mirrors ``get_revocation_store``.
+
+    :return: The process-wide user cache store.
+    """
+    settings = get_settings()
+    if settings.redis_url:
+        client = redis.from_url(settings.redis_url, socket_connect_timeout=2, socket_timeout=2)
+        return RedisUserCache(client)
+    return InMemoryUserCache()

--- a/api/services/user_cache.py
+++ b/api/services/user_cache.py
@@ -165,10 +165,15 @@ class InMemoryUserCache:
     def set(self, data: CachedUserData, ttl_seconds: int) -> None:
         """Store ``data`` under its own id for ``ttl_seconds``.
 
+        A non-positive TTL is not stored (the entry would expire immediately),
+        keeping behaviour identical to ``RedisUserCache``.
+
         :param data: The snapshot to cache.
-        :param ttl_seconds: Time to live in seconds.
+        :param ttl_seconds: Time to live in seconds; values below 1 are not stored.
         """
-        expires_at = datetime.now(UTC) + timedelta(seconds=max(ttl_seconds, 0))
+        if ttl_seconds < 1:
+            return
+        expires_at = datetime.now(UTC) + timedelta(seconds=ttl_seconds)
         with self._lock:
             self._entries[data.id] = (data, expires_at)
 
@@ -233,11 +238,16 @@ class RedisUserCache:
     def set(self, data: CachedUserData, ttl_seconds: int) -> None:
         """Store the snapshot under its user id with a TTL; no-op on error.
 
+        A non-positive TTL is not stored (Redis ``EX`` requires a positive value),
+        keeping behaviour identical to ``InMemoryUserCache``.
+
         :param data: The snapshot to cache.
-        :param ttl_seconds: Time to live in seconds.
+        :param ttl_seconds: Time to live in seconds; values below 1 are not stored.
         """
+        if ttl_seconds < 1:
+            return
         try:
-            self._client.set(self._key(data.id), data.to_json(), ex=max(ttl_seconds, 1))
+            self._client.set(self._key(data.id), data.to_json(), ex=ttl_seconds)
         except redis.RedisError:
             logger.warning(
                 "user cache write failed",

--- a/api/services/user_service.py
+++ b/api/services/user_service.py
@@ -3,12 +3,13 @@
 import logging
 from uuid import UUID
 
-from sqlmodel import select
+from sqlmodel import Session, select
 
 from api.auth.password import hash_password, verify_password
 from api.db.models import User
 from api.exceptions import InvalidCredentialsError, UserExistsError
 from api.services.base import BaseService
+from api.services.user_cache import UserCacheStore
 
 logger = logging.getLogger("api.service.user")
 
@@ -19,6 +20,23 @@ _DUMMY_PASSWORD_HASH = hash_password("not-a-real-password-timing-equalizer")
 
 class UserService(BaseService):
     """Service for user-related operations."""
+
+    def __init__(self, session: Session, user_cache: UserCacheStore | None = None) -> None:
+        """Initialize with a DB session and an optional user cache.
+
+        :param session: SQLModel session for database operations.
+        :param user_cache: Cache to invalidate on mutations; ``None`` disables it.
+        """
+        super().__init__(session)
+        self._user_cache = user_cache
+
+    def _invalidate_cache(self, user_id: UUID) -> None:
+        """Drop the cached snapshot for ``user_id`` when a cache is configured.
+
+        :param user_id: ID of the user whose cached snapshot should be dropped.
+        """
+        if self._user_cache is not None:
+            self._user_cache.invalidate(user_id)
 
     def create_user(
         self,
@@ -118,7 +136,9 @@ class UserService(BaseService):
         if last_name is not None:
             user.last_name = last_name
 
-        return self._save_and_refresh(user)
+        saved = self._save_and_refresh(user)
+        self._invalidate_cache(saved.id)
+        return saved
 
     def change_password(self, user: User, current_password: str, new_password: str) -> User:
         """Change user password.
@@ -136,18 +156,21 @@ class UserService(BaseService):
             )
 
         user.hashed_password = hash_password(new_password)
-        return self._save_and_refresh(user)
+        saved = self._save_and_refresh(user)
+        self._invalidate_cache(saved.id)
+        return saved
 
     def delete_user(self, user: User) -> None:
         """Delete user account.
 
         :param user: User to delete
         """
-        user_id = str(user.id)
+        user_id = user.id
         self._delete_and_commit(user)
+        self._invalidate_cache(user_id)
         logger.info(
             "User deleted",
-            extra={"event": "user_deleted", "user_id": user_id},
+            extra={"event": "user_deleted", "user_id": str(user_id)},
         )
 
     def update_photo_url(self, user: User, photo_key: str | None) -> User:
@@ -158,4 +181,6 @@ class UserService(BaseService):
         :return: Updated User instance
         """
         user.photo_url = photo_key
-        return self._save_and_refresh(user)
+        saved = self._save_and_refresh(user)
+        self._invalidate_cache(saved.id)
+        return saved

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest==9.1.1",
+    "pytest-asyncio==1.4.0",
     "pytest-cov==7.1.0",
     "pytest-postgresql==8.1.0",
     "pytest-xdist==3.8.0",
@@ -136,6 +137,7 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = ["-v", "--cov=src", "--cov=api"]
+asyncio_mode = "strict"
 markers = [
     "e2e: end-to-end tests requiring running server and PostgreSQL",
 ]

--- a/tests/integration/api/auth/test_current_user_cache.py
+++ b/tests/integration/api/auth/test_current_user_cache.py
@@ -1,0 +1,39 @@
+"""The auth dependency serves cached users and bypasses the DB on a hit."""
+
+from uuid import uuid4
+
+import pytest
+
+from api.services.user_cache import CachedUserData, get_user_cache
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_skips_the_database(monkeypatch):
+    """A pre-warmed cache entry satisfies get_current_user without a DB call."""
+    from api.auth import dependencies as deps
+
+    user_id = uuid4()
+    cached = CachedUserData(
+        id=user_id,
+        email="hit@example.com",
+        first_name="Hit",
+        last_name="User",
+        photo_url=None,
+        created_at=__import__("datetime").datetime.now(__import__("datetime").UTC),
+    )
+    get_user_cache.cache_clear()
+    get_user_cache().set(cached, ttl_seconds=60)
+
+    monkeypatch.setattr(deps, "decode_access_token", lambda token, store: user_id)
+
+    def _boom(self, _id):
+        raise AssertionError("DB must not be hit on a cache hit")
+
+    monkeypatch.setattr("api.services.user_service.UserService.get_by_id", _boom)
+
+    user = await deps.get_current_user(
+        token="t", session=object(), store=object(), cache=get_user_cache()
+    )
+    assert user.id == user_id
+    assert user.email == "hit@example.com"
+    assert user.hashed_password == ""

--- a/tests/integration/api/auth/test_current_user_cache.py
+++ b/tests/integration/api/auth/test_current_user_cache.py
@@ -1,5 +1,6 @@
 """The auth dependency serves cached users and bypasses the DB on a hit."""
 
+from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
@@ -19,7 +20,7 @@ async def test_cache_hit_skips_the_database(monkeypatch):
         first_name="Hit",
         last_name="User",
         photo_url=None,
-        created_at=__import__("datetime").datetime.now(__import__("datetime").UTC),
+        created_at=datetime.now(UTC),
     )
     get_user_cache.cache_clear()
     get_user_cache().set(cached, ttl_seconds=60)
@@ -37,3 +38,64 @@ async def test_cache_hit_skips_the_database(monkeypatch):
     assert user.id == user_id
     assert user.email == "hit@example.com"
     assert user.hashed_password == ""
+
+
+class _MismatchedCache:
+    """Cache stub returning a snapshot whose id disagrees with the queried key.
+
+    A real ``InMemoryUserCache.set`` always keys an entry by the snapshot's own
+    ``id``, so it cannot represent key/value drift. This stub stands in for a
+    tampered or corrupted backend that returns the wrong snapshot for a key.
+    """
+
+    def __init__(self, snapshot: CachedUserData) -> None:
+        self._snapshot = snapshot
+
+    def get(self, user_id):
+        """Return the fixed snapshot regardless of the requested id."""
+        return self._snapshot
+
+    def set(self, data, ttl_seconds):
+        """No-op: the miss path's cache write is not under test here."""
+
+    def invalidate(self, user_id):
+        """No-op: invalidation is not under test here."""
+
+
+@pytest.mark.asyncio
+async def test_cache_id_mismatch_falls_through_to_the_database(monkeypatch):
+    """A cached snapshot whose id disagrees with the token subject is not served."""
+    from api.auth import dependencies as deps
+    from api.db.models import User
+
+    token_user_id = uuid4()
+    other_user_id = uuid4()
+    mismatched = CachedUserData(
+        id=other_user_id,
+        email="mismatched@example.com",
+        first_name="Mismatched",
+        last_name="User",
+        photo_url=None,
+        created_at=datetime.now(UTC),
+    )
+
+    monkeypatch.setattr(deps, "decode_access_token", lambda token, store: token_user_id)
+
+    db_user = User(
+        id=token_user_id,
+        email="db@example.com",
+        hashed_password="hashed",
+        first_name="DB",
+        last_name="User",
+    )
+
+    def _fake_get_by_id(self, _id):
+        return db_user
+
+    monkeypatch.setattr("api.services.user_service.UserService.get_by_id", _fake_get_by_id)
+
+    user = await deps.get_current_user(
+        token="t", session=object(), store=object(), cache=_MismatchedCache(mismatched)
+    )
+    assert user.id == token_user_id
+    assert user.email == "db@example.com"

--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -186,6 +186,23 @@ def _reset_auth_throttles():
     get_reset_email_throttle.cache_clear()
 
 
+@pytest.fixture(autouse=True)
+def _reset_user_cache():
+    """Give each test a fresh user cache.
+
+    ``get_user_cache`` is an lru_cache singleton whose in-memory state would
+    otherwise leak between tests reusing a user id.
+    """
+    from api.services.user_cache import InMemoryUserCache, get_user_cache
+
+    get_user_cache.cache_clear()
+    store = get_user_cache()
+    if isinstance(store, InMemoryUserCache):
+        store.clear()
+    yield
+    get_user_cache.cache_clear()
+
+
 class _HeaderOnlyClient(TestClient):
     """Test client that discards response cookies after each request.
 

--- a/tests/integration/api/routes/test_users_cache.py
+++ b/tests/integration/api/routes/test_users_cache.py
@@ -1,0 +1,31 @@
+"""Deleting an account revokes its tokens (M2) and profile edits show immediately."""
+
+from tests.integration.api.conftest import auth_header, register_and_login
+
+
+def test_profile_update_is_visible_immediately(client):
+    """A profile edit is served back on the very next GET, not a stale cache entry."""
+    token = register_and_login(client, "cache-fresh@example.com")
+    # Warm the profile cache first, so the update runs against whatever dependency the
+    # write endpoint uses while a cache entry is live (transient on a cache hit).
+    client.get("/api/v1/users/me", headers=auth_header(token))
+
+    client.put("/api/v1/users/me", json={"first_name": "Renamed"}, headers=auth_header(token))
+    me = client.get("/api/v1/users/me", headers=auth_header(token))
+
+    assert me.json()["first_name"] == "Renamed"
+
+
+def test_delete_account_revokes_the_access_token(client):
+    """A deleted account's token is rejected immediately, not served from cache (M2)."""
+    token = register_and_login(client, "cache-delete@example.com")
+    # Warm the profile cache first (e.g. the user viewed their own profile) so deletion
+    # must cope with a live cache entry instead of the common cold-cache path.
+    client.get("/api/v1/users/me", headers=auth_header(token))
+
+    resp = client.delete("/api/v1/users/me", headers=auth_header(token))
+    assert resp.status_code == 204
+
+    # The same token must now be rejected (valid_after cutoff), not served from cache.
+    after = client.get("/api/v1/users/me", headers=auth_header(token))
+    assert after.status_code == 401

--- a/tests/integration/api/services/__init__.py
+++ b/tests/integration/api/services/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for API services."""

--- a/tests/integration/api/services/test_user_cache_invalidation.py
+++ b/tests/integration/api/services/test_user_cache_invalidation.py
@@ -15,3 +15,45 @@ def test_update_user_invalidates_cache(session):
     service.update_user(user, first_name="Changed")
 
     assert cache.get(user.id) is None
+
+
+def test_change_password_invalidates_cache(session):
+    """change_password drops the cached snapshot after the hash is updated."""
+    cache = InMemoryUserCache()
+    service = UserService(session, user_cache=cache)
+    user = service.create_user(
+        email="u@example.com", password="pw-123456", first_name="U", last_name="Ser"
+    )
+    cache.set(CachedUserData.from_user(user), ttl_seconds=60)
+
+    service.change_password(user, current_password="pw-123456", new_password="pw-654321")
+
+    assert cache.get(user.id) is None
+
+
+def test_update_photo_url_invalidates_cache(session):
+    """update_photo_url drops the cached snapshot after the photo key is updated."""
+    cache = InMemoryUserCache()
+    service = UserService(session, user_cache=cache)
+    user = service.create_user(
+        email="u@example.com", password="pw-123456", first_name="U", last_name="Ser"
+    )
+    cache.set(CachedUserData.from_user(user), ttl_seconds=60)
+
+    service.update_photo_url(user, "some/key.jpg")
+
+    assert cache.get(user.id) is None
+
+
+def test_delete_user_invalidates_cache(session):
+    """delete_user drops the cached snapshot after the account is removed."""
+    cache = InMemoryUserCache()
+    service = UserService(session, user_cache=cache)
+    user = service.create_user(
+        email="u@example.com", password="pw-123456", first_name="U", last_name="Ser"
+    )
+    cache.set(CachedUserData.from_user(user), ttl_seconds=60)
+
+    service.delete_user(user)
+
+    assert cache.get(user.id) is None

--- a/tests/integration/api/services/test_user_cache_invalidation.py
+++ b/tests/integration/api/services/test_user_cache_invalidation.py
@@ -1,0 +1,17 @@
+"""Mutations invalidate the cached user snapshot."""
+
+from api.services.user_cache import CachedUserData, InMemoryUserCache
+from api.services.user_service import UserService
+
+
+def test_update_user_invalidates_cache(session):
+    cache = InMemoryUserCache()
+    service = UserService(session, user_cache=cache)
+    user = service.create_user(
+        email="u@example.com", password="pw-123456", first_name="U", last_name="Ser"
+    )
+    cache.set(CachedUserData.from_user(user), ttl_seconds=60)
+
+    service.update_user(user, first_name="Changed")
+
+    assert cache.get(user.id) is None

--- a/tests/unit/api/auth/test_dependencies.py
+++ b/tests/unit/api/auth/test_dependencies.py
@@ -13,6 +13,7 @@ from api.auth.jwt import ALGORITHM, create_access_token, revoke_token
 from api.auth.revocation_store import InMemoryRevocationStore
 from api.config import get_settings
 from api.logging_context import get_user_id
+from api.services.user_cache import InMemoryUserCache
 
 
 @pytest.fixture
@@ -21,10 +22,16 @@ def store() -> InMemoryRevocationStore:
     return InMemoryRevocationStore()
 
 
+@pytest.fixture
+def cache() -> InMemoryUserCache:
+    """Provide a fresh, empty in-memory user cache per test."""
+    return InMemoryUserCache()
+
+
 class TestGetCurrentUser:
     """Tests for get_current_user dependency."""
 
-    def test_returns_user_for_valid_token(self, store):
+    def test_returns_user_for_valid_token(self, store, cache):
         """Valid token returns corresponding user."""
         # GIVEN
         user_id = uuid4()
@@ -39,13 +46,13 @@ class TestGetCurrentUser:
             mock_service.get_by_id.return_value = mock_user
             mock_service_class.return_value = mock_service
 
-            result = asyncio.run(get_current_user(token, mock_session, store))
+            result = asyncio.run(get_current_user(token, mock_session, store, cache))
 
         # THEN
         assert result == mock_user
         mock_service.get_by_id.assert_called_once_with(user_id)
 
-    def test_binds_user_id_to_logging_context(self, store):
+    def test_binds_user_id_to_logging_context(self, store, cache):
         """A successful resolution binds the acting user ID to the context."""
         # GIVEN
         user_id = uuid4()
@@ -59,7 +66,7 @@ class TestGetCurrentUser:
                 mock_service = MagicMock()
                 mock_service.get_by_id.return_value = mock_user
                 mock_service_class.return_value = mock_service
-                await get_current_user(token, mock_session, store)
+                await get_current_user(token, mock_session, store, cache)
             return get_user_id()
 
         # WHEN
@@ -68,7 +75,7 @@ class TestGetCurrentUser:
         # THEN
         assert bound == str(user_id)
 
-    def test_raises_401_for_invalid_token(self, store):
+    def test_raises_401_for_invalid_token(self, store, cache):
         """Invalid token raises HTTPException 401."""
         # GIVEN
         invalid_token = "invalid.token.here"
@@ -76,12 +83,12 @@ class TestGetCurrentUser:
 
         # WHEN / THEN
         with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(get_current_user(invalid_token, mock_session, store))
+            asyncio.run(get_current_user(invalid_token, mock_session, store, cache))
 
         assert exc_info.value.status_code == 401
         assert "Could not validate credentials" in exc_info.value.detail
 
-    def test_raises_401_for_nonexistent_user(self, store):
+    def test_raises_401_for_nonexistent_user(self, store, cache):
         """Valid token but non-existent user raises HTTPException 401."""
         # GIVEN
         user_id = uuid4()
@@ -96,12 +103,12 @@ class TestGetCurrentUser:
 
             # THEN
             with pytest.raises(HTTPException) as exc_info:
-                asyncio.run(get_current_user(token, mock_session, store))
+                asyncio.run(get_current_user(token, mock_session, store, cache))
 
         assert exc_info.value.status_code == 401
         assert "Could not validate credentials" in exc_info.value.detail
 
-    def test_raises_401_for_revoked_token(self, store):
+    def test_raises_401_for_revoked_token(self, store, cache):
         """Revoked token raises HTTPException 401."""
         # GIVEN
         user_id = uuid4()
@@ -115,7 +122,7 @@ class TestGetCurrentUser:
 
         # WHEN / THEN
         with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(get_current_user(token, mock_session, store))
+            asyncio.run(get_current_user(token, mock_session, store, cache))
 
         assert exc_info.value.status_code == 401
 

--- a/tests/unit/api/services/test_user_cache.py
+++ b/tests/unit/api/services/test_user_cache.py
@@ -1,0 +1,42 @@
+"""Tests for the user profile cache."""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from api.db.models import User
+from api.services.user_cache import CachedUserData
+
+
+def _sample_user() -> User:
+    return User(
+        id=uuid4(),
+        email="alice@example.com",
+        hashed_password="secret-hash",
+        first_name="Alice",
+        last_name="Smith",
+        photo_url="key/photo.jpg",
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+
+def test_cached_user_data_roundtrips_through_json():
+    user = _sample_user()
+    data = CachedUserData.from_user(user)
+    restored = CachedUserData.from_json(data.to_json())
+    assert restored == data
+    assert restored.email == "alice@example.com"
+
+
+def test_cached_user_data_never_serializes_hashed_password():
+    data = CachedUserData.from_user(_sample_user())
+    assert "secret-hash" not in data.to_json()
+
+
+def test_to_user_rebuilds_user_with_empty_hash():
+    user = _sample_user()
+    restored = CachedUserData.from_user(user).to_user()
+    assert isinstance(restored, User)
+    assert restored.id == user.id
+    assert restored.email == user.email
+    assert restored.first_name == user.first_name
+    assert restored.hashed_password == ""

--- a/tests/unit/api/services/test_user_cache.py
+++ b/tests/unit/api/services/test_user_cache.py
@@ -65,6 +65,23 @@ def test_in_memory_cache_expires_entries():
     assert cache.get(data.id) is None
 
 
+def test_caches_skip_nonpositive_ttl():
+    """A TTL below 1 is not stored by either backend, giving a consistent miss."""
+    import fakeredis
+
+    from api.services.user_cache import InMemoryUserCache, RedisUserCache
+
+    data = CachedUserData.from_user(_sample_user())
+
+    in_memory = InMemoryUserCache()
+    in_memory.set(data, ttl_seconds=0)
+    assert in_memory.get(data.id) is None
+
+    redis_cache = RedisUserCache(fakeredis.FakeStrictRedis())
+    redis_cache.set(data, ttl_seconds=0)
+    assert redis_cache.get(data.id) is None
+
+
 def test_in_memory_cache_satisfies_protocol():
     """InMemoryUserCache implements the UserCacheStore protocol."""
     from api.services.user_cache import InMemoryUserCache, UserCacheStore

--- a/tests/unit/api/services/test_user_cache.py
+++ b/tests/unit/api/services/test_user_cache.py
@@ -153,6 +153,22 @@ def test_redis_cache_treats_corrupted_value_as_miss():
     client.set(key_template(user_id), b"\xff\xfe")
     assert cache.get(user_id) is None
 
+    # Test wrong-typed id (integer instead of string)
+    user_id = uuid4()
+    client.set(
+        key_template(user_id),
+        b'{"id": 42, "email": "e@x.com", "first_name": "A", "last_name": "B", "photo_url": null, "created_at": "2026-01-01T00:00:00+00:00"}',
+    )
+    assert cache.get(user_id) is None
+
+    # Test unparseable uuid
+    user_id = uuid4()
+    client.set(
+        key_template(user_id),
+        b'{"id": "not-a-uuid", "email": "e@x.com", "first_name": "A", "last_name": "B", "photo_url": null, "created_at": "2026-01-01T00:00:00+00:00"}',
+    )
+    assert cache.get(user_id) is None
+
 
 def test_redis_cache_satisfies_protocol():
     """RedisUserCache implements the UserCacheStore protocol."""

--- a/tests/unit/api/services/test_user_cache.py
+++ b/tests/unit/api/services/test_user_cache.py
@@ -121,3 +121,43 @@ def test_redis_cache_is_fail_open_on_errors():
     assert cache.get(data.id) is None
     cache.set(data, ttl_seconds=60)
     cache.invalidate(data.id)
+
+
+def test_redis_cache_treats_corrupted_value_as_miss():
+    """Corrupted cached values (non-JSON, null, number, invalid UTF-8) return None."""
+    import fakeredis
+
+    from api.services.user_cache import RedisUserCache
+
+    client = fakeredis.FakeStrictRedis()
+    cache = RedisUserCache(client)
+    key_template = RedisUserCache._key
+
+    # Test non-JSON bytes
+    user_id = uuid4()
+    client.set(key_template(user_id), b"not json")
+    assert cache.get(user_id) is None
+
+    # Test JSON null
+    user_id = uuid4()
+    client.set(key_template(user_id), b"null")
+    assert cache.get(user_id) is None
+
+    # Test JSON number
+    user_id = uuid4()
+    client.set(key_template(user_id), b"42")
+    assert cache.get(user_id) is None
+
+    # Test invalid UTF-8
+    user_id = uuid4()
+    client.set(key_template(user_id), b"\xff\xfe")
+    assert cache.get(user_id) is None
+
+
+def test_redis_cache_satisfies_protocol():
+    """RedisUserCache implements the UserCacheStore protocol."""
+    import fakeredis
+
+    from api.services.user_cache import RedisUserCache, UserCacheStore
+
+    assert isinstance(RedisUserCache(fakeredis.FakeStrictRedis()), UserCacheStore)

--- a/tests/unit/api/services/test_user_cache.py
+++ b/tests/unit/api/services/test_user_cache.py
@@ -40,3 +40,33 @@ def test_to_user_rebuilds_user_with_empty_hash():
     assert restored.email == user.email
     assert restored.first_name == user.first_name
     assert restored.hashed_password == ""
+
+
+def test_in_memory_cache_get_set_invalidate():
+    """Set, get, and invalidate a cache entry."""
+    from api.services.user_cache import InMemoryUserCache
+
+    cache = InMemoryUserCache()
+    data = CachedUserData.from_user(_sample_user())
+    assert cache.get(data.id) is None
+    cache.set(data, ttl_seconds=60)
+    assert cache.get(data.id) == data
+    cache.invalidate(data.id)
+    assert cache.get(data.id) is None
+
+
+def test_in_memory_cache_expires_entries():
+    """Expired entries return None on get."""
+    from api.services.user_cache import InMemoryUserCache
+
+    cache = InMemoryUserCache()
+    data = CachedUserData.from_user(_sample_user())
+    cache.set(data, ttl_seconds=-1)  # already expired
+    assert cache.get(data.id) is None
+
+
+def test_in_memory_cache_satisfies_protocol():
+    """InMemoryUserCache implements the UserCacheStore protocol."""
+    from api.services.user_cache import InMemoryUserCache, UserCacheStore
+
+    assert isinstance(InMemoryUserCache(), UserCacheStore)

--- a/tests/unit/api/services/test_user_cache.py
+++ b/tests/unit/api/services/test_user_cache.py
@@ -70,3 +70,54 @@ def test_in_memory_cache_satisfies_protocol():
     from api.services.user_cache import InMemoryUserCache, UserCacheStore
 
     assert isinstance(InMemoryUserCache(), UserCacheStore)
+
+
+def test_redis_cache_roundtrip_and_key():
+    """Redis cache roundtrips data and stores with correct TTL."""
+
+    import fakeredis
+
+    from api.services.user_cache import RedisUserCache
+
+    client = fakeredis.FakeStrictRedis()
+    cache = RedisUserCache(client)
+    data = CachedUserData.from_user(_sample_user())
+    cache.set(data, ttl_seconds=60)
+    assert cache.get(data.id) == data
+    assert client.ttl(f"user:profile:v1:{data.id}") > 0
+
+
+def test_redis_cache_invalidate_removes_key():
+    """Invalidation removes the key from cache."""
+
+    import fakeredis
+
+    from api.services.user_cache import RedisUserCache
+
+    client = fakeredis.FakeStrictRedis()
+    cache = RedisUserCache(client)
+    data = CachedUserData.from_user(_sample_user())
+    cache.set(data, ttl_seconds=60)
+    cache.invalidate(data.id)
+    assert cache.get(data.id) is None
+
+
+def test_redis_cache_is_fail_open_on_errors():
+    """Redis errors are logged and swallowed, returning None or no-op."""
+    from unittest.mock import MagicMock
+
+    import fakeredis
+    import redis
+
+    from api.services.user_cache import RedisUserCache
+
+    client = MagicMock(spec=fakeredis.FakeStrictRedis)
+    client.get.side_effect = redis.RedisError("down")
+    client.set.side_effect = redis.RedisError("down")
+    client.delete.side_effect = redis.RedisError("down")
+    cache = RedisUserCache(client)
+    data = CachedUserData.from_user(_sample_user())
+    # None of these raise:
+    assert cache.get(data.id) is None
+    cache.set(data, ttl_seconds=60)
+    cache.invalidate(data.id)

--- a/tests/unit/api/services/test_user_cache.py
+++ b/tests/unit/api/services/test_user_cache.py
@@ -177,3 +177,21 @@ def test_redis_cache_satisfies_protocol():
     from api.services.user_cache import RedisUserCache, UserCacheStore
 
     assert isinstance(RedisUserCache(fakeredis.FakeStrictRedis()), UserCacheStore)
+
+
+def test_ttl_setting_defaults_to_60():
+    """TTL setting defaults to 60 seconds."""
+    from api.config import get_settings
+
+    assert get_settings().user_cache_ttl_seconds == 60
+
+
+def test_get_user_cache_is_singleton():
+    """get_user_cache returns the same instance (singleton pattern)."""
+    from api.services.user_cache import UserCacheStore, get_user_cache
+
+    get_user_cache.cache_clear()
+    first = get_user_cache()
+    second = get_user_cache()
+    assert first is second
+    assert isinstance(first, UserCacheStore)

--- a/tests/unit/api/test_dependencies.py
+++ b/tests/unit/api/test_dependencies.py
@@ -169,9 +169,10 @@ class TestGetPasswordResetService:
         """
         # GIVEN
         mock_session = MagicMock()
+        mock_cache = MagicMock()
 
         # WHEN
-        result = get_password_reset_service(mock_session)
+        result = get_password_reset_service(mock_session, mock_cache)
 
         # THEN
         assert isinstance(result, PasswordResetService)

--- a/uv.lock
+++ b/uv.lock
@@ -336,6 +336,7 @@ dev = [
     { name = "pip-audit" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-postgresql" },
     { name = "pytest-xdist" },
@@ -395,6 +396,7 @@ requires-dist = [
     { name = "pydantic-settings", marker = "extra == 'api'", specifier = "==2.14.2" },
     { name = "pyjwt", marker = "extra == 'api'", specifier = "==2.13.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.1" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.4.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
     { name = "pytest-postgresql", marker = "extra == 'dev'", specifier = "==8.1.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "==3.8.0" },
@@ -2925,6 +2927,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Caches the per-request user lookup (`get_current_user`) in Redis, taking a `SELECT ... FROM users` off every authenticated request. Built on the project's existing store pattern (`RevocationStore`).

## What

- New `UserCacheStore`: `Protocol` + `RedisUserCache` + `InMemoryUserCache` + `@lru_cache` factory, selected by `redis_url` exactly like `get_revocation_store`.
- On a cache hit, `get_current_user` rebuilds a transient `User` from a hashless `CachedUserData` snapshot and skips the DB. The `CurrentUser` type stays `User`, so routes and schemas are untouched.
- Write endpoints move to a new `CurrentUserFresh` dependency (session-bound, always DB) and invalidate the cache after commit; `GET /me` stays cached.
- TTL `user_cache_ttl_seconds` (default 60) bounds the cache-aside staleness window.

## Security

- `hashed_password` is never serialized into Redis. Revocation and `valid_after` checks run before the cache is consulted.
- Deleting an account revokes its tokens, so a deleted user cannot keep authenticating from a warm cache entry.
- Cache identity is bound to the authenticated token subject, not the cached value.
- Fail-open on Redis errors; corrupted or wrong-typed cache values are treated as a miss (total `from_json` boundary).

## Tests

1221 passed, 59 skipped, 0 failed; `mypy --strict` and `ruff` clean. Coverage includes adversarial corrupted-value handling, per-mutation invalidation, and deleted-account-401 end-to-end.

The design was reviewed by an external adversarial pass (Gemini) before implementation and by a whole-branch review after; deferred items (delayed double-delete, circuit breaker) are noted as YAGNI for a follow-up.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Redis-backed user-profile cache to eliminate a `SELECT … FROM users` on every authenticated request. It introduces a `UserCacheStore` Protocol with `RedisUserCache` and `InMemoryUserCache` implementations, wires them into `UserService` and `PasswordResetService` for post-mutation invalidation, and splits the auth dependency into a cached `CurrentUser` (read-only `GET /me`) and a session-bound `CurrentUserFresh` (all mutating endpoints).

- **`api/services/user_cache.py`** — new `CachedUserData` snapshot (no `hashed_password`), `UserCacheStore` Protocol, both backends, and an `@lru_cache` factory mirroring the existing `get_revocation_store` pattern.
- **`api/auth/dependencies.py`** — `get_current_user` short-circuits on a cache hit; a new `get_current_user_fresh` always hits the DB; the id-mismatch guard prevents a tampered backend from serving the wrong profile.
- **`api/routes/users.py`** — all mutating endpoints switch to `CurrentUserFresh`; `DELETE /me` gains `store.set_user_valid_after` so tokens for the deleted account are rejected before the cache is even consulted.

<h3>Confidence Score: 4/5</h3>

The cache layer is well-isolated: revocation checks run before the cache, mutations invalidate eagerly, and Redis errors fail open. No correctness or security issues were found in the core auth and invalidation paths.

Two small logic gaps exist: the TTL floor differs between InMemoryUserCache (allows 0) and RedisUserCache (enforces 1), creating a subtle behavioural difference at zero TTL; and the service factories in api/dependencies.py call get_user_cache() directly rather than via Depends, silently ignoring app.dependency_overrides for that injection site. Neither causes a current defect, but both are worth resolving for long-term maintainability.

api/dependencies.py (direct get_user_cache() call) and api/services/user_cache.py (InMemoryUserCache TTL floor).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/services/user_cache.py | New module implementing CachedUserData snapshot, UserCacheStore Protocol, InMemoryUserCache, RedisUserCache, and @lru_cache factory; well-structured with fail-open Redis error handling and a full serialization boundary in from_json. |
| api/auth/dependencies.py | get_current_user gains cache-hit short-circuit with id-mismatch guard; new get_current_user_fresh always hits DB for mutating endpoints; revocation checks are correctly ordered before the cache lookup. |
| api/routes/users.py | All mutating endpoints now use CurrentUserFresh; delete_current_user gains token revocation (set_user_valid_after) after service.delete_user to close the cache-serving-deleted-account window. |
| api/dependencies.py | get_user_service and get_password_reset_service now pass get_user_cache() directly (not via Depends), which means app.dependency_overrides[get_user_cache] cannot intercept the cache injected into these factories. |
| api/services/user_service.py | Optional UserCacheStore injected via constructor; _invalidate_cache helper called after every mutation (update_user, change_password, delete_user, update_photo_url). |
| api/services/password_reset_service.py | Optional UserCacheStore injected via constructor; cache invalidated after successful password reset. |
| tests/integration/api/services/test_user_cache_invalidation.py | Four integration tests cover per-mutation invalidation; test_update_user_invalidates_cache is the only test missing a docstring, inconsistent with its siblings. |
| tests/unit/api/services/test_user_cache.py | Thorough unit tests covering JSON roundtrip, password exclusion, expiry, protocol conformance, Redis fail-open behaviour, and corrupted-value handling. |
| tests/integration/api/auth/test_current_user_cache.py | Async integration tests verifying cache-hit DB bypass and id-mismatch fallthrough; lru_cache is cleared between tests correctly. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant FastAPI as FastAPI (get_current_user)
    participant RevStore as RevocationStore
    participant Cache as UserCacheStore (Redis / InMemory)
    participant DB as Database (UserService)

    Client->>FastAPI: request + JWT token
    FastAPI->>RevStore: decode_access_token(token, store)
    RevStore-->>FastAPI: "user_id (or TokenError -> 401)"
    FastAPI->>Cache: cache.get(user_id)
    alt Cache HIT
        Cache-->>FastAPI: CachedUserData
        FastAPI->>FastAPI: "cached.to_user() -> transient User"
    else Cache MISS
        Cache-->>FastAPI: None
        FastAPI->>DB: UserService.get_by_id(user_id)
        DB-->>FastAPI: "User (or None -> 401)"
        FastAPI->>Cache: cache.set(CachedUserData.from_user(user), ttl)
    end
    FastAPI-->>Client: User

    note over FastAPI,DB: Mutation path (CurrentUserFresh)
    Client->>FastAPI: PUT/DELETE/POST with JWT
    FastAPI->>RevStore: decode_access_token (fresh, no cache)
    FastAPI->>DB: UserService.get_by_id(user_id)
    DB-->>FastAPI: session-bound User
    FastAPI->>DB: service.update_user / change_password / delete_user
    DB-->>FastAPI: saved
    FastAPI->>Cache: cache.invalidate(user_id)
    FastAPI-->>Client: response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant FastAPI as FastAPI (get_current_user)
    participant RevStore as RevocationStore
    participant Cache as UserCacheStore (Redis / InMemory)
    participant DB as Database (UserService)

    Client->>FastAPI: request + JWT token
    FastAPI->>RevStore: decode_access_token(token, store)
    RevStore-->>FastAPI: "user_id (or TokenError -> 401)"
    FastAPI->>Cache: cache.get(user_id)
    alt Cache HIT
        Cache-->>FastAPI: CachedUserData
        FastAPI->>FastAPI: "cached.to_user() -> transient User"
    else Cache MISS
        Cache-->>FastAPI: None
        FastAPI->>DB: UserService.get_by_id(user_id)
        DB-->>FastAPI: "User (or None -> 401)"
        FastAPI->>Cache: cache.set(CachedUserData.from_user(user), ttl)
    end
    FastAPI-->>Client: User

    note over FastAPI,DB: Mutation path (CurrentUserFresh)
    Client->>FastAPI: PUT/DELETE/POST with JWT
    FastAPI->>RevStore: decode_access_token (fresh, no cache)
    FastAPI->>DB: UserService.get_by_id(user_id)
    DB-->>FastAPI: session-bound User
    FastAPI->>DB: service.update_user / change_password / delete_user
    DB-->>FastAPI: saved
    FastAPI->>Cache: cache.invalidate(user_id)
    FastAPI-->>Client: response
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
tests/integration/api/services/test_user_cache_invalidation.py:7-8
This test is the only one in the file without a docstring; all three of its siblings (`test_change_password_invalidates_cache`, `test_update_photo_url_invalidates_cache`, `test_delete_user_invalidates_cache`) carry one. Per `py-docstring-contracts`, public functions need at least a one-line docstring.

```suggestion
def test_update_user_invalidates_cache(session):
    """update_user drops the cached snapshot after the profile is saved."""
    cache = InMemoryUserCache()
```

### Issue 2 of 3
api/services/user_cache.py:171
The floor value differs between the two backends: `InMemoryUserCache.set` accepts `0` (the entry expires the instant it is stored), while `RedisUserCache.set` enforces a minimum of `1`. If `user_cache_ttl_seconds` is ever set to `0` in config or tests, the in-memory cache always misses but Redis keeps entries alive for one extra second — a behaviour gap that would be hard to reproduce.

```suggestion
        expires_at = datetime.now(UTC) + timedelta(seconds=max(ttl_seconds, 1))
```

### Issue 3 of 3
api/dependencies.py:61
**Direct call bypasses FastAPI dependency override**

Both `get_user_service` and `get_password_reset_service` call `get_user_cache()` directly rather than receiving it via `Depends(get_user_cache)`. Because `get_user_cache` is `@lru_cache`, the right singleton is always returned in production, so there is no runtime defect. However, `app.dependency_overrides[get_user_cache]` is silently ignored for the cache injected into these two factories — a test that overrides the dependency at the FastAPI layer would see the override in `get_current_user` but not in the mutating service path, which could give a false-green on future cache-related service tests.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: refresh secrets baseline for user..."](https://github.com/caitlon/become/commit/dab7ecac5a49c3f5a488e73b901ba32e92fd3b1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43141479)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - Public classes, methods, and functions need a reSt... ([source](.greptile))

<!-- /greptile_comment -->