### PR TITLE
fix: sit the onboarding opinion triangle on its axis and even up the results cards

### DIFF
--- a/frontend/src/components/onboarding/StepEnterOpinion.tsx
+++ b/frontend/src/components/onboarding/StepEnterOpinion.tsx
@@ -105,7 +105,7 @@ export function StepEnterOpinion() {
             {/* Triangle Preview */}
             <div className="bg-muted rounded-lg p-4">
               <svg
-                viewBox="0 0 300 120"
+                viewBox="0 0 300 130"
                 className="w-full"
                 aria-labelledby="triangle-preview-title"
               >
@@ -130,35 +130,6 @@ export function StepEnterOpinion() {
                   strokeOpacity="0.2"
                 />
 
-                {/* Scale labels */}
-                <text
-                  x="20"
-                  y="115"
-                  className="fill-muted-foreground"
-                  fontSize="10"
-                  textAnchor="middle"
-                >
-                  0
-                </text>
-                <text
-                  x="150"
-                  y="115"
-                  className="fill-muted-foreground"
-                  fontSize="10"
-                  textAnchor="middle"
-                >
-                  50
-                </text>
-                <text
-                  x="280"
-                  y="115"
-                  className="fill-muted-foreground"
-                  fontSize="10"
-                  textAnchor="middle"
-                >
-                  100
-                </text>
-
                 {/* Y axis label */}
                 <text
                   x="10"
@@ -171,6 +142,17 @@ export function StepEnterOpinion() {
                   {t("steps.enterOpinion.yAxisLabel")}
                 </text>
 
+                {/* X axis label */}
+                <text
+                  x="150"
+                  y="126"
+                  className="fill-muted-foreground"
+                  fontSize="8"
+                  textAnchor="middle"
+                >
+                  {t("steps.enterOpinion.xAxisLabel")}
+                </text>
+
                 {isValid && (
                   <>
                     {/* Triangle */}
@@ -178,7 +160,7 @@ export function StepEnterOpinion() {
                       initial={{ opacity: 0 }}
                       animate={{
                         opacity: 1,
-                        points: `${scaleToX(lowerNum)},88 ${scaleToX(peakNum)},25 ${scaleToX(upperNum)},88`,
+                        points: `${scaleToX(lowerNum)},100 ${scaleToX(peakNum)},25 ${scaleToX(upperNum)},100`,
                       }}
                       transition={{ duration: 0.3 }}
                       fill="currentColor"
@@ -198,12 +180,33 @@ export function StepEnterOpinion() {
                       transition={{ delay: 0.2 }}
                     />
 
+                    {/* Base markers -- where the triangle sits on the axis */}
+                    <motion.circle
+                      cx={scaleToX(lowerNum)}
+                      cy={100}
+                      r="4"
+                      fill="hsl(var(--primary))"
+                      initial={{ scale: 0 }}
+                      animate={{ scale: 1 }}
+                      transition={{ delay: 0.2 }}
+                    />
+                    <motion.circle
+                      cx={scaleToX(upperNum)}
+                      cy={100}
+                      r="4"
+                      fill="hsl(var(--primary))"
+                      initial={{ scale: 0 }}
+                      animate={{ scale: 1 }}
+                      transition={{ delay: 0.2 }}
+                    />
+
                     {/* Value labels */}
                     <text
                       x={scaleToX(lowerNum)}
-                      y="100"
-                      className="fill-muted-foreground"
+                      y="113"
+                      className="fill-foreground"
                       fontSize="9"
+                      fontWeight="bold"
                       textAnchor="middle"
                     >
                       {lowerNum}
@@ -220,9 +223,10 @@ export function StepEnterOpinion() {
                     </text>
                     <text
                       x={scaleToX(upperNum)}
-                      y="100"
-                      className="fill-muted-foreground"
+                      y="113"
+                      className="fill-foreground"
                       fontSize="9"
+                      fontWeight="bold"
                       textAnchor="middle"
                     >
                       {upperNum}

--- a/frontend/src/components/onboarding/StepViewResults.tsx
+++ b/frontend/src/components/onboarding/StepViewResults.tsx
@@ -57,8 +57,8 @@ export function StepViewResults() {
 
         <div className="grid grid-cols-2 gap-4">
           {/* Max Error */}
-          <motion.div variants={fadeInUp}>
-            <Card>
+          <motion.div variants={fadeInUp} className="h-full">
+            <Card className="h-full">
               <CardHeader className="pb-2">
                 <CardTitle className="text-sm flex items-center gap-2">
                   <AlertCircle className="h-4 w-4" />
@@ -75,8 +75,8 @@ export function StepViewResults() {
           </motion.div>
 
           {/* Experts */}
-          <motion.div variants={fadeInUp}>
-            <Card>
+          <motion.div variants={fadeInUp} className="h-full">
+            <Card className="h-full">
               <CardHeader className="pb-2">
                 <CardTitle className="text-sm flex items-center gap-2">
                   <Users className="h-4 w-4" />

--- a/frontend/src/i18n/locales/cs/onboarding.json
+++ b/frontend/src/i18n/locales/cs/onboarding.json
@@ -69,7 +69,8 @@
       "rule": "Hodnoty musí splňovat: Dolní ≤ Vrchol ≤ Horní",
       "preview": "Váš trojúhelník se zobrazí zde",
       "previewTitle": "Náhled trojúhelníku",
-      "yAxisLabel": "příslušnost"
+      "yAxisLabel": "příslušnost",
+      "xAxisLabel": "hodnota"
     },
     "viewResults": {
       "title": "Zobrazení výsledků",

--- a/frontend/src/i18n/locales/en/onboarding.json
+++ b/frontend/src/i18n/locales/en/onboarding.json
@@ -69,7 +69,8 @@
       "rule": "Values must satisfy: Lower ≤ Peak ≤ Upper",
       "preview": "Your triangle will appear here",
       "previewTitle": "Triangle preview",
-      "yAxisLabel": "membership"
+      "yAxisLabel": "membership",
+      "xAxisLabel": "value"
     },
     "viewResults": {
       "title": "View Results",


### PR DESCRIPTION
## Summary

Onboarding-tour polish from the live design review -- no change to the tour flow, only the two preview visuals.

**Step 4 -- "Enter Your Opinion" triangle preview:**
- The triangle now **sits on the x-axis**: its base was drawn floating ~12px above the axis; both base vertices now touch the axis line, each marked with a dot (matching the existing peak dot), so the shape visibly rests on its labelled points 30 / 70.
- The three vertex numbers (lower / peak / upper) are all **bold**; the x-axis gains a **"value" label** to match the existing "membership" y-axis label. The redundant fixed 0/50/100 scale is dropped so it can't collide with the moving value labels.

**Step 5 -- "View Results":**
- The **Experts card is now the same height** as the Max Error card (they share a row; the shorter one no longer looks clipped) via `h-full`.

## Tests / i18n

`test:coverage` green (branches 95.35%). New `steps.enterOpinion.xAxisLabel` key added to both `en` and `cs` onboarding locales; the existing onboarding tests pass unchanged.
