### PR TITLE
fix: give the uv cache mounts an explicit id for the Railway builder

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ COPY pyproject.toml uv.lock ./
 # Install dependencies first (without project) for better layer caching.
 # The BuildKit cache mount keeps uv's wheel cache across builds (Railway persists
 # it), so wheels aren't re-downloaded when only the lockfile layer is invalidated.
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
     uv sync --locked --no-install-project --no-dev --extra api
 
 # Copy application code
@@ -41,7 +41,7 @@ COPY api/ ./api/
 COPY README.md ./
 
 # Install project with dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
     uv sync --locked --no-dev --extra api
 
 # ============================================

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -20,7 +20,7 @@ COPY --from=ghcr.io/astral-sh/uv@sha256:9a23023be68b2ed09750ae636228e903a54a05ea
 COPY pyproject.toml uv.lock ./
 
 # Install all dependencies including dev extras (with cache)
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
     uv sync --locked --extra api --extra dev
 
 # Copy application code (will be overridden by volume mount)


### PR DESCRIPTION
## Summary

Railway rejected the backend image build with:

```
dockerfile invalid: flag '--mount=type=cache,target=/root/.cache/uv' is missing an id argument at Line 35
dockerfile invalid: flag '--mount=type=cache,target=/root/.cache/uv' is missing an id argument at Line 44
```

Railway moved backend builds onto its new **Metal builder**, which requires every BuildKit cache mount to carry an explicit `id`. The three `uv` wheel-cache mounts (two in `docker/Dockerfile`, one in `docker/Dockerfile.dev`) omitted it -- accepted by the previous builder, rejected by the new one -- so the backend image failed at the "Build image" step. The dev deploy of `develop` failed this way, and staging + production would fail identically on promotion.

This gives all three mounts an explicit `id=uv-cache`. That is canonical BuildKit syntax accepted by both the old and new builders, and the shared id lets the two build stages reuse the same wheel cache (the original intent of the mount).

## Verification

- `docker/Dockerfile:35`, `docker/Dockerfile:44`, and `docker/Dockerfile.dev:23` now read `--mount=type=cache,id=uv-cache,target=/root/.cache/uv`.
- No image content or dependency change -- only the cache-mount flag.
- Final validation is the Railway rebuild on merge: the dev-backend deploy that failed will re-run through the build step.
