### PR TITLE
fix: replace the end-of-life react-router-dom with react-router 8 to clear the CSRF advisory

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -56,7 +56,7 @@
         "react-hook-form": "7.81.0",
         "react-i18next": "17.0.8",
         "react-is": "19.2.7",
-        "react-router-dom": "7.18.1",
+        "react-router": "8.3.0",
         "recharts": "3.9.2",
         "tailwind-merge": "3.6.0",
         "tw-animate-css": "1.4.0",
@@ -4110,18 +4110,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7090,41 +7083,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/react-style-singleton": {
@@ -7365,12 +7341,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,7 +66,7 @@
     "react-hook-form": "7.81.0",
     "react-i18next": "17.0.8",
     "react-is": "19.2.7",
-    "react-router-dom": "7.18.1",
+    "react-router": "8.3.0",
     "recharts": "3.9.2",
     "tailwind-merge": "3.6.0",
     "tw-animate-css": "1.4.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { MotionConfig } from "framer-motion";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { RouteAnnouncer } from "@/components/RouteAnnouncer";

--- a/frontend/src/components/CaseStudyCard.tsx
+++ b/frontend/src/components/CaseStudyCard.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import { Users } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";

--- a/frontend/src/components/NotFoundState.tsx
+++ b/frontend/src/components/NotFoundState.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 
 import { Navbar } from "@/components/layout/Navbar";

--- a/frontend/src/components/RouteAnnouncer.tsx
+++ b/frontend/src/components/RouteAnnouncer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 
 export function RouteAnnouncer() {
   const location = useLocation();

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useLocation } from "react-router-dom";
+import { Navigate, useLocation } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "@/contexts/AuthContext";
 import { ServiceUnavailable } from "@/components/auth/ServiceUnavailable";

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 import { MessageSquare } from "lucide-react";
 

