### PR TITLE
ci: document the snapshot-harvest fallback and type the regen workflow inputs

### DIFF
--- a/.github/workflows/regen-snapshots.yml
+++ b/.github/workflows/regen-snapshots.yml
@@ -9,6 +9,21 @@ name: Regenerate Visual Snapshots
 # Run it from the Actions tab (or `gh workflow run regen-snapshots.yml
 # -f branch=<feature-branch>`). Uploading an artifact needs only the default
 # read token, so no repository permission change is required.
+#
+# FALLBACK -- if this workflow is unavailable, the fresh amd64 renders are
+# already inside the failed E2E run's report, so harvest them instead:
+#   1. gh run download <run-id> -n playwright-report -D <dir>
+#   2. <dir>/index.html embeds the report as a base64 zip in
+#      <template id="playwrightReportBase64">; decode + unzip it. The JSONs
+#      inside list attachments named "<snapshot>-actual/-expected/-diff.png",
+#      each pointing at data/<sha1>.png.
+#   3. The "-actual" files are the new baselines. Sanity-check that each
+#      "-expected" matches the currently committed PNG, then copy the
+#      "-actual" ones over frontend/e2e/visual-regression.spec.ts-snapshots/
+#      <snapshot>-visual-regression-linux.png and commit.
+# Only the *-linux.png baselines are tracked; *-darwin.png are gitignored and
+# are regenerated locally with `npx playwright test --project=visual-regression
+# --update-snapshots`.
 
 on:
   workflow_dispatch:
@@ -16,10 +31,12 @@ on:
       branch:
         description: "Branch to regenerate snapshots on and push the result to"
         required: true
+        type: string
       grep:
         description: "Playwright -g filter selecting which tests to update"
         required: false
         default: "project results"
+        type: string
 
 permissions:
   contents: read

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -189,21 +189,21 @@
         "filename": ".github/workflows/regen-snapshots.yml",
         "hashed_secret": "7bcbf908e034c8e5209b8a83d086693f77bafb3d",
         "is_verified": false,
-        "line_number": 40
+        "line_number": 57
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github/workflows/regen-snapshots.yml",
         "hashed_secret": "7bcbf908e034c8e5209b8a83d086693f77bafb3d",
         "is_verified": false,
-        "line_number": 91
+        "line_number": 108
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/regen-snapshots.yml",
         "hashed_secret": "b71d494da8d930401ba9b32b7cef87295f3eb6d3",
         "is_verified": false,
-        "line_number": 92
+        "line_number": 109
       }
     ],
     "README.md": [
@@ -1049,5 +1049,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-19T16:05:50Z"
+  "generated_at": "2026-07-19T21:10:32Z"
 }


### PR DESCRIPTION
## Summary

Documents the fallback for regenerating the amd64 visual-regression baselines, and makes the `workflow_dispatch` inputs explicitly typed.

- **Harvest fallback, written down.** When the regen workflow isn't available, the fresh amd64 renders are already inside the failed E2E run's Playwright report — the header comment now spells out how to get them: download the `playwright-report` artifact, decode the base64 zip embedded in `index.html` as `<template id="playwrightReportBase64">`, and pull the `-actual` attachments (checking each `-expected` against the currently committed PNG first). This path was used twice while landing #305 and is what actually regenerated the four dark-theme baselines.
- **Which baselines are tracked.** Also noted that only `*-linux.png` is committed; `*-darwin.png` is gitignored and regenerated locally with `--update-snapshots`.
- **Typed inputs.** `branch` and `grep` now declare `type: string` instead of relying on the implicit default.

## Why now

The workflow has been on `develop` since #306 merged, but GitHub never indexed it — it does not appear in the Actions tab and both `GET /actions/workflows/regen-snapshots.yml` and the dispatch endpoint return 404, even though every documented requirement is met (file on the default branch, Actions enabled with `allowed_actions: all`, valid YAML matching the shape of the already-registered `ci.yml`). Landing a commit that touches the workflow file produces a fresh push event on the default branch, which is the usual way to make the indexer pick it up. If it registers, "Run workflow" becomes available; if it doesn't, the fallback above is now documented in the file itself, so nothing is blocked either way.

The secrets baseline is refreshed only for shifted line numbers — the flagged entries are the same CI fixtures already in this workflow (no new findings).
