### PR TITLE
fix: repair broken aria keys, localize the switcher label, and unify date formatting

### DIFF
--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -7,7 +7,7 @@ const languages = [
 ] as const;
 
 export function LanguageSwitcher() {
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const resolved = (i18n.resolvedLanguage ?? i18n.language).split("-")[0];
   const currentLang = resolved === "cs" ? "cs" : "en";
@@ -23,7 +23,7 @@ export function LanguageSwitcher() {
       size="sm"
       onClick={toggleLanguage}
       className="h-10 px-3 hover:bg-muted transition-colors duration-300"
-      aria-label={`Switch to ${nextLang.name}`}
+      aria-label={t("switchToLanguage", { language: nextLang.name })}
     >
       <span className="text-sm font-medium">
         {currentLang.toUpperCase()}

--- a/frontend/src/components/forms/PasswordInput.tsx
+++ b/frontend/src/components/forms/PasswordInput.tsx
@@ -42,6 +42,7 @@ const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
             onClick={() => setShowPassword(!showPassword)}
             className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
             aria-label={showPassword ? t("password.hide") : t("password.show")}
+            aria-pressed={showPassword}
           >
             {showPassword ? (
               <EyeOff className="h-4 w-4" />

--- a/frontend/src/components/modals/DeleteAccountDialog.tsx
+++ b/frontend/src/components/modals/DeleteAccountDialog.tsx
@@ -125,7 +125,7 @@ export function DeleteAccountDialog({
             <div
               className="flex justify-center py-6"
               role="status"
-              aria-label={tCommon("aria.loading")}
+              aria-label={tCommon("a11y.loading")}
             >
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
             </div>

--- a/frontend/src/components/project/MemberProfileDialog.tsx
+++ b/frontend/src/components/project/MemberProfileDialog.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
 import { Member, Opinion } from "@/types/api";
+import { formatDate } from "@/lib/formatDate";
 
 export interface MemberProfileDialogProps {
   member: Member | null;
@@ -127,7 +128,7 @@ export const MemberProfileDialog = ({
               {t("memberProfile.joined")}
             </p>
             <p className="text-sm">
-              {new Date(member.joined_at).toLocaleDateString(i18n.language)}
+              {formatDate(member.joined_at, i18n.language)}
             </p>
           </div>
         </div>

--- a/frontend/src/components/project/TeamTable.tsx
+++ b/frontend/src/components/project/TeamTable.tsx
@@ -14,6 +14,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Member, ProjectInvitation } from "@/types/api";
+import { formatDate } from "@/lib/formatDate";
 
 export interface TeamTableProps {
   members: Member[];
@@ -96,7 +97,7 @@ export const TeamTable = ({
                     </Badge>
                   </TableCell>
                   <TableCell className="text-muted-foreground">
-                    {new Date(member.joined_at).toLocaleDateString(i18n.language)}
+                    {formatDate(member.joined_at, i18n.language)}
                   </TableCell>
                   {isAdmin && (
                     <TableCell>

--- a/frontend/src/i18n/locales/cs/common.json
+++ b/frontend/src/i18n/locales/cs/common.json
@@ -3,6 +3,7 @@
     "name": "BeCoMe"
   },
   "cancel": "Zrušit",
+  "switchToLanguage": "Přepnout na {{language}}",
   "deleteModal": {
     "permanentlyDelete": "Trvale smaže:",
     "cannotUndo": "Tuto akci nelze vrátit zpět.",

--- a/frontend/src/i18n/locales/cs/landing.json
+++ b/frontend/src/i18n/locales/cs/landing.json
@@ -1,7 +1,7 @@
 {
   "hero": {
     "title1": "Skupinová rozhodnutí,",
-    "title2": "Přesně změřená",
+    "title2": "přesně změřená",
     "subtitle": "Agregujte názory expertů pomocí fuzzy trojúhelníkových čísel. Najděte nejlepší kompromis matematickým konsenzem.",
     "goToProjects": "Přejít na projekty",
     "startProject": "Založit projekt"

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -3,6 +3,7 @@
     "name": "BeCoMe"
   },
   "cancel": "Cancel",
+  "switchToLanguage": "Switch to {{language}}",
   "deleteModal": {
     "permanentlyDelete": "This will permanently delete:",
     "cannotUndo": "This action cannot be undone.",

--- a/frontend/src/lib/formatDate.ts
+++ b/frontend/src/lib/formatDate.ts
@@ -1,0 +1,18 @@
+/**
+ * Format a date consistently across the app for the given locale.
+ *
+ * Always spells out the month (e.g. "Jul 18, 2026" for en, "18. 7. 2026"
+ * for cs) so the result is never a bare numeric date that reads as DD/MM in
+ * one place and MM/DD in another depending on how the locale was passed.
+ *
+ * @param value - ISO date string or Date instance.
+ * @param locale - BCP 47 locale tag, typically `i18n.language`.
+ */
+export function formatDate(value: string | Date, locale: string): string {
+  const date = typeof value === 'string' ? new Date(value) : value;
+  return new Intl.DateTimeFormat(locale, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  }).format(date);
+}

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -227,7 +227,7 @@ const Profile = () => {
     return (
       <div className="min-h-screen">
         <Navbar />
-        <div className="pt-24 flex items-center justify-center" role="status" aria-label={tCommon("aria.loading")}>
+        <div className="pt-24 flex items-center justify-center" role="status" aria-label={tCommon("a11y.loading")}>
           <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
         </div>
       </div>

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -24,6 +24,7 @@ import { queryKeys } from "@/lib/queryKeys";
 import { ProjectWithRole } from "@/types/api";
 import { useToast } from "@/hooks/use-toast";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { formatDate } from "@/lib/formatDate";
 
 // Multiple of the 1/2/3-column grid so every full page fills whole rows.
 const PAGE_SIZE = 24;
@@ -46,7 +47,7 @@ const itemVariants = {
 };
 
 const Projects = () => {
-  const { t } = useTranslation("projects");
+  const { t, i18n } = useTranslation("projects");
   const { t: tCommon } = useTranslation();
   const { toast } = useToast();
   useDocumentTitle(tCommon("pageTitle.projects"));
@@ -371,7 +372,7 @@ const Projects = () => {
                                 {invitation.current_experts_count} {t("card.experts")}
                               </span>
                               <span>
-                                {t("invitations.invitedDate")}: {new Date(invitation.invited_at).toLocaleDateString()}
+                                {t("invitations.invitedDate")}: {formatDate(invitation.invited_at, i18n.language)}
                               </span>
                             </div>
 

--- a/frontend/tests/components/DeleteAccountDialog.test.tsx
+++ b/frontend/tests/components/DeleteAccountDialog.test.tsx
@@ -123,4 +123,14 @@ describe('DeleteAccountDialog', () => {
     expect(screen.getByRole('button', { name: 'Delete My Account' })).toBeDisabled();
     expect(mockApi.deleteAccount).not.toHaveBeenCalled();
   });
+
+  it('shows an accessible loading status while owned projects load', () => {
+    mockApi.getProjects.mockReturnValue(new Promise(() => {}));
+    renderDialog();
+
+    // Exact match, not a substring regex: pins the resolved a11y.loading
+    // translation so a broken i18n key (e.g. "aria.loading") fails loudly
+    // instead of accidentally matching on its own literal text.
+    expect(screen.getByRole('status', { name: 'Loading' })).toBeInTheDocument();
+  });
 });

--- a/frontend/tests/components/LanguageSwitcher.test.tsx
+++ b/frontend/tests/components/LanguageSwitcher.test.tsx
@@ -3,6 +3,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '@tests/utils';
 import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import i18n from '@/i18n';
 
 // Mock i18n with hoisted variables
 const { mockI18n, mockChangeLanguage } = vi.hoisted(() => {
@@ -17,12 +18,15 @@ const { mockI18n, mockChangeLanguage } = vi.hoisted(() => {
   };
 });
 
+// Only the resolvedLanguage/language/changeLanguage trio is faked (so the
+// resolvedLanguage-fallback branches below stay easy to drive); `t` stays
+// the real hook so the aria-label is checked against the actual translations.
 vi.mock('react-i18next', async () => {
-  const actual = await vi.importActual('react-i18next');
+  const actual = await vi.importActual<typeof import('react-i18next')>('react-i18next');
   return {
     ...actual,
-    useTranslation: () => ({
-      t: (key: string) => key,
+    useTranslation: (...args: Parameters<typeof actual.useTranslation>) => ({
+      ...actual.useTranslation(...args),
       i18n: mockI18n,
     }),
   };
@@ -46,6 +50,22 @@ describe('LanguageSwitcher', () => {
 
     const button = screen.getByRole('button');
     expect(button).toHaveAttribute('aria-label', 'Switch to Čeština');
+  });
+
+  it('translates the accessible label when the UI language is Czech', async () => {
+    await i18n.changeLanguage('cs');
+    try {
+      const { unmount } = render(<LanguageSwitcher />);
+
+      const button = screen.getByRole('button');
+      expect(button).toHaveAttribute('aria-label', 'Přepnout na Čeština');
+
+      // Unmount before reverting the language so the language change below
+      // does not re-render this already-asserted component outside act().
+      unmount();
+    } finally {
+      await i18n.changeLanguage('en');
+    }
   });
 
   it('calls changeLanguage with "cs" when current is "en"', async () => {

--- a/frontend/tests/components/forms/PasswordInput.test.tsx
+++ b/frontend/tests/components/forms/PasswordInput.test.tsx
@@ -27,6 +27,29 @@ describe('PasswordInput', () => {
     expect(input).toHaveAttribute('type', 'password')
   })
 
+  it('is a plain button that never submits the surrounding form', () => {
+    render(<PasswordInput label="Password" name="password" />)
+
+    const toggleButton = screen.getByRole('button', { name: /show|hide/i })
+    expect(toggleButton).toHaveAttribute('type', 'button')
+  })
+
+  it('reflects visibility state via aria-pressed and updates the aria-label on toggle', async () => {
+    const user = userEvent.setup()
+    render(<PasswordInput label="Password" name="password" />)
+
+    const toggleButton = screen.getByRole('button', { name: 'Show password' })
+    expect(toggleButton).toHaveAttribute('aria-pressed', 'false')
+
+    await user.click(toggleButton)
+    expect(toggleButton).toHaveAttribute('aria-pressed', 'true')
+    expect(toggleButton).toHaveAccessibleName('Hide password')
+
+    await user.click(toggleButton)
+    expect(toggleButton).toHaveAttribute('aria-pressed', 'false')
+    expect(toggleButton).toHaveAccessibleName('Show password')
+  })
+
   it('displays error message', () => {
     render(
       <PasswordInput

--- a/frontend/tests/components/project/MemberProfileDialog.test.tsx
+++ b/frontend/tests/components/project/MemberProfileDialog.test.tsx
@@ -63,6 +63,22 @@ describe('MemberProfileDialog - Basic Rendering', () => {
 
     expect(screen.getByRole('heading', { name: 'Jane Smith' })).toBeInTheDocument();
   });
+
+  it('renders the joined date through the shared formatDate helper', () => {
+    const member = createMember({
+      first_name: 'Jane',
+      last_name: 'Smith',
+      role: 'expert',
+      joined_at: '2024-03-15T12:00:00Z',
+    });
+
+    render(<MemberProfileDialog member={member} opinion={null} onOpenChange={vi.fn()} />);
+
+    // Spelled-out month, not a bare numeric date (AUD-031): unambiguous
+    // regardless of DD/MM vs MM/DD locale conventions.
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText('Mar 15, 2024')).toBeInTheDocument();
+  });
 });
 
 describe('MemberProfileDialog - Opinion Content', () => {

--- a/frontend/tests/components/project/TeamTable.test.tsx
+++ b/frontend/tests/components/project/TeamTable.test.tsx
@@ -35,6 +35,18 @@ describe('TeamTable - Rendering', () => {
     // in the test environment), so the initials fallback is what actually renders.
     expect(screen.getByText('JS')).toBeInTheDocument();
   });
+
+  it('renders the joined date through the shared formatDate helper', () => {
+    const members = [
+      createMember({ user_id: 'user-2', first_name: 'Jane', last_name: 'Smith', joined_at: '2024-03-15T12:00:00Z' }),
+    ];
+
+    render(<TeamTable {...baseProps} members={members} pendingInvitations={[]} />);
+
+    // Spelled-out month, not a bare numeric date (AUD-031): unambiguous
+    // regardless of DD/MM vs MM/DD locale conventions.
+    expect(screen.getByText('Mar 15, 2024')).toBeInTheDocument();
+  });
 });
 
 describe('TeamTable - Pending Invitations', () => {

--- a/frontend/tests/i18n/aria-smoke.test.ts
+++ b/frontend/tests/i18n/aria-smoke.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import i18n, { resources } from '@/i18n';
+
+/**
+ * Regression guard for AUD-004: a component called `t("aria.loading")`, a
+ * key that does not exist (the real key is `a11y.loading`). i18next's
+ * missing-key fallback returns the key string unchanged, so the screen
+ * reader read the literal text "aria.loading" instead of "Loading".
+ *
+ * Every key below is one actually passed to `t()`/`tCommon()` for an
+ * aria-label, role name, or sr-only string somewhere in the app. Resolving
+ * to something other than the key itself proves the key exists in both
+ * locales -- it would have caught the aria.loading typo immediately.
+ */
+function collectKeys(obj: Record<string, unknown>, prefix = ''): string[] {
+  const keys: string[] = [];
+
+  for (const key of Object.keys(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    const value = obj[key];
+
+    if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      keys.push(...collectKeys(value as Record<string, unknown>, path));
+    } else {
+      keys.push(path);
+    }
+  }
+
+  return keys.sort();
+}
+
+const a11yKeys = collectKeys(resources.en.common.a11y as Record<string, unknown>).map(
+  (key) => `a11y.${key}`
+);
+
+// Aria-label-bound keys that live outside the a11y.* block.
+const otherCriticalAriaKeys = [
+  'password.show',
+  'password.hide',
+  'switchToLanguage',
+  'theme.toggle',
+  'theme.switchToDark',
+  'theme.switchToLight',
+];
+
+const criticalAriaKeys = [...a11yKeys, ...otherCriticalAriaKeys];
+
+describe('critical aria strings resolve to real translations', () => {
+  it.each(criticalAriaKeys)('%s resolves in English', (key) => {
+    const t = i18n.getFixedT('en', 'common');
+    expect(t(key)).not.toBe(key);
+  });
+
+  it.each(criticalAriaKeys)('%s resolves in Czech', (key) => {
+    const t = i18n.getFixedT('cs', 'common');
+    expect(t(key)).not.toBe(key);
+  });
+
+  it('demonstrates the historical aria.loading typo would have failed this check', () => {
+    const t = i18n.getFixedT('en', 'common');
+    expect(t('aria.loading')).toBe('aria.loading');
+  });
+});

--- a/frontend/tests/lib/formatDate.test.ts
+++ b/frontend/tests/lib/formatDate.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { formatDate } from '@/lib/formatDate';
+
+describe('formatDate', () => {
+  it('formats an ISO date string for the English locale with a spelled-out month', () => {
+    expect(formatDate('2026-07-18T12:00:00Z', 'en')).toBe('Jul 18, 2026');
+  });
+
+  it('formats a Date instance the same way as the equivalent ISO string', () => {
+    expect(formatDate(new Date('2026-07-18T12:00:00Z'), 'en')).toBe('Jul 18, 2026');
+  });
+
+  it('never renders an all-numeric, locale-ambiguous date for en', () => {
+    // This is the AUD-031 bug: plain numeric formatting reads as DD/MM in
+    // one place and MM/DD in another depending on how the locale is passed.
+    const result = formatDate('2026-07-18T12:00:00Z', 'en');
+    expect(result).not.toMatch(/^\d{1,2}\/\d{1,2}\/\d{4}$/);
+  });
+
+  it('localizes for cs using Czech day-month-year order', () => {
+    expect(formatDate('2026-07-18T12:00:00Z', 'cs')).toBe('18. 7. 2026');
+  });
+
+  it('renders single-digit days and months without leading zeros', () => {
+    expect(formatDate('2026-01-05T12:00:00Z', 'en')).toBe('Jan 5, 2026');
+    expect(formatDate('2026-01-05T12:00:00Z', 'cs')).toBe('5. 1. 2026');
+  });
+});

--- a/frontend/tests/pages/Profile.loading.test.tsx
+++ b/frontend/tests/pages/Profile.loading.test.tsx
@@ -45,7 +45,10 @@ describe('Profile - Loading State', () => {
   it('shows loading spinner when user is null', () => {
     render(<Profile />);
 
-    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+    // Exact match, not a substring regex: pins the resolved a11y.loading
+    // translation so a broken i18n key (e.g. "aria.loading") fails loudly
+    // instead of accidentally matching on its own literal text.
+    expect(screen.getByRole('status', { name: 'Loading' })).toBeInTheDocument();
   });
 
   it('does not render profile form when user is null', () => {

--- a/frontend/tests/pages/Projects.test.tsx
+++ b/frontend/tests/pages/Projects.test.tsx
@@ -293,6 +293,20 @@ describe('Projects', () => {
       });
     });
 
+    it('renders the invited date through the shared formatDate helper', async () => {
+      mockApi.getInvitations.mockResolvedValue([
+        createInvitation({ invited_at: '2024-03-15T12:00:00Z' }),
+      ]);
+
+      await openInvitationsTab();
+
+      // Spelled-out month, not a bare numeric date (AUD-031): unambiguous
+      // regardless of DD/MM vs MM/DD locale conventions.
+      await waitFor(() => {
+        expect(screen.getByText(/Mar 15, 2024/)).toBeInTheDocument();
+      });
+    });
+
     it('accept invitation calls API and refreshes', async () => {
       mockApi.getInvitations.mockResolvedValue([createInvitation({ id: 'inv-123' })]);
       mockApi.acceptInvitation.mockResolvedValue({});


### PR DESCRIPTION
## Summary

Baseline-safe i18n + accessibility polish from the UI/UX audit. No visual or layout change — the navbar, charts, and theme are untouched (so the visual-regression baselines are unaffected).

- **AUD-004:** `tCommon("aria.loading")` in `DeleteAccountDialog` and `Profile` resolved to the literal string `"aria.loading"` (the key is `a11y.loading`), so screen readers announced "aria.loading" on those loading states. Fixed the key and added an `aria-smoke` test that asserts the critical `a11y.*` / aria keys actually resolve (`t(key) !== key`) in both locales, so a broken aria key fails CI. This also un-masked a loose `/loading/i` matcher in the Profile loading test that had been passing *on* the bug.
- **AUD-012:** `LanguageSwitcher`'s `aria-label` was a hardcoded English ``Switch to ${name}`` even in the Czech UI — now `t("switchToLanguage", { language })` (added to `en` + `cs`).
- **AUD-020:** the Czech hero headline "…, Přesně změřená" carried a mid-sentence capital (Title Case from EN) — lowercased to "přesně změřená". EN unchanged.
- **AUD-031:** invitation cards rendered dates as DD/MM/YYYY while the team table rendered M/D/YYYY (one of them used no explicit locale). New `lib/formatDate.ts` (`Intl.DateTimeFormat`, spelled-out month so the result is never an ambiguous bare-numeric date) is applied to all three date renders.
- **AUD-023:** the password show/hide toggle gains `aria-pressed` reflecting state (its `type="button"` and i18n-driven `aria-label` were already in place).

## Tests

Full `ci-local.sh fast` green (frontend **851**, +71 tests; backend 1222). New `aria-smoke` (guards every `a11y.*`/aria key against the raw-key regression) and `formatDate` suites; i18n key-parity holds (new `common.switchToLanguage` in both `en` and `cs`).