--- a/frontend/src/components/layout/FooterMinimal.tsx
+++ b/frontend/src/components/layout/FooterMinimal.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 
 export function FooterMinimal() {

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "@/components/ThemeToggle";

--- a/frontend/src/components/onboarding/StepComplete.tsx
+++ b/frontend/src/components/onboarding/StepComplete.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import { CheckCircle2, Rocket } from "lucide-react";

--- a/frontend/src/hooks/use-auth-submit.ts
+++ b/frontend/src/hooks/use-auth-submit.ts
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 
 import { useToast } from "@/hooks/use-toast";

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import { ArrowRight, BookOpen, FileText } from "lucide-react";

--- a/frontend/src/pages/CaseStudy.tsx
+++ b/frontend/src/pages/CaseStudy.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams, Link } from "react-router";
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import {

--- a/frontend/src/pages/FAQ.tsx
+++ b/frontend/src/pages/FAQ.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import {

--- a/frontend/src/pages/ForgotPassword.tsx
+++ b/frontend/src/pages/ForgotPassword.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router";
 import { useTranslation } from "react-i18next";
 import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 import { motion, AnimatePresence } from "framer-motion";
 import { ChevronLeft, ChevronRight, X } from "lucide-react";

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react";
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { Loader2, AlertTriangle, Camera, Trash2, Download } from "lucide-react";
 
 import { Button } from "@/components/ui/button";

--- a/frontend/src/pages/ProjectDetail.tsx
+++ b/frontend/src/pages/ProjectDetail.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useParams, Link, useNavigate } from "react-router-dom";
+import { useParams, Link, useNavigate } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { motion } from "framer-motion";

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";

--- a/frontend/src/pages/ResetPassword.tsx
+++ b/frontend/src/pages/ResetPassword.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router";
 import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -9,8 +9,8 @@ const routeRef = vi.hoisted(() => ({ value: '/' }));
 // --- Mocks ---
 
 // 1. Replace BrowserRouter with MemoryRouter for route control
-vi.mock('react-router-dom', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('react-router-dom')>();
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>();
   return {
     ...actual,
     BrowserRouter: ({ children }: { children: ReactNode }) => (

--- a/frontend/tests/components/RouteAnnouncer.test.tsx
+++ b/frontend/tests/components/RouteAnnouncer.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
-import { MemoryRouter, useNavigate } from 'react-router-dom';
+import { MemoryRouter, useNavigate } from 'react-router';
 import { RouteAnnouncer } from '@/components/RouteAnnouncer';
 
 // Shared navigate function, set by NavigateHelper inside MemoryRouter

--- a/frontend/tests/components/auth/ProtectedRoute.test.tsx
+++ b/frontend/tests/components/auth/ProtectedRoute.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@tests/utils'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi } from 'vitest'
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute'

--- a/frontend/tests/components/layout/Navbar.a11y.test.tsx
+++ b/frontend/tests/components/layout/Navbar.a11y.test.tsx
@@ -17,8 +17,8 @@ const { mockUser, mockLogout, mockPathname } = vi.hoisted(() => ({
   mockPathname: { value: '/' },
 }));
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useLocation: () => ({ pathname: mockPathname.value, search: '', hash: '', state: null, key: 'default' }),

--- a/frontend/tests/components/layout/Navbar.test.tsx
+++ b/frontend/tests/components/layout/Navbar.test.tsx
@@ -18,9 +18,9 @@ const { mockUser, mockLogout, mockPathname } = vi.hoisted(() => ({
   mockPathname: { value: '/' },
 }));
 
-// Mock react-router-dom
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+// Mock react-router
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useLocation: () => ({ pathname: mockPathname.value, search: '', hash: '', state: null, key: 'default' }),

--- a/frontend/tests/components/layout/Navbar.unauth.test.tsx
+++ b/frontend/tests/components/layout/Navbar.unauth.test.tsx
@@ -4,8 +4,8 @@ import userEvent from '@testing-library/user-event';
 import { render, framerMotionMock, unauthenticatedAuthMock } from '@tests/utils';
 import { Navbar } from '@/components/layout/Navbar';
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useLocation: () => ({ pathname: '/', search: '', hash: '', state: null, key: 'default' }),

--- a/frontend/tests/hooks/use-auth-submit.test.ts
+++ b/frontend/tests/hooks/use-auth-submit.test.ts
@@ -9,8 +9,8 @@ const { mockNavigate, mockToast } = vi.hoisted(() => ({
   mockToast: vi.fn(),
 }));
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return { ...actual, useNavigate: () => mockNavigate };
 });
 

--- a/frontend/tests/pages/CaseStudy.test.tsx
+++ b/frontend/tests/pages/CaseStudy.test.tsx
@@ -7,8 +7,8 @@ const { mockParams } = vi.hoisted(() => ({
   mockParams: { value: { id: 'budget' } },
 }));
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useParams: () => mockParams.value,

--- a/frontend/tests/pages/Login.test.tsx
+++ b/frontend/tests/pages/Login.test.tsx
@@ -18,8 +18,8 @@ vi.mock('@/contexts/AuthContext', () => ({
 
 // Mock useNavigate
 const mockNavigate = vi.fn();
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/frontend/tests/pages/Onboarding.a11y.test.tsx
+++ b/frontend/tests/pages/Onboarding.a11y.test.tsx
@@ -15,8 +15,8 @@ const { mockUser, mockPathname } = vi.hoisted(() => ({
   mockPathname: { value: '/onboarding' },
 }));
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useNavigate: () => vi.fn(),

--- a/frontend/tests/pages/Onboarding.test.tsx
+++ b/frontend/tests/pages/Onboarding.test.tsx
@@ -18,8 +18,8 @@ const { mockUser, mockNavigate, mockPathname } = vi.hoisted(() => ({
   mockPathname: { value: '/onboarding' },
 }));
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/frontend/tests/pages/Profile.loading.test.tsx
+++ b/frontend/tests/pages/Profile.loading.test.tsx
@@ -4,8 +4,8 @@ import { render, framerMotionMock } from '@tests/utils';
 import Profile from '@/pages/Profile';
 
 // Mock useNavigate
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useNavigate: () => vi.fn(),

--- a/frontend/tests/pages/Profile.test.tsx
+++ b/frontend/tests/pages/Profile.test.tsx
@@ -7,8 +7,8 @@ import { createUser } from '@tests/factories/user';
 
 // Mock useNavigate
 const mockNavigate = vi.fn();
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/frontend/tests/pages/ProjectDetail.test.tsx
+++ b/frontend/tests/pages/ProjectDetail.test.tsx
@@ -41,8 +41,8 @@ const { mockApi, mockToast, mockUser, mockNavigate, mockDownloadBlob } = vi.hois
 }));
 
 // Mock useParams
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useParams: () => ({ id: 'project-1' }),

--- a/frontend/tests/pages/Register.test.tsx
+++ b/frontend/tests/pages/Register.test.tsx
@@ -17,8 +17,8 @@ vi.mock('@/contexts/AuthContext', () => ({
 
 // Mock useNavigate
 const mockNavigate = vi.fn();
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/frontend/tests/pages/ResetPassword.test.tsx
+++ b/frontend/tests/pages/ResetPassword.test.tsx
@@ -15,8 +15,8 @@ vi.mock('@/lib/api', () => ({
 // Mock navigation and the reset token read from the URL query string
 const mockNavigate = vi.fn();
 const routeState: { token: string | null } = { token: 'valid-reset-token' };
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/frontend/tests/utils.tsx
+++ b/frontend/tests/utils.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, ReactNode, useState } from 'react'
 import { render, RenderOptions, screen } from '@testing-library/react'
-import { MemoryRouter, MemoryRouterProps } from 'react-router-dom'
+import { MemoryRouter, MemoryRouterProps } from 'react-router'
 import { I18nextProvider } from 'react-i18next'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import i18n from '@/i18n'


### PR DESCRIPTION
## Summary

Clears the high-severity advisory that is currently failing `Dependency Audit` on every PR, by moving from the discontinued `react-router-dom` package to `react-router` 8.

[GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2) covers react-router `7.12.0 – 8.2.0`; we were on `react-router-dom@7.18.1`, which pulls a vulnerable react-router. There is no patched release inside the 7.x line — `react-router-dom` ends at 7.18.1, because v8 folded the DOM bindings back into the `react-router` package. So the only forward fix is 8.3.0, which also means dropping `react-router-dom`.

- `frontend/package.json`: `react-router-dom@7.18.1` → `react-router@8.3.0` (exact pin, no range).
- 40 source, test, and e2e files: import specifier `react-router-dom` → `react-router`. No API calls changed — this is a package rename, not a code migration.

The upgrade itself is documented as non-breaking coming from v7: v8 removes or promotes the old future flags and raises its baselines to Node 22+, Vite 7+, React 19+, ESM-only. This project already satisfies all four (Node 22 in CI, Vite 8.1.3, React 19.2.7, ESM). The remaining v8 breaking changes concern framework-mode server adapters, which this SPA does not use — it renders a plain `<BrowserRouter>` and only consumes `Link`, `Navigate`, `Route`, `Routes`, `MemoryRouter`, `useLocation`, `useNavigate`, `useParams`, and `useSearchParams`.

Worth noting for context: the advisory describes a CSRF bypass in **RSC mode**, which this application never enters, so the practical exposure was nil. It is fixed rather than suppressed because 7.x is end-of-life regardless.

## Testing

- `npm audit --omit=dev --audit-level=moderate` → **found 0 vulnerabilities** (was 2 high).
- `tsc` and `eslint` clean; 983 frontend tests pass with coverage above the gate; production build succeeds.
- Smoke-tested the running app across every routing feature in use: client-side navigation via `Link` (verified no full page reload — a marker set on `window` survived the transition), the protected-route `<Navigate>` redirect, a dynamic `useParams` route (`/case-study/budget`), and the catch-all 404. No console errors.
