### PR TITLE
ci: add a workflow to regenerate visual-regression baselines on amd64

### DIFF
--- a/.github/workflows/regen-snapshots.yml
+++ b/.github/workflows/regen-snapshots.yml
@@ -1,13 +1,14 @@
 name: Regenerate Visual Snapshots
 
 # Manually regenerates Playwright visual-regression baselines on the amd64 CI
-# runner (the only environment whose rendering matches the E2E job) and commits
-# the updated *-linux.png files back to the target branch. Use after an
-# intentional layout change shifts the whole-page project-results snapshots.
+# runner (the only environment whose rendering matches the E2E job) and uploads
+# the updated *-linux.png files as an artifact. Use after an intentional layout
+# change shifts the whole-page project-results snapshots; then download the
+# artifact and commit the PNGs onto the feature branch.
 #
 # Run it from the Actions tab (or `gh workflow run regen-snapshots.yml
-# -f branch=<feature-branch>`). Needs the repo's Actions workflow permissions
-# set to "Read and write" so the job can push the regenerated PNGs.
+# -f branch=<feature-branch>`). Uploading an artifact needs only the default
+# read token, so no repository permission change is required.
 
 on:
   workflow_dispatch:
@@ -21,7 +22,7 @@ on:
         default: "project results"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   regen:
@@ -98,16 +99,9 @@ jobs:
           GREP: ${{ inputs.grep }}
         run: npx playwright test visual-regression --update-snapshots -g "$GREP"
 
-      - name: Commit and push regenerated snapshots
-        env:
-          TARGET_BRANCH: ${{ inputs.branch }}
-        run: |
-          if git diff --quiet -- 'frontend/e2e/**/*.png'; then
-            echo "No snapshot changes to commit."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add frontend/e2e/**/*.png
-          git commit -m "test: regenerate visual-regression snapshots on amd64"
-          git push origin "HEAD:$TARGET_BRANCH"
+      - name: Upload regenerated snapshots
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: regenerated-snapshots
+          path: frontend/e2e/visual-regression.spec.ts-snapshots/*-linux.png
+          if-no-files-found: error

--- a/.github/workflows/regen-snapshots.yml
+++ b/.github/workflows/regen-snapshots.yml
@@ -1,0 +1,113 @@
+name: Regenerate Visual Snapshots
+
+# Manually regenerates Playwright visual-regression baselines on the amd64 CI
+# runner (the only environment whose rendering matches the E2E job) and commits
+# the updated *-linux.png files back to the target branch. Use after an
+# intentional layout change shifts the whole-page project-results snapshots.
+#
+# Run it from the Actions tab (or `gh workflow run regen-snapshots.yml
+# -f branch=<feature-branch>`). Needs the repo's Actions workflow permissions
+# set to "Read and write" so the job can push the regenerated PNGs.
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to regenerate snapshots on and push the result to"
+        required: true
+      grep:
+        description: "Playwright -g filter selecting which tests to update"
+        required: false
+        default: "project results"
+
+permissions:
+  contents: write
+
+jobs:
+  regen:
+    name: Regenerate snapshots (amd64)
+    runs-on: ubuntu-24.04
+    env:
+      APP_ENV: "test"
+      TESTING: "1"
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: become
+          POSTGRES_PASSWORD: become
+          POSTGRES_DB: become_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.13.7
+
+      - name: Install Python dependencies
+        run: uv sync --locked --extra dev --extra api
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: frontend
+        run: npx playwright install --with-deps
+
+      - name: Start API server
+        run: |
+          uv run uvicorn api.main:app --host 0.0.0.0 --port 8000 &
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:8000/api/v1/health && break
+            echo "Waiting for API... ($i/30)"
+            sleep 2
+          done
+          curl -sf http://localhost:8000/api/v1/health || { echo "API failed to start"; exit 1; }
+        env:
+          DATABASE_URL: postgresql://become:become@localhost:5432/become_test
+          SECRET_KEY: test-secret-key-for-ci
+          CORS_ORIGINS: '["http://localhost:8080"]'
+          DEBUG: "false"
+
+      - name: Update snapshots
+        working-directory: frontend
+        env:
+          GREP: ${{ inputs.grep }}
+        run: npx playwright test visual-regression --update-snapshots -g "$GREP"
+
+      - name: Commit and push regenerated snapshots
+        env:
+          TARGET_BRANCH: ${{ inputs.branch }}
+        run: |
+          if git diff --quiet -- 'frontend/e2e/**/*.png'; then
+            echo "No snapshot changes to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add frontend/e2e/**/*.png
+          git commit -m "test: regenerate visual-regression snapshots on amd64"
+          git push origin "HEAD:$TARGET_BRANCH"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -183,6 +183,29 @@
         "line_number": 259
       }
     ],
+    ".github/workflows/regen-snapshots.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/regen-snapshots.yml",
+        "hashed_secret": "7bcbf908e034c8e5209b8a83d086693f77bafb3d",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": ".github/workflows/regen-snapshots.yml",
+        "hashed_secret": "7bcbf908e034c8e5209b8a83d086693f77bafb3d",
+        "is_verified": false,
+        "line_number": 91
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/regen-snapshots.yml",
+        "hashed_secret": "b71d494da8d930401ba9b32b7cef87295f3eb6d3",
+        "is_verified": false,
+        "line_number": 92
+      }
+    ],
     "README.md": [
       {
         "type": "Secret Keyword",
@@ -1026,5 +1049,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-18T20:04:29Z"
+  "generated_at": "2026-07-19T16:05:50Z"
 }


### PR DESCRIPTION
## Summary

Adds a manual `workflow_dispatch` workflow that regenerates the Playwright visual-regression baselines on the **amd64 CI runner** -- the only environment whose rendering matches the `E2E Tests (Playwright)` job -- and **uploads the updated `*-linux.png` files as an artifact**.

It is needed because the `project-results-*` snapshots are whole-page screenshots, so any intentional results-page layout change (e.g. #305) shifts them, and they can't be reliably regenerated on a developer's arm64 Mac. The job mirrors the `e2e` job's setup (postgres service + uv/python + node + `npx playwright install` + start API), checks out the target branch, runs `playwright test visual-regression --update-snapshots -g "<filter>"` (default filter `project results`), and uploads the result.

Uploading an artifact needs only the default **read** token, so no repository permission change is required; the regenerated PNGs are then downloaded and committed onto the feature branch locally. Untrusted `workflow_dispatch` inputs are passed through `env:` rather than interpolated into `run:` commands.

## Usage

1. `gh workflow run regen-snapshots.yml -f branch=<feature-branch>`
2. Download the `regenerated-snapshots` artifact, drop the PNGs into `frontend/e2e/visual-regression.spec.ts-snapshots/`, commit + push to the branch.
3. The branch's E2E re-runs green against the fresh baselines.

Reusable for every future baseline-affecting change.
