### PR TITLE
fix: drop the uv cache mounts so Railway's Metal builder can build the image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,10 +30,10 @@ ENV UV_LINK_MODE=copy
 COPY pyproject.toml uv.lock ./
 
 # Install dependencies first (without project) for better layer caching.
-# The BuildKit cache mount keeps uv's wheel cache across builds (Railway persists
-# it), so wheels aren't re-downloaded when only the lockfile layer is invalidated.
-RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project --no-dev --extra api
+# No BuildKit --mount=type=cache here: Railway's Metal builder rejects custom
+# cache mounts (it does its own layer caching), so this relies on Docker's own
+# layer cache -- the deps layer is only rebuilt when pyproject.toml / uv.lock change.
+RUN uv sync --locked --no-install-project --no-dev --extra api
 
 # Copy application code
 COPY src/ ./src/
@@ -41,8 +41,7 @@ COPY api/ ./api/
 COPY README.md ./
 
 # Install project with dependencies
-RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev --extra api
+RUN uv sync --locked --no-dev --extra api
 
 # ============================================
 # Stage 2: Runtime

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -19,9 +19,8 @@ COPY --from=ghcr.io/astral-sh/uv@sha256:9a23023be68b2ed09750ae636228e903a54a05ea
 # Copy dependency files
 COPY pyproject.toml uv.lock ./
 
-# Install all dependencies including dev extras (with cache)
-RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
-    uv sync --locked --extra api --extra dev
+# Install all dependencies including dev extras
+RUN uv sync --locked --extra api --extra dev
 
 # Copy application code (will be overridden by volume mount)
 COPY src/ ./src/


### PR DESCRIPTION
## Summary

Follow-up to #299. Adding an explicit `id` cleared the first Railway Metal-builder error, but the build then failed with a second, stricter one:

```
dockerfile invalid: flag '--mount=type=cache,id=uv-cache,target=/root/.cache/uv' is missing the cacheKey prefix from its id at Line 35/44
```

Railway's Metal builder namespaces every BuildKit cache mount under an internal, build-scoped `cacheKey` and rejects any id that lacks it. Rather than couple the Dockerfile to an undocumented Railway-internal prefix (fragile), this **drops the custom `--mount=type=cache` mounts entirely** -- the Metal builder does its own layer caching, which is the Railway-recommended approach. The three `uv sync` steps (`docker/Dockerfile` x2, `docker/Dockerfile.dev` x1) now run as plain `RUN uv sync ...`.

The dependency-install layer is still cached by Docker's own layer cache (rebuilt only when `pyproject.toml` / `uv.lock` change). The only thing lost is uv's cross-build wheel cache -- a first-time re-download of wheels when that layer is invalidated. A minor build-time cost, no correctness or runtime change.

## Verification

- `docker/Dockerfile:36,44` and `docker/Dockerfile.dev:23` are now plain `RUN uv sync ...` with no cache mount; no `--mount=type=cache` directive remains (only a comment noting why).
- A plain `RUN` has no mount flag for the builder to reject, so this whole class of "dockerfile invalid" error is gone; the rest of the build is unchanged from what built fine before Railway switched builders.
- Final validation is the Railway rebuild on merge: the dev-backend deploy retries and should clear the build step.
