### PR TITLE
fix: align the public page headings with their content and even out the footer columns

### DIFF
--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -34,7 +34,7 @@ export function Footer() {
         </div>
 
         {/* 3-column grid */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-8">
+        <div className="grid grid-cols-1 md:grid-cols-3 md:justify-items-center gap-8 mb-8">
           {/* Product */}
           <div>
             <h4 className="font-medium text-sm mb-4">{t("footer.product")}</h4>

--- a/frontend/src/components/layout/HeroSection.tsx
+++ b/frontend/src/components/layout/HeroSection.tsx
@@ -1,11 +1,18 @@
 import { motion } from "framer-motion";
 
+import { cn } from "@/lib/utils";
+
 interface HeroSectionProps {
   readonly title: string;
   readonly subtitle: string;
+  /**
+   * "center" keeps the heading block centred, which suits a long-form reading
+   * column (About). "left" matches the flush-left headings on Docs and FAQ.
+   */
+  readonly align?: "left" | "center";
 }
 
-export function HeroSection({ title, subtitle }: HeroSectionProps) {
+export function HeroSection({ title, subtitle, align = "center" }: HeroSectionProps) {
   return (
     <section className="pt-24 pb-12 md:pt-32 md:pb-16 bg-secondary/30">
       <div className="container mx-auto px-6">
@@ -13,7 +20,7 @@ export function HeroSection({ title, subtitle }: HeroSectionProps) {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
-          className="max-w-3xl mx-auto"
+          className={cn("max-w-3xl", align === "center" && "mx-auto")}
         >
           <h1 className="font-display text-3xl md:text-5xl font-normal mb-4">
             {title}

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -123,43 +123,45 @@ const About = () => {
       {/* Authors */}
       <section className="py-12 md:py-16 bg-card">
         <div className="container mx-auto px-6">
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.5 }}
-          >
-            <h2 className="font-display text-2xl md:text-3xl font-normal mb-6">
-              {t("authors.title")}
-            </h2>
-            <Card className="max-w-xl mx-auto">
-              <CardContent className="pt-6">
-                <div className="flex items-start gap-4">
-                  <div className="w-12 h-12 rounded-full bg-secondary flex items-center justify-center">
-                    <BookOpen className="h-6 w-6 text-muted-foreground" />
+          <div className="max-w-3xl mx-auto">
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.5 }}
+            >
+              <h2 className="font-display text-2xl md:text-3xl font-normal mb-6">
+                {t("authors.title")}
+              </h2>
+              <Card>
+                <CardContent className="pt-6">
+                  <div className="flex flex-col items-center gap-4 text-center">
+                    <div className="w-12 h-12 rounded-full bg-secondary flex items-center justify-center">
+                      <BookOpen className="h-6 w-6 text-muted-foreground" />
+                    </div>
+                    <div>
+                      <p className="font-medium">{t("authors.vrana")}</p>
+                      <p className="font-medium">{t("authors.tyrychtr")}</p>
+                      <p className="font-medium">{t("authors.pelikan")}</p>
+                      <p className="text-sm text-muted-foreground mt-2">
+                        {t("authors.department")}
+                        <br />
+                        {t("authors.faculty")}
+                        <br />
+                        {t("authors.university")}
+                      </p>
+                    </div>
                   </div>
-                  <div>
-                    <p className="font-medium">{t("authors.vrana")}</p>
-                    <p className="font-medium">{t("authors.tyrychtr")}</p>
-                    <p className="font-medium">{t("authors.pelikan")}</p>
-                    <p className="text-sm text-muted-foreground mt-2">
-                      {t("authors.department")}
-                      <br />
-                      {t("authors.faculty")}
-                      <br />
-                      {t("authors.university")}
+                  <div className="mt-6 pt-4 border-t text-center">
+                    <p className="text-xs text-muted-foreground">
+                      <strong>{t("authors.citation")}</strong>{" "}
+                      {t("authors.citationText")}
                     </p>
                   </div>
-                </div>
-                <div className="mt-6 pt-4 border-t">
-                  <p className="text-xs text-muted-foreground">
-                    <strong>{t("authors.citation")}</strong>{" "}
-                    {t("authors.citationText")}
-                  </p>
-                </div>
-              </CardContent>
-            </Card>
-          </motion.div>
+                </CardContent>
+              </Card>
+            </motion.div>
+          </div>
         </div>
       </section>
 

--- a/frontend/src/pages/CaseStudies.tsx
+++ b/frontend/src/pages/CaseStudies.tsx
@@ -22,12 +22,16 @@ const CaseStudies = () => {
     <div className="min-h-screen flex flex-col">
       <Navbar />
       <main id="main-content">
-        <HeroSection title={t("listing.title")} subtitle={t("listing.subtitle")} />
+        <HeroSection
+          title={t("listing.title")}
+          subtitle={t("listing.subtitle")}
+          align="left"
+        />
 
         {/* Case Study Cards */}
         <section className="py-12 md:py-16">
           <div className="container mx-auto px-6">
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-5xl mx-auto">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
               {studies.map((study, index) => (
                 <motion.div
                   key={study.id}

--- a/frontend/src/pages/FAQ.tsx
+++ b/frontend/src/pages/FAQ.tsx
@@ -3,7 +3,6 @@ import { Link } from "react-router";
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import {
-  HelpCircle,
   BookOpen,
   Calculator,
   BarChart3,
@@ -72,14 +71,9 @@ const FAQ = () => {
       <section className="pt-24 pb-8 md:pt-32 md:pb-12 bg-secondary/30">
         <div className="container mx-auto px-6">
           <motion.div {...fadeInUp} className="max-w-3xl">
-            <div className="flex items-center gap-3 mb-4">
-              <div className="w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center">
-                <HelpCircle className="h-6 w-6 text-primary" />
-              </div>
-              <h1 className="font-display text-3xl md:text-5xl font-normal">
-                {t("title")}
-              </h1>
-            </div>
+            <h1 className="font-display text-3xl md:text-5xl font-normal mb-4">
+              {t("title")}
+            </h1>
             <p className="text-lg text-muted-foreground">{t("subtitle")}</p>
           </motion.div>
         </div>


### PR DESCRIPTION
## Summary

Fixes four alignment issues on the public pages, spotted while reviewing the desktop layout.

- **Footer columns.** The three link columns (Product / Method Authors / Resources) each sat flush-left inside their third of the grid. Because "Resources" holds only short links, the block trailed off well before the right edge and read as shifted left. The columns are now centred within their thirds, so the middle one lands on the page centre and the outer two sit an equal distance from it.
- **FAQ heading.** Dropped the circled `HelpCircle` badge next to "Frequently Asked Questions" — no other page heading carries one, and Docs sets the pattern. The now-unused import went with it.
- **Case Studies heading.** The listing heading was centred while Docs and FAQ are flush-left. `HeroSection` centred its heading block unconditionally, so it now takes an `align` prop: Case Studies asks for `left`, and About keeps the centred reading column it was designed around. The case-study cards were also centred inside a narrower `max-w-5xl`, which would have left the heading hanging 104px to their left — they now span the container, so the heading and the first card share a left edge.
- **About → Authors.** That section was missing the `max-w-3xl mx-auto` wrapper every other section on the page uses, so its heading ran to the container edge while the card floated in its own narrow box. It now follows the same pattern as The Challenge / The BeCoMe Method / Applications, and the card's contents (icon, names, affiliation, citation) are centred.

## Testing

- `tsc` and `eslint` clean; 983 frontend tests pass.
- Verified in the browser at 1280px: all four About headings now share a left edge at 256px, the Case Studies heading and first card both start at 24px with the last card ending flush at the container edge, and the footer's middle column centres on the page.
- The `case-study-budget` visual baselines are captured with `fullPage: true`, so they include the footer and were regenerated on the amd64 runner.
