### PR TITLE
fix: guard forms against double-submit, refine validation, and surface rate-limit delays

### DIFF
--- a/frontend/src/components/modals/CreateProjectModal.tsx
+++ b/frontend/src/components/modals/CreateProjectModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -41,6 +41,7 @@ export function CreateProjectModal({
   const { t } = useTranslation("projects");
   const { toast } = useToast();
   const [isLoading, setIsLoading] = useState(false);
+  const submittingRef = useRef(false);
 
   const createProjectSchema = useMemo(
     () =>
@@ -77,6 +78,8 @@ export function CreateProjectModal({
   });
 
   const onSubmit = async (data: CreateProjectFormData) => {
+    if (submittingRef.current) return; // ignore re-entrant submits (double-click)
+    submittingRef.current = true;
     setIsLoading(true);
     try {
       await api.createProject({
@@ -100,6 +103,7 @@ export function CreateProjectModal({
       });
     } finally {
       setIsLoading(false);
+      submittingRef.current = false;
     }
   };
 
@@ -115,6 +119,7 @@ export function CreateProjectModal({
           </DialogDescription>
         </DialogHeader>
 
+        {/* eslint-disable-next-line react-hooks/refs -- handleSubmit defers to the browser's submit event; submittingRef is only read/written once that event fires, never during render */}
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <FormField
             label={`${t("create.name")} *`}
@@ -141,10 +146,17 @@ export function CreateProjectModal({
                   placeholder={t("create.scaleMinPlaceholder")}
                   {...register("scale_min")}
                   className={cn(/* v8 ignore next */ errors.scale_min && "border-destructive")}
+                  aria-invalid={!!errors.scale_min}
+                  aria-describedby={/* v8 ignore next */ errors.scale_min ? "scale-min-error" : undefined}
                 />
                 <span className="text-xs text-muted-foreground mt-1 block" aria-hidden="true">
                   {t("create.scaleMin")}
                 </span>
+                {errors.scale_min && (
+                  <p id="scale-min-error" className="text-xs text-destructive mt-1">
+                    {errors.scale_min.message}
+                  </p>
+                )}
               </div>
               <div>
                 <Label htmlFor="scale-max" className="sr-only">{t("create.scaleMax")}</Label>
@@ -154,10 +166,17 @@ export function CreateProjectModal({
                   placeholder={t("create.scaleMaxPlaceholder")}
                   {...register("scale_max")}
                   className={cn(errors.scale_max && "border-destructive")}
+                  aria-invalid={!!errors.scale_max}
+                  aria-describedby={errors.scale_max ? "scale-max-error" : undefined}
                 />
                 <span className="text-xs text-muted-foreground mt-1 block" aria-hidden="true">
                   {t("create.scaleMax")}
                 </span>
+                {errors.scale_max && (
+                  <p id="scale-max-error" className="text-xs text-destructive mt-1">
+                    {errors.scale_max.message}
+                  </p>
+                )}
               </div>
               <div>
                 <Label htmlFor="scale-unit" className="sr-only">{t("create.scaleUnit")}</Label>
@@ -166,17 +185,19 @@ export function CreateProjectModal({
                   placeholder={t("create.scaleUnitPlaceholder")}
                   {...register("scale_unit")}
                   className={cn(errors.scale_unit && "border-destructive")}
+                  aria-invalid={!!errors.scale_unit}
+                  aria-describedby={errors.scale_unit ? "scale-unit-error" : undefined}
                 />
                 <span className="text-xs text-muted-foreground mt-1 block" aria-hidden="true">
                   {t("create.scaleUnit")}
                 </span>
+                {errors.scale_unit && (
+                  <p id="scale-unit-error" className="text-xs text-destructive mt-1">
+                    {errors.scale_unit.message}
+                  </p>
+                )}
               </div>
             </div>
-            {errors.scale_max && (
-              <p className="text-sm text-destructive">
-                {errors.scale_max.message}
-              </p>
-            )}
           </fieldset>
 
           <div className="flex justify-end gap-3 pt-4">

--- a/frontend/src/components/modals/CreateProjectModal.tsx
+++ b/frontend/src/components/modals/CreateProjectModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef } from "react";
+import { useState, useMemo, useRef, useId } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -42,6 +42,7 @@ export function CreateProjectModal({
   const { toast } = useToast();
   const [isLoading, setIsLoading] = useState(false);
   const submittingRef = useRef(false);
+  const scaleId = useId();
 
   const createProjectSchema = useMemo(
     () =>
@@ -139,60 +140,60 @@ export function CreateProjectModal({
             <legend className="text-sm font-medium leading-none">{t("create.scaleSettings")}</legend>
             <div className="grid grid-cols-3 gap-3">
               <div>
-                <Label htmlFor="scale-min" className="sr-only">{t("create.scaleMin")}</Label>
+                <Label htmlFor={`${scaleId}-min`} className="sr-only">{t("create.scaleMin")}</Label>
                 <Input
-                  id="scale-min"
+                  id={`${scaleId}-min`}
                   type="number"
                   placeholder={t("create.scaleMinPlaceholder")}
                   {...register("scale_min")}
                   className={cn(/* v8 ignore next */ errors.scale_min && "border-destructive")}
                   aria-invalid={!!errors.scale_min}
-                  aria-describedby={/* v8 ignore next */ errors.scale_min ? "scale-min-error" : undefined}
+                  aria-describedby={/* v8 ignore next */ errors.scale_min ? `${scaleId}-min-error` : undefined}
                 />
                 <span className="text-xs text-muted-foreground mt-1 block" aria-hidden="true">
                   {t("create.scaleMin")}
                 </span>
                 {errors.scale_min && (
-                  <p id="scale-min-error" className="text-xs text-destructive mt-1">
+                  <p id={`${scaleId}-min-error`} className="text-xs text-destructive mt-1">
                     {errors.scale_min.message}
                   </p>
                 )}
               </div>
               <div>
-                <Label htmlFor="scale-max" className="sr-only">{t("create.scaleMax")}</Label>
+                <Label htmlFor={`${scaleId}-max`} className="sr-only">{t("create.scaleMax")}</Label>
                 <Input
-                  id="scale-max"
+                  id={`${scaleId}-max`}
                   type="number"
                   placeholder={t("create.scaleMaxPlaceholder")}
                   {...register("scale_max")}
                   className={cn(errors.scale_max && "border-destructive")}
                   aria-invalid={!!errors.scale_max}
-                  aria-describedby={errors.scale_max ? "scale-max-error" : undefined}
+                  aria-describedby={errors.scale_max ? `${scaleId}-max-error` : undefined}
                 />
                 <span className="text-xs text-muted-foreground mt-1 block" aria-hidden="true">
                   {t("create.scaleMax")}
                 </span>
                 {errors.scale_max && (
-                  <p id="scale-max-error" className="text-xs text-destructive mt-1">
+                  <p id={`${scaleId}-max-error`} className="text-xs text-destructive mt-1">
                     {errors.scale_max.message}
                   </p>
                 )}
               </div>
               <div>
-                <Label htmlFor="scale-unit" className="sr-only">{t("create.scaleUnit")}</Label>
+                <Label htmlFor={`${scaleId}-unit`} className="sr-only">{t("create.scaleUnit")}</Label>
                 <Input
-                  id="scale-unit"
+                  id={`${scaleId}-unit`}
                   placeholder={t("create.scaleUnitPlaceholder")}
                   {...register("scale_unit")}
                   className={cn(errors.scale_unit && "border-destructive")}
                   aria-invalid={!!errors.scale_unit}
-                  aria-describedby={errors.scale_unit ? "scale-unit-error" : undefined}
+                  aria-describedby={errors.scale_unit ? `${scaleId}-unit-error` : undefined}
                 />
                 <span className="text-xs text-muted-foreground mt-1 block" aria-hidden="true">
                   {t("create.scaleUnit")}
                 </span>
                 {errors.scale_unit && (
-                  <p id="scale-unit-error" className="text-xs text-destructive mt-1">
+                  <p id={`${scaleId}-unit-error`} className="text-xs text-destructive mt-1">
                     {errors.scale_unit.message}
                   </p>
                 )}

--- a/frontend/src/components/modals/DeleteConfirmModal.tsx
+++ b/frontend/src/components/modals/DeleteConfirmModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AlertTriangle } from "lucide-react";
 import {
@@ -34,13 +34,17 @@ export function DeleteConfirmModal({
 }: DeleteConfirmModalProps) {
   const { t } = useTranslation("common");
   const [isLoading, setIsLoading] = useState(false);
+  const submittingRef = useRef(false);
 
   const handleConfirm = async () => {
+    if (submittingRef.current) return; // ignore re-entrant submits (double-click)
+    submittingRef.current = true;
     setIsLoading(true);
     try {
       await onConfirm();
     } finally {
       setIsLoading(false);
+      submittingRef.current = false;
     }
   };
 

--- a/frontend/src/components/modals/InviteExpertModal.tsx
+++ b/frontend/src/components/modals/InviteExpertModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -38,6 +38,7 @@ export function InviteExpertModal({
   const { toast } = useToast();
   const [isLoading, setIsLoading] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
+  const submittingRef = useRef(false);
 
   const inviteSchema = useMemo(
     () =>
@@ -67,6 +68,8 @@ export function InviteExpertModal({
 
   const onSubmit = async (data: InviteFormData) => {
     if (!projectId) return;
+    if (submittingRef.current) return; // ignore re-entrant submits (double-click)
+    submittingRef.current = true;
 
     setIsLoading(true);
     try {
@@ -81,6 +84,7 @@ export function InviteExpertModal({
       });
     } finally {
       setIsLoading(false);
+      submittingRef.current = false;
     }
   };
 
@@ -129,6 +133,7 @@ export function InviteExpertModal({
           </DialogDescription>
         </DialogHeader>
 
+        {/* eslint-disable-next-line react-hooks/refs -- handleSubmit defers to the browser's submit event; submittingRef is only read/written once that event fires, never during render */}
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <FormField
             label={`${t("invite.email")} *`}

--- a/frontend/src/components/project/OpinionForm.tsx
+++ b/frontend/src/components/project/OpinionForm.tsx
@@ -49,6 +49,21 @@ const NumericField = ({ form, name, label, placeholder, fieldId }: NumericFieldP
             aria-invalid={!!error}
             aria-describedby={error ? errorId : undefined}
             {...field}
+            onChange={(event) => {
+              field.onChange(event);
+              // The "lower <= peak <= upper" rule attaches its error to `peak`, so editing
+              // any sibling must re-check the group -- otherwise a corrected value leaves a
+              // stale cross-field error behind. Re-validate only the SIBLINGS already allowed
+              // to show errors (touched, or every field once submitted), never the field being
+              // typed into: form.trigger([name]) validates eagerly and would bypass
+              // mode:"onTouched", flashing an error mid-keystroke. RHF still revalidates the
+              // edited field itself through its own onTouched/reValidate path.
+              const { touchedFields, isSubmitted } = form.formState;
+              const group = (["lower", "peak", "upper"] as const).filter(
+                (candidate) => candidate !== name && (isSubmitted || touchedFields[candidate]),
+              );
+              void form.trigger(group);
+            }}
           />
         )}
       />

--- a/frontend/src/components/project/OpinionForm.tsx
+++ b/frontend/src/components/project/OpinionForm.tsx
@@ -62,7 +62,7 @@ const NumericField = ({ form, name, label, placeholder, fieldId }: NumericFieldP
               const group = (["lower", "peak", "upper"] as const).filter(
                 (candidate) => candidate !== name && (isSubmitted || touchedFields[candidate]),
               );
-              void form.trigger(group);
+              if (group.length) void form.trigger(group);
             }}
           />
         )}

--- a/frontend/src/hooks/use-auth-submit.ts
+++ b/frontend/src/hooks/use-auth-submit.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
@@ -17,8 +17,11 @@ export function useAuthSubmit(messages: AuthSubmitMessages) {
   const { toast } = useToast();
   const { t: tCommon } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
+  const submittingRef = useRef(false);
 
   const execute = async (action: () => Promise<void>) => {
+    if (submittingRef.current) return; // ignore re-entrant submits (double-click)
+    submittingRef.current = true;
     setIsLoading(true);
     try {
       await action();
@@ -35,6 +38,7 @@ export function useAuthSubmit(messages: AuthSubmitMessages) {
       });
     } finally {
       setIsLoading(false);
+      submittingRef.current = false;
     }
   };
 

--- a/frontend/src/i18n/locales/cs/common.json
+++ b/frontend/src/i18n/locales/cs/common.json
@@ -160,6 +160,7 @@
     "sessionExpired": "Vaše relace vypršela. Přihlaste se prosím znovu.",
     "sessionExpiredTitle": "Relace vypršela",
     "tooManyAttempts": "Příliš mnoho pokusů. Chvíli počkejte a zkuste to znovu.",
+    "tooManyAttemptsRetry": "Příliš mnoho pokusů. Zkuste to znovu za {{seconds}} s.",
     "retry": "Zkusit znovu"
   }
 }

--- a/frontend/src/i18n/locales/cs/projects.json
+++ b/frontend/src/i18n/locales/cs/projects.json
@@ -173,7 +173,7 @@
     "scaleUnit": "Jednotka",
     "scaleMinPlaceholder": "Min",
     "scaleMaxPlaceholder": "Max",
-    "scaleUnitPlaceholder": "např. miliard Kč, %, bodů",
+    "scaleUnitPlaceholder": "např. Kč, %",
     "cancel": "Zrušit",
     "create": "Vytvořit projekt",
     "creating": "Vytváření...",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -160,6 +160,7 @@
     "sessionExpired": "Your session has expired. Please sign in again.",
     "sessionExpiredTitle": "Session expired",
     "tooManyAttempts": "Too many attempts. Please wait a moment and try again.",
+    "tooManyAttemptsRetry": "Too many attempts. Please try again in {{seconds}}s.",
     "retry": "Try again"
   }
 }

--- a/frontend/src/i18n/locales/en/projects.json
+++ b/frontend/src/i18n/locales/en/projects.json
@@ -173,7 +173,7 @@
     "scaleUnit": "Unit",
     "scaleMinPlaceholder": "Min",
     "scaleMaxPlaceholder": "Max",
-    "scaleUnitPlaceholder": "e.g., billion CZK, %, points",
+    "scaleUnitPlaceholder": "e.g., CZK, %",
     "cancel": "Cancel",
     "create": "Create Project",
     "creating": "Creating...",

--- a/frontend/src/lib/errorMessages.ts
+++ b/frontend/src/lib/errorMessages.ts
@@ -6,20 +6,24 @@ import { HttpError, isServiceUnavailable, isRateLimited } from '@/lib/errors';
  * Network hiccups and 5xx responses get a generic "service unavailable"
  * message rather than whatever text happened to be in the response body,
  * since that body was not written with an end user in mind. Rate limiting
- * gets its own dedicated message. Any other HttpError (401, 409, other 4xx)
- * and plain Error instances use their own message, since those already
- * carry a message meant to be read. Anything else falls back to the
- * caller-supplied default.
+ * gets its own dedicated message, including the server-provided retry delay
+ * when one is known. Any other HttpError (401, 409, other 4xx) and plain
+ * Error instances use their own message, since those already carry a
+ * message meant to be read. Anything else falls back to the caller-supplied
+ * default.
  */
 export function describeError(
   error: unknown,
-  t: (key: string) => string,
+  t: (key: string, options?: Record<string, unknown>) => string,
   fallback: string
 ): string {
   if (isServiceUnavailable(error)) {
     return t('errors.serviceUnavailable');
   }
   if (isRateLimited(error)) {
+    if (typeof error.retryAfter === 'number' && error.retryAfter > 0) {
+      return t('errors.tooManyAttemptsRetry', { seconds: error.retryAfter });
+    }
     return t('errors.tooManyAttempts');
   }
   if (error instanceof HttpError) {

--- a/frontend/src/pages/ForgotPassword.tsx
+++ b/frontend/src/pages/ForgotPassword.tsx
@@ -76,6 +76,7 @@ const ForgotPassword = () => {
         <FormField
           label={t("forgotPassword.email")}
           type="email"
+          autoComplete="email"
           placeholder={t("forgotPassword.emailPlaceholder")}
           error={errors.email}
           {...register("email")}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -56,6 +56,7 @@ const Login = () => {
         <FormField
           label={t("login.email")}
           type="email"
+          autoComplete="email"
           placeholder={t("login.emailPlaceholder")}
           error={errors.email}
           {...register("email")}
@@ -63,6 +64,7 @@ const Login = () => {
 
         <PasswordInput
           label={t("login.password")}
+          autoComplete="current-password"
           placeholder={t("login.passwordPlaceholder")}
           error={errors.password}
           {...register("password")}

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -114,6 +114,7 @@ const Register = () => {
           <FormField
             label={`${t("register.email")} *`}
             type="email"
+            autoComplete="email"
             placeholder={t("register.emailPlaceholder")}
             error={errors.email}
             {...register("email")}
@@ -128,6 +129,7 @@ const Register = () => {
         <div>
           <PasswordInput
             label={`${t("register.password")} *`}
+            autoComplete="new-password"
             placeholder={t("register.passwordPlaceholder")}
             error={errors.password}
             {...register("password")}
@@ -142,6 +144,7 @@ const Register = () => {
         <FormField
           label={`${t("register.confirmPassword")} *`}
           type="password"
+          autoComplete="new-password"
           placeholder={t("register.confirmPasswordPlaceholder")}
           error={errors.confirmPassword}
           {...register("confirmPassword")}
@@ -149,6 +152,7 @@ const Register = () => {
 
         <FormField
           label={`${t("register.firstName")} *`}
+          autoComplete="given-name"
           placeholder={t("register.firstNamePlaceholder")}
           error={errors.firstName}
           {...register("firstName")}
@@ -156,6 +160,7 @@ const Register = () => {
 
         <FormField
           label={`${t("register.lastName")} *`}
+          autoComplete="family-name"
           placeholder={t("register.lastNamePlaceholder")}
           error={errors.lastName}
           {...register("lastName")}

--- a/frontend/src/pages/ResetPassword.tsx
+++ b/frontend/src/pages/ResetPassword.tsx
@@ -105,6 +105,7 @@ const ResetPassword = () => {
         <div>
           <PasswordInput
             label={t("resetPassword.password")}
+            autoComplete="new-password"
             placeholder={t("resetPassword.passwordPlaceholder")}
             error={errors.password}
             {...register("password")}
@@ -119,6 +120,7 @@ const ResetPassword = () => {
         <FormField
           label={t("resetPassword.confirmPassword")}
           type="password"
+          autoComplete="new-password"
           placeholder={t("resetPassword.confirmPasswordPlaceholder")}
           error={errors.confirmPassword}
           {...register("confirmPassword")}

--- a/frontend/tests/components/modals/CreateProjectModal.test.tsx
+++ b/frontend/tests/components/modals/CreateProjectModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '@tests/utils';
 import { CreateProjectModal } from '@/components/modals/CreateProjectModal';
@@ -30,7 +30,7 @@ describe('CreateProjectModal', () => {
   });
 
   const getNameInput = () => screen.getByPlaceholderText('Enter project name');
-  const getUnitInput = () => screen.getByPlaceholderText(/%, points/i);
+  const getUnitInput = () => screen.getByPlaceholderText(/e\.g\., CZK/i);
   const getSubmitButton = () => screen.getByRole('button', { name: 'Create Project' });
 
   it('renders form fields when open', () => {
@@ -132,6 +132,27 @@ describe('CreateProjectModal', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/creating/i)).toBeInTheDocument();
+    });
+  });
+
+  it('ignores a re-entrant submit from a double-click (calls the API only once)', async () => {
+    const user = userEvent.setup();
+    mockCreateProject.mockImplementation(() => new Promise(() => {}));
+
+    render(<CreateProjectModal {...defaultProps} />);
+
+    await user.type(getNameInput(), 'New Project');
+    await user.type(getUnitInput(), '%');
+
+    const button = getSubmitButton();
+    // Two synchronous submits, mirroring a rapid double-click: the isLoading
+    // state update from the first submit has not re-rendered (and disabled
+    // the button) by the time the second submit event fires.
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(mockCreateProject).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/frontend/tests/components/modals/DeleteConfirmModal.test.tsx
+++ b/frontend/tests/components/modals/DeleteConfirmModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@tests/utils'
+import { fireEvent, render, screen, waitFor } from '@tests/utils'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi } from 'vitest'
 import { DeleteConfirmModal } from '@/components/modals/DeleteConfirmModal'
@@ -54,6 +54,23 @@ describe('DeleteConfirmModal', () => {
 
     await waitFor(() => {
       expect(onConfirm).toHaveBeenCalled()
+    })
+  })
+
+  it('ignores a re-entrant confirm from a double-click (calls onConfirm only once)', async () => {
+    const onConfirm = vi.fn().mockImplementation(() => new Promise(() => {}))
+
+    render(<DeleteConfirmModal {...defaultProps} onConfirm={onConfirm} />)
+
+    const button = screen.getByRole('button', { name: /delete/i })
+    // Two synchronous clicks, mirroring a rapid double-click: the isLoading
+    // state update from the first click has not re-rendered (and disabled
+    // the button) by the time the second click event fires.
+    fireEvent.click(button)
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/frontend/tests/components/modals/InviteExpertModal.test.tsx
+++ b/frontend/tests/components/modals/InviteExpertModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '@tests/utils';
 import { InviteExpertModal } from '@/components/modals/InviteExpertModal';
@@ -68,6 +68,26 @@ describe('InviteExpertModal', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/sending/i)).toBeInTheDocument();
+    });
+  });
+
+  it('ignores a re-entrant submit from a double-click (calls the API only once)', async () => {
+    const user = userEvent.setup();
+    mockInviteExpert.mockImplementation(() => new Promise(() => {}));
+
+    render(<InviteExpertModal {...defaultProps} />);
+
+    await user.type(getEmailInput(), 'expert@test.com');
+
+    const button = getSubmitButton();
+    // Two synchronous submits, mirroring a rapid double-click: the isLoading
+    // state update from the first submit has not re-rendered (and disabled
+    // the button) by the time the second submit event fires.
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(mockInviteExpert).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/frontend/tests/components/project/OpinionForm.test.tsx
+++ b/frontend/tests/components/project/OpinionForm.test.tsx
@@ -142,6 +142,35 @@ describe('OpinionForm - Submission', () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
+  it('clears the stale lower<=peak<=upper error once a sibling field is corrected', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<Harness onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText('Position'), 'Director');
+    await user.type(screen.getByLabelText(/lower/i), '20');
+    await user.type(screen.getByLabelText(/peak/i), '50');
+    await user.type(screen.getByLabelText(/upper/i), '40');
+    await user.click(screen.getByRole('button', { name: 'Save Opinion' }));
+
+    // The ordering error attaches to `peak` (path: ["peak"]), even though
+    // `upper` is the field that needs correcting.
+    await waitFor(() => {
+      expect(screen.getByText('Values must satisfy: lower ≤ peak ≤ upper')).toBeInTheDocument();
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    const upperInput = screen.getByLabelText(/upper/i);
+    await user.clear(upperInput);
+    await user.type(upperInput, '80');
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Values must satisfy: lower ≤ peak ≤ upper')
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it('marks the invalid field with aria-invalid', async () => {
     const user = userEvent.setup();
     render(<Harness onSubmit={vi.fn().mockResolvedValue(undefined)} />);
@@ -154,6 +183,27 @@ describe('OpinionForm - Submission', () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText(/peak/i)).toHaveAttribute('aria-invalid', 'true');
+    });
+  });
+
+  it('does not flash a validation error on the field being typed into before blur', async () => {
+    const user = userEvent.setup();
+    render(<Harness onSubmit={vi.fn().mockResolvedValue(undefined)} />);
+
+    const lowerInput = screen.getByLabelText(/lower/i);
+    // Type an out-of-range value into a pristine field WITHOUT blurring it.
+    // mode:"onTouched" keeps the error hidden until blur, so the group
+    // revalidation must not eagerly validate the field being edited.
+    await user.type(lowerInput, '-5');
+    expect(lowerInput).toHaveAttribute('aria-invalid', 'false');
+    expect(
+      screen.queryByText('Values must be within scale range: 0 — 100')
+    ).not.toBeInTheDocument();
+
+    // Blur -> onTouched now surfaces the error, so validation still works.
+    await user.tab();
+    await waitFor(() => {
+      expect(lowerInput).toHaveAttribute('aria-invalid', 'true');
     });
   });
 });

--- a/frontend/tests/components/project/OpinionForm.test.tsx
+++ b/frontend/tests/components/project/OpinionForm.test.tsx
@@ -206,6 +206,19 @@ describe('OpinionForm - Submission', () => {
       expect(lowerInput).toHaveAttribute('aria-invalid', 'true');
     });
   });
+
+  it('surfaces the required error on the position field once it is blurred empty', async () => {
+    const user = userEvent.setup();
+    render(<Harness onSubmit={vi.fn().mockResolvedValue(undefined)} />);
+
+    const positionInput = screen.getByLabelText('Position');
+    await user.click(positionInput);
+    await user.tab();
+
+    await waitFor(() => {
+      expect(positionInput).toHaveAttribute('aria-invalid', 'true');
+    });
+  });
 });
 
 describe('OpinionForm - Delete Opinion Link', () => {

--- a/frontend/tests/hooks/use-auth-submit.test.ts
+++ b/frontend/tests/hooks/use-auth-submit.test.ts
@@ -160,4 +160,29 @@ describe('useAuthSubmit', () => {
 
     expect(result.current.isLoading).toBe(false);
   });
+
+  it('drops a re-entrant execute while one is already in flight (double-submit guard)', async () => {
+    let resolveAction!: () => void;
+    const action = vi.fn(() => new Promise<void>((resolve) => { resolveAction = resolve; }));
+
+    const { result } = renderHook(() => useAuthSubmit(messages));
+
+    // Fire two execute() calls before the first settles; the guard must drop
+    // the second so the wrapped action runs exactly once.
+    let first!: Promise<void>;
+    let second!: Promise<void>;
+    act(() => {
+      first = result.current.execute(action);
+      second = result.current.execute(action);
+    });
+
+    expect(action).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      resolveAction();
+      await Promise.all([first, second]);
+    });
+
+    expect(action).toHaveBeenCalledOnce();
+  });
 });

--- a/frontend/tests/lib/errorMessages.test.ts
+++ b/frontend/tests/lib/errorMessages.test.ts
@@ -12,6 +12,18 @@ import {
 // independent of the actual English/Czech copy in the i18n JSON files.
 const t = (key: string) => key;
 
+// Mimics i18next's {{placeholder}} interpolation, so assertions can verify
+// both which key was picked AND that the options were threaded through.
+const tInterpolate = (key: string, options?: Record<string, unknown>) => {
+  const templates: Record<string, string> = {
+    'errors.tooManyAttempts': 'Too many attempts.',
+    'errors.tooManyAttemptsRetry': 'Too many attempts. Retry in {{seconds}}s.',
+  };
+  const template = templates[key] ?? key;
+  if (!options) return template;
+  return template.replace(/{{(\w+)}}/g, (_match, name: string) => String(options[name] ?? ''));
+};
+
 describe('describeError', () => {
   it('maps a NetworkError to the serviceUnavailable key', () => {
     expect(describeError(new NetworkError(), t, 'fallback')).toBe('errors.serviceUnavailable');
@@ -23,6 +35,24 @@ describe('describeError', () => {
 
   it('maps a RateLimitError to the tooManyAttempts key', () => {
     expect(describeError(new RateLimitError(), t, 'fallback')).toBe('errors.tooManyAttempts');
+  });
+
+  it('includes the retry delay when the RateLimitError carries a retryAfter', () => {
+    const result = describeError(new RateLimitError('Too many requests', 30), tInterpolate, 'fallback');
+    expect(result).toBe('Too many attempts. Retry in 30s.');
+    expect(result).toContain('30');
+  });
+
+  it('falls back to the plain tooManyAttempts key when retryAfter is absent', () => {
+    expect(describeError(new RateLimitError(), tInterpolate, 'fallback')).toBe(
+      'Too many attempts.'
+    );
+  });
+
+  it('falls back to the plain tooManyAttempts key when retryAfter is not positive', () => {
+    expect(describeError(new RateLimitError('Too many requests', 0), tInterpolate, 'fallback')).toBe(
+      'Too many attempts.'
+    );
   });
 
   it('uses the error message for other HttpError instances (401, 409, etc.)', () => {

--- a/frontend/tests/pages/ForgotPassword.test.tsx
+++ b/frontend/tests/pages/ForgotPassword.test.tsx
@@ -40,6 +40,12 @@ describe('ForgotPassword', () => {
     expect(getSubmitButton()).toBeInTheDocument();
   });
 
+  it('sets autocomplete="email" so password managers fill the right field', () => {
+    render(<ForgotPassword />);
+
+    expect(getEmailInput()).toHaveAttribute('autocomplete', 'email');
+  });
+
   it('shows a validation error for an invalid email', async () => {
     const user = userEvent.setup();
     render(<ForgotPassword />);

--- a/frontend/tests/pages/Login.test.tsx
+++ b/frontend/tests/pages/Login.test.tsx
@@ -48,6 +48,13 @@ describe('Login', () => {
     expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
   });
 
+  it('sets autocomplete attributes so password managers fill the right field', () => {
+    render(<Login />);
+
+    expect(getEmailInput()).toHaveAttribute('autocomplete', 'email');
+    expect(getPasswordInput()).toHaveAttribute('autocomplete', 'current-password');
+  });
+
   it('shows validation error for invalid email', async () => {
     const user = userEvent.setup();
     render(<Login />);

--- a/frontend/tests/pages/Register.test.tsx
+++ b/frontend/tests/pages/Register.test.tsx
@@ -54,6 +54,16 @@ describe('Register', () => {
     expect(getSubmitButton()).toBeInTheDocument();
   });
 
+  it('sets autocomplete attributes so password managers fill the right field', () => {
+    render(<Register />);
+
+    expect(getEmailInput()).toHaveAttribute('autocomplete', 'email');
+    expect(getPasswordInput()).toHaveAttribute('autocomplete', 'new-password');
+    expect(getConfirmPasswordInput()).toHaveAttribute('autocomplete', 'new-password');
+    expect(getFirstNameInput()).toHaveAttribute('autocomplete', 'given-name');
+    expect(getLastNameInput()).toHaveAttribute('autocomplete', 'family-name');
+  });
+
   it('shows email requirements checklist when email entered', async () => {
     const user = userEvent.setup();
     render(<Register />);

--- a/frontend/tests/pages/ResetPassword.test.tsx
+++ b/frontend/tests/pages/ResetPassword.test.tsx
@@ -70,6 +70,13 @@ describe('ResetPassword', () => {
     expect(link).toHaveAttribute('href', '/forgot-password');
   });
 
+  it('sets autocomplete="new-password" on both password fields', () => {
+    render(<ResetPassword />);
+
+    expect(getPasswordInput()).toHaveAttribute('autocomplete', 'new-password');
+    expect(getConfirmInput()).toHaveAttribute('autocomplete', 'new-password');
+  });
+
   it('shows the password requirements checklist when typing', async () => {
     const user = userEvent.setup();
     render(<ResetPassword />);


### PR DESCRIPTION
## Summary

Form-UX hardening from the UI/UX audit, across the project modals, the opinion editor, and the auth forms. No visual/layout change (visual-regression baselines untouched).

- **AUD-035 (double-submit):** a fast double-click on "Create Project" created two projects -- the `isLoading` state disable lags the async react-hook-form validation gap, so a second click lands before the button re-renders disabled. Added a synchronous `submittingRef` guard (`if (submittingRef.current) return`) that drops a re-entrant submit before the mutation fires, regardless of render timing. Applied to all three modals (`CreateProjectModal`, `InviteExpertModal`, `DeleteConfirmModal`) **and** to the auth forms (Login / Register / Forgot / Reset) through their shared submit hook, so a double-click on Login can't fire two attempts (429) and a double Register can't 409.
- **AUD-025 (stale validation):** the `lower <= peak <= upper` rule attaches its error to `peak`, so after a submit left it there, correcting a sibling field left the error stranded. `NumericField` now re-validates the group on change -- but only the *siblings* already allowed to show errors (touched, or every field once submitted), never the field being typed into. Re-validating the edited field would bypass `mode:"onTouched"` and flash an error mid-keystroke; leaving it to react-hook-form's own onTouched path keeps that UX while still clearing the stale cross-field error.
- **AUD-027 (scale-field a11y):** the three scale inputs painted a red border on error but carried no `aria-invalid` and (for min/unit) no visible message -- a red border a screen reader could not explain. All three now expose `aria-invalid` + `aria-describedby` and render their own error text uniformly; the unit placeholder was shortened so it no longer truncates in the narrow grid cell.
- **AUD-009 (autocomplete):** the auth inputs (Login, Register, Forgot/Reset password) gained the correct `autoComplete` values (`email` / `new-password` / `current-password` / `given-name` / `family-name`) -- WCAG 1.3.5, and password managers stop mis-filling.
- **AUD-024 (rate-limit feedback):** on a 429 the toast already surfaced a "too many attempts" message (via the PR1 error taxonomy); it now includes the server-provided retry delay when known -- `describeError` returns `errors.tooManyAttemptsRetry` with `{ seconds }` from `RateLimitError.retryAfter`, falling back to the plain message otherwise.

### Note on the eslint-disable

`CreateProjectModal` and `InviteExpertModal` carry a scoped `// eslint-disable-next-line react-hooks/refs` on their `<form onSubmit={handleSubmit(onSubmit)}>` line. `eslint-plugin-react-hooks@7.1.1`'s React-Compiler `refs` rule flags the new `submittingRef` read inside `onSubmit` as a render-time ref access -- a false positive, since `handleSubmit(...)` returns a handler that only runs on the browser submit event, never during render (`DeleteConfirmModal`, which uses `onClick`, does not trip it). The disable is line-scoped and justified, following the existing precedent in `eslint.config.js`.

## Review

An independent adversarial review pass verified, against react-hook-form's actual source, that the `submittingRef` check/set is atomic (no interleave, never latches stuck) and that the eslint-disable is a genuine false positive. It also caught two things folded into this branch: the eager-revalidation flash above (now siblings-only), and extending the double-submit guard to the auth forms rather than just the modals.

## Tests

New/extended vitest: double-submit dedup on all three modals and on the auth submit hook; the stale cross-field error clears after a sibling is corrected; a pristine field does **not** flash an error before blur (guards the siblings-only fix) yet still validates on blur; the required `autoComplete` attributes are present; and `describeError` renders the retry delay when `retryAfter` is set and falls back when absent or non-positive. i18n key-parity holds (`errors.tooManyAttemptsRetry` in both `en` and `cs`).

Full `ci-local.sh fast` green; frontend 949 tests, lint + typecheck clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens form UX across modals and auth pages: a synchronous `useRef` guard prevents double-submit races before the async react-hook-form validation cycle can disable the button, sibling-field revalidation clears stale cross-field errors without triggering premature error flashes on fields still being typed, and the three scale inputs in `CreateProjectModal` gain full `aria-invalid`/`aria-describedby`/error-text coverage. `autoComplete` tokens are added to all auth inputs, and `describeError` now surfaces the server-provided Retry-After delay on 429 responses. Both EN and CS i18n files are updated in parallel.

- **Double-submit guard (`submittingRef`)** applied to all three modals and to `useAuthSubmit`; the ref is set synchronously before the first `await`, so a second click that arrives during async validation is dropped regardless of render timing.
- **Sibling revalidation in `NumericField`** re-triggers only touched or post-submit siblings of the edited field; calling `form.trigger([])` (empty array) is a confirmed no-op in RHF v7, keeping the pristine-field UX intact.
- **Rate-limit toast** now includes `retryAfter` seconds when the server provides a `Retry-After` header, falling back to the plain \"too many attempts\" message when absent or non-positive."

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changed paths are additive guards or a11y attributes with no behavioural regressions.

The double-submit guard, sibling revalidation, aria improvements, and rate-limit feedback are all well-reasoned and backed by targeted tests. The one pattern worth cleaning up is the hardcoded static IDs for the new error elements in CreateProjectModal — the rest of the codebase uses useId() for the same purpose, so this is a consistency gap rather than a correctness issue.

frontend/src/components/modals/CreateProjectModal.tsx — the new scale-*-error IDs are hardcoded strings rather than useId()-generated values, unlike the pattern in OpinionForm.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/modals/CreateProjectModal.tsx | Adds submittingRef double-submit guard, per-field aria-invalid/aria-describedby, and per-field error messages for the three scale inputs. Hardcoded error IDs (scale-min-error etc.) are inconsistent with the useId() pattern used elsewhere. |
| frontend/src/components/modals/DeleteConfirmModal.tsx | Minimal, correct addition of submittingRef guard to the handleConfirm onClick handler; reset is always in finally. |
| frontend/src/components/modals/InviteExpertModal.tsx | Adds submittingRef guard after the existing !projectId early-return; guard ordering and finally-reset are correct. |
| frontend/src/components/project/OpinionForm.tsx | NumericField now revalidates sibling fields on change to clear stale cross-field errors; filters correctly to exclude the field being typed and untouched pristine siblings. trigger([]) is confirmed a no-op in RHF v7, but an explicit group.length guard would improve clarity. |
| frontend/src/hooks/use-auth-submit.ts | submittingRef guard added correctly before the first await; reset is always in finally. No regressions to existing auth-error handling or navigation. |
| frontend/src/lib/errorMessages.ts | describeError now threads retryAfter through the tooManyAttemptsRetry i18n key when positive; falls back to the plain key otherwise. t() signature widened to accept options correctly. |
| frontend/src/i18n/locales/en/common.json | Adds tooManyAttemptsRetry key with {{seconds}} interpolation; parallel CS key is also present. |
| frontend/src/pages/Login.tsx | Adds autoComplete="email" and autoComplete="current-password" to the two login inputs; correct per WCAG 1.3.5. |
| frontend/src/pages/Register.tsx | Adds autoComplete for all five fields (email, new-password x2, given-name, family-name); values are correct. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant Form as Form / Button
    participant RHF as react-hook-form
    participant Ref as submittingRef
    participant API

    User->>Form: "click #1"
    Form->>RHF: handleSubmit → onSubmit()
    RHF->>Ref: current? false → set true
    RHF->>API: await mutation (async gap)
    User->>Form: "click #2 (before re-render)"
    Form->>RHF: handleSubmit → onSubmit()
    RHF->>Ref: current? true → return (dropped)
    API-->>RHF: resolve / reject
    RHF->>Ref: finally: set false
    RHF->>Form: setIsLoading(false)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant Form as Form / Button
    participant RHF as react-hook-form
    participant Ref as submittingRef
    participant API

    User->>Form: "click #1"
    Form->>RHF: handleSubmit → onSubmit()
    RHF->>Ref: current? false → set true
    RHF->>API: await mutation (async gap)
    User->>Form: "click #2 (before re-render)"
    Form->>RHF: handleSubmit → onSubmit()
    RHF->>Ref: current? true → return (dropped)
    API-->>RHF: resolve / reject
    RHF->>Ref: finally: set false
    RHF->>Form: setIsLoading(false)
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
frontend/src/components/project/OpinionForm.tsx:62-65
**Add an empty-array guard before `form.trigger`**

`group` can be `[]` when no siblings are touched yet and the form hasn't been submitted. RHF v7 treats `trigger([])` as a no-op today (an empty array is distinct from `undefined`/no-argument, which does trigger all fields), so the current behaviour is correct — but the intent is invisible to future readers, and a silent RHF behavioural change across versions would re-introduce the eager-flash bug without any obvious callsite. Wrapping the call in `if (group.length > 0)` makes the guard self-documenting.

### Issue 2 of 2
frontend/src/components/modals/CreateProjectModal.tsx:36-44
**Hardcoded aria-describedby IDs are inconsistent with the rest of the codebase**

The new `id="scale-min-error"`, `id="scale-max-error"`, and `id="scale-unit-error"` values are static strings. `OpinionForm` (the closest parallel) uses `useId()` for every error-anchor pair, which guarantees uniqueness even if the component renders more than once. Since `CreateProjectModal` is a singleton dialog this won't cause a real duplicate-ID collision today, but it diverges from the established pattern in the codebase and would break the `aria-describedby` link silently if the modal were ever composited (e.g., a stacked-dialog flow).

```suggestion
export function CreateProjectModal({
  open,
  onOpenChange,
  onSuccess,
}: CreateProjectModalProps) {
  const { t } = useTranslation("projects");
  const { toast } = useToast();
  const [isLoading, setIsLoading] = useState(false);
  const submittingRef = useRef(false);
  const scaleMinErrorId = useId();
  const scaleMaxErrorId = useId();
  const scaleUnitErrorId = useId();
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: cover the opinion position-error p..."](https://github.com/caitlon/become/commit/91a4fa3f96ad4ccb4a08304940c873939def2802) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45439854)</sub>

<!-- /greptile_comment -->