### PR TITLE
chore: ignore local .worktreeinclude file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ scripts/seed_db.py
 .mcp.json
 CLAUDE.md
 .claude
+.worktreeinclude
 .github/ISSUE_TEMPLATE
 
 # Mutation testing


### PR DESCRIPTION
## What

Adds `.worktreeinclude` to `.gitignore`.

## Why

`.worktreeinclude` is a local-only Claude Code config file — a list of untracked/gitignored paths to copy into freshly created session worktrees. It is machine-specific and should never be committed. This rule puts it alongside the already-ignored `.mcp.json`, `CLAUDE.md`, and `.claude`.

## Scope

One line in `.gitignore`. No product behaviour or code touched.