### PR TITLE
fix: keep live credentials out of Sentry events and error responses

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -30,7 +30,7 @@ CLOUDFLARE_ORIGIN_SECRET=
 # Email: send real password-reset mail via Resend. EMAIL_FROM must be on a domain
 # verified in Resend; FRONTEND_BASE_URL is the deployed frontend origin.
 # EMAIL_API_KEY is required here: startup fails without it, since the fallback console
-# sender would write reset links to the log instead of delivering them.
+# sender would print reset links to stdout instead of delivering them.
 EMAIL_PROVIDER=http
 EMAIL_API_KEY=re-set-the-real-resend-key-in-railway
 EMAIL_FROM=no-reply@your-domain.example

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -29,8 +29,10 @@ CLOUDFLARE_ORIGIN_SECRET=
 
 # Email: send real password-reset mail via Resend. EMAIL_FROM must be on a domain
 # verified in Resend; FRONTEND_BASE_URL is the deployed frontend origin.
+# EMAIL_API_KEY is required here: startup fails without it, since the fallback console
+# sender would write reset links to the log instead of delivering them.
 EMAIL_PROVIDER=http
-EMAIL_API_KEY=
+EMAIL_API_KEY=re-set-the-real-resend-key-in-railway
 EMAIL_FROM=no-reply@your-domain.example
 EMAIL_FROM_NAME=BeCoMe
 FRONTEND_BASE_URL=https://your-frontend.example

--- a/.env.test.example
+++ b/.env.test.example
@@ -17,8 +17,8 @@ API_PUBLIC_URL=https://test-backend-staging.up.railway.app
 # BUCKET_NAME / BUCKET_ENDPOINT / BUCKET_ACCESS_KEY_ID / BUCKET_SECRET_ACCESS_KEY
 
 # Email: required on the deployed staging profile too (APP_ENV=test without TESTING=1).
-# Startup fails without a key, because the fallback console sender writes reset links to
-# the log instead of delivering them. The pytest profile (TESTING=1) is exempt.
+# Startup fails without a key, because the fallback console sender prints reset links to
+# stdout instead of delivering them. The pytest profile (TESTING=1) is exempt.
 EMAIL_PROVIDER=http
 EMAIL_API_KEY=re-set-the-real-resend-key-in-railway
 EMAIL_FROM=no-reply@your-domain.example

--- a/.env.test.example
+++ b/.env.test.example
@@ -15,3 +15,12 @@ API_PUBLIC_URL=https://test-backend-staging.up.railway.app
 
 # Railway injects bucket credentials when a bucket is attached to the service:
 # BUCKET_NAME / BUCKET_ENDPOINT / BUCKET_ACCESS_KEY_ID / BUCKET_SECRET_ACCESS_KEY
+
+# Email: required on the deployed staging profile too (APP_ENV=test without TESTING=1).
+# Startup fails without a key, because the fallback console sender writes reset links to
+# the log instead of delivering them. The pytest profile (TESTING=1) is exempt.
+EMAIL_PROVIDER=http
+EMAIL_API_KEY=re-set-the-real-resend-key-in-railway
+EMAIL_FROM=no-reply@your-domain.example
+EMAIL_FROM_NAME=BeCoMe
+FRONTEND_BASE_URL=https://staging.your-domain.example

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -509,21 +509,21 @@
         "filename": "tests/integration/api/auth/test_password_reset.py",
         "hashed_secret": "ff69976f0b5192e1116c184127da03377a4426df",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 21
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/api/auth/test_password_reset.py",
         "hashed_secret": "6e9119e671bbe324edd23d0453db69fe73f5f240",
         "is_verified": false,
-        "line_number": 207
+        "line_number": 246
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/api/auth/test_password_reset.py",
         "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
         "is_verified": false,
-        "line_number": 223
+        "line_number": 262
       }
     ],
     "tests/integration/api/db/test_cascade.py": [
@@ -1056,5 +1056,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-26T18:22:56Z"
+  "generated_at": "2026-07-26T22:23:33Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -641,7 +641,7 @@
         "filename": "tests/integration/api/routes/test_users.py",
         "hashed_secret": "4d81c30a1e76bc8adbbb6af9fc64162241e13f34",
         "is_verified": false,
-        "line_number": 272
+        "line_number": 275
       }
     ],
     "tests/integration/api/services/test_user_cache_invalidation.py": [
@@ -733,56 +733,56 @@
         "filename": "tests/unit/api/schemas/test_auth.py",
         "hashed_secret": "72559b51f94a7a3ad058c5740cbe2f7cb0d4080b",
         "is_verified": false,
-        "line_number": 25
+        "line_number": 27
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/api/schemas/test_auth.py",
         "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
         "is_verified": false,
-        "line_number": 40
+        "line_number": 42
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/api/schemas/test_auth.py",
         "hashed_secret": "509364dd6d0d59d9252a50d7e0c3460e36fa8d3c",
         "is_verified": false,
-        "line_number": 53
+        "line_number": 55
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/api/schemas/test_auth.py",
         "hashed_secret": "bfa01b56367d9c452774171e566110d6949a37c2",
         "is_verified": false,
-        "line_number": 66
+        "line_number": 68
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/api/schemas/test_auth.py",
         "hashed_secret": "1edceb6f7f99ae39da7ed9c6988a704573791392",
         "is_verified": false,
-        "line_number": 79
+        "line_number": 81
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/api/schemas/test_auth.py",
         "hashed_secret": "dc5d5fc2388c2380fd35f2bf3c2de1e26895777b",
         "is_verified": false,
-        "line_number": 222
+        "line_number": 224
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/api/schemas/test_auth.py",
         "hashed_secret": "e9e4a6d29515c8e53e4df7bc6646a23237b8f862",
         "is_verified": false,
-        "line_number": 322
+        "line_number": 324
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/api/schemas/test_auth.py",
         "hashed_secret": "6d959b8d5424573736ee5ff5c0d15537b469d496",
         "is_verified": false,
-        "line_number": 323
+        "line_number": 325
       }
     ],
     "tests/unit/api/schemas/test_internal.py": [
@@ -1013,7 +1013,7 @@
         "filename": "tests/unit/api/test_config.py",
         "hashed_secret": "0fda60f593b23b78f2b02d07152b82593abdab52",
         "is_verified": false,
-        "line_number": 279
+        "line_number": 281
       }
     ],
     "tests/unit/api/test_logging_config.py": [
@@ -1045,9 +1045,9 @@
         "filename": "tests/unit/api/test_main.py",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 9
+        "line_number": 14
       }
     ]
   },
-  "generated_at": "2026-07-19T21:10:32Z"
+  "generated_at": "2026-07-26T17:50:54Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1037,6 +1037,13 @@
         "hashed_secret": "77d52a1258cbac72db430cbce22b157351915e5e",
         "is_verified": false,
         "line_number": 31
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/api/test_logging_config.py",
+        "hashed_secret": "907c184320b6f5ee0f72365a6b4da6c4c93cdb28",
+        "is_verified": false,
+        "line_number": 34
       }
     ],
     "tests/unit/api/test_main.py": [
@@ -1049,5 +1056,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-26T17:50:54Z"
+  "generated_at": "2026-07-26T18:22:56Z"
 }

--- a/api/README.md
+++ b/api/README.md
@@ -137,7 +137,7 @@ returns `422`. The profile photo blob is removed from object storage as part of 
 | PATCH | `/api/v1/projects/{id}` | Update project |
 | DELETE | `/api/v1/projects/{id}` | Delete project |
 | GET | `/api/v1/projects/{id}/members` | List members |
-| DELETE | `/api/v1/projects/{id}/members/{user_id}` | Remove member |
+| DELETE | `/api/v1/projects/{id}/members/{user_id}` | Remove member (discards their opinion and recalculates) |
 | POST | `/api/v1/projects/{id}/transfer-ownership` | Transfer ownership to another member |
 | POST | `/api/v1/projects/{id}/invite` | Invite user |
 
@@ -193,7 +193,7 @@ Environment variables (can use `.env` file):
 | `REDIS_URL` | *required when deployed* | Redis for rate limiting, token revocation, and auth throttles |
 | `CLOUDFLARE_ORIGIN_SECRET` | *required in prod* | Shared secret proving the request came through Cloudflare |
 | `EMAIL_PROVIDER` | `console` | Password-reset email delivery: `console` (log) or `http` (Resend) |
-| `EMAIL_API_KEY` | *optional* | API key for the `http` email provider |
+| `EMAIL_API_KEY` | *required when deployed* | API key for the `http` email provider; startup fails without it on the staging and production profiles, where the console fallback would log reset links instead of sending them |
 | `API_PUBLIC_URL` | `http://localhost:8000` | Public base URL of this API, used to build profile photo proxy links |
 | `BUCKET_NAME` | *optional* | Railway Storage Bucket name (auto-injected when a bucket is attached) |
 | `BUCKET_ENDPOINT` | *optional* | S3-compatible bucket endpoint |

--- a/api/README.md
+++ b/api/README.md
@@ -193,7 +193,7 @@ Environment variables (can use `.env` file):
 | `REDIS_URL` | *required when deployed* | Redis for rate limiting, token revocation, and auth throttles |
 | `CLOUDFLARE_ORIGIN_SECRET` | *required in prod* | Shared secret proving the request came through Cloudflare |
 | `EMAIL_PROVIDER` | `console` | Password-reset email delivery: `console` (log) or `http` (Resend) |
-| `EMAIL_API_KEY` | *required when deployed* | API key for the `http` email provider; startup fails without it on the staging and production profiles, where the console fallback would log reset links instead of sending them |
+| `EMAIL_API_KEY` | *required when deployed* | API key for the `http` email provider; startup fails without it on the staging and production profiles, where the console fallback would print reset links to stdout instead of sending them |
 | `API_PUBLIC_URL` | `http://localhost:8000` | Public base URL of this API, used to build profile photo proxy links |
 | `BUCKET_NAME` | *optional* | Railway Storage Bucket name (auto-injected when a bucket is attached) |
 | `BUCKET_ENDPOINT` | *optional* | S3-compatible bucket endpoint |

--- a/api/auth/logging.py
+++ b/api/auth/logging.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger("api.security")
 
 
-def _hash_email(email: str) -> str:
+def hash_email(email: str) -> str:
     """Return a short, non-reversible tag for an email.
 
     Security events log this instead of the raw address so a log drain or Sentry
@@ -40,7 +40,7 @@ def log_login_success(user_id: UUID, email: str, request: "Request | None" = Non
         extra={
             "event": "login_success",
             "user_id": str(user_id),
-            "email_hash": _hash_email(email),
+            "email_hash": hash_email(email),
             "ip": ip,
         },
     )
@@ -58,7 +58,7 @@ def log_login_failure(email: str, reason: str, request: "Request | None" = None)
         "Login failed",
         extra={
             "event": "login_failure",
-            "email_hash": _hash_email(email),
+            "email_hash": hash_email(email),
             "reason": reason,
             "ip": ip,
         },
@@ -78,7 +78,7 @@ def log_registration(user_id: UUID, email: str, request: "Request | None" = None
         extra={
             "event": "registration",
             "user_id": str(user_id),
-            "email_hash": _hash_email(email),
+            "email_hash": hash_email(email),
             "ip": ip,
         },
     )
@@ -131,7 +131,7 @@ def log_password_reset_requested(email: str, request: "Request | None" = None) -
         "Password reset requested",
         extra={
             "event": "password_reset_requested",
-            "email_hash": _hash_email(email),
+            "email_hash": hash_email(email),
             "ip": ip,
         },
     )
@@ -167,7 +167,7 @@ def log_account_deletion(user_id: UUID, email: str, request: "Request | None" = 
         extra={
             "event": "account_deletion",
             "user_id": str(user_id),
-            "email_hash": _hash_email(email),
+            "email_hash": hash_email(email),
             "ip": ip,
         },
     )

--- a/api/config.py
+++ b/api/config.py
@@ -221,15 +221,17 @@ class Settings(BaseSettings):
     def _validate_deploy_invariants(self) -> "Settings":
         """Reject development defaults on the deployed (TEST/PROD) profiles.
 
-        A strong secret, real PostgreSQL database, Redis-backed store, and a real
-        (non-loopback) CORS origin are required on both the staging (TEST) and
-        production (PROD) deploys, since both serve real browser traffic and
-        share the rate-limit / revocation store. The Cloudflare origin lock is
-        required only in production, where the app sits behind Cloudflare.
+        A strong secret, real PostgreSQL database, Redis-backed store, a real
+        (non-loopback) CORS origin, and a configured email provider are required on
+        both the staging (TEST) and production (PROD) deploys, since both serve real
+        browser traffic and share the rate-limit / revocation store. The Cloudflare
+        origin lock is required only in production, where the app sits behind
+        Cloudflare.
 
         :return: The validated settings instance.
         :raises ValueError: If a deployed profile still carries a development
-            default, or production lacks the Cloudflare origin secret.
+            default, lacks a real email provider, or production lacks the
+            Cloudflare origin secret.
         """
         # Environment.TEST doubles as the pytest-runner profile (the conftests set
         # APP_ENV=test with TESTING=1 and weak throwaway secrets), so its invariants
@@ -264,6 +266,12 @@ class Settings(BaseSettings):
             raise ValueError(
                 f"cors_origins must include the deployed frontend origin in the {profile} "
                 "profile; the localhost defaults cannot serve real browser traffic"
+            )
+        if not self.email_enabled:
+            raise ValueError(
+                f"email_api_key is required in the {profile} profile with "
+                "email_provider=http; without it the sender falls back to the console one, "
+                "which delivers no mail and writes reset links to the log instead"
             )
         return self
 

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -130,6 +130,10 @@ def get_email_service() -> EmailSender:
     that logs the link. The forgot-password flow must never 503 (that would leak
     account existence), so there is no None / unconfigured branch here.
 
+    The fallback is a development affordance only. The deployed profiles reject an
+    unconfigured provider at startup (``Settings._validate_deploy_invariants``), so a
+    deploy cannot silently end up logging reset links instead of sending them.
+
     :return: An EmailSender implementation.
     """
     settings = get_settings()

--- a/api/main.py
+++ b/api/main.py
@@ -61,9 +61,13 @@ def _init_sentry(settings: Settings) -> None:
             dsn=settings.sentry_dsn,
             traces_sample_rate=0.1,
             environment=settings.environment.value,
-            # Never attach PII (client IP, cookies, headers, request bodies) to events,
-            # so passwords and emails on auth requests are not shipped to the tracker.
+            # Never attach PII (client IP, cookies, headers, request bodies) to events.
             send_default_pii=False,
+            # Frame locals are a separate switch that send_default_pii does not cover, and
+            # they default to on. Auth handlers bind the parsed body to a local, so a fault
+            # anywhere in the request would ship repr(ChangePasswordRequest) -- i.e. the
+            # plaintext passwords, or a still-valid reset token -- to the tracker.
+            include_local_variables=False,
         )
 
 

--- a/api/middleware/csrf.py
+++ b/api/middleware/csrf.py
@@ -52,7 +52,9 @@ class CSRFMiddleware(BaseHTTPMiddleware):
             cookie = request.cookies.get(CSRF_COOKIE)
             if cookie is not None:
                 header = request.headers.get(CSRF_HEADER)
-                if header is None or not secrets.compare_digest(header, cookie):
+                # Compare as bytes: compare_digest raises TypeError on a non-ASCII str,
+                # which would turn a junk header into a 500 instead of this 403.
+                if header is None or not secrets.compare_digest(header.encode(), cookie.encode()):
                     return JSONResponse(
                         status_code=status.HTTP_403_FORBIDDEN,
                         content={"detail": "CSRF token missing or invalid"},

--- a/api/middleware/exception_handlers.py
+++ b/api/middleware/exception_handlers.py
@@ -32,6 +32,12 @@ from api.exceptions import (
     ValidationError,
     ValuesOutOfRangeError,
 )
+from api.services.storage.exceptions import (
+    StorageConfigurationError,
+    StorageDeleteError,
+    StorageError,
+    StorageUploadError,
+)
 
 logger = logging.getLogger("api.exception")
 
@@ -83,6 +89,15 @@ EXCEPTION_MAP: dict[type[BeCoMeAPIError], tuple[int, str | None]] = {
     # 422 Unprocessable Content
     ValuesOutOfRangeError: (status.HTTP_422_UNPROCESSABLE_CONTENT, None),  # Use exception message
     ScaleRangeError: (status.HTTP_422_UNPROCESSABLE_CONTENT, None),  # Use exception message
+    # 503 Service Unavailable -- storage faults.
+    # These carry the raw botocore text (bucket host, object key, S3 error code), and the
+    # lookup below matches types exactly, so every subclass needs its own entry: without
+    # one it falls through to BeCoMeAPIError and returns str(exc) to the caller. The photo
+    # endpoint is public, so that text would be world-readable.
+    StorageError: (status.HTTP_503_SERVICE_UNAVAILABLE, "Storage temporarily unavailable"),
+    StorageConfigurationError: (status.HTTP_503_SERVICE_UNAVAILABLE, "Storage is not available"),
+    StorageUploadError: (status.HTTP_503_SERVICE_UNAVAILABLE, "Failed to upload photo"),
+    StorageDeleteError: (status.HTTP_503_SERVICE_UNAVAILABLE, "Failed to delete photo"),
 }
 
 # Default mappings for base exception classes

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -334,8 +334,15 @@ def reset_password(
     :param service: Password reset service
     :param store: Revocation store (invalidates sessions issued before the reset)
     """
-    user = service.reset_password(data.token, data.new_password)
+    # Order matters: resolve the token, close the session window, then write. Recording
+    # the cutoff first means a store fault surfaces as a 503 with the password unchanged
+    # and the token unspent, rather than committing a new password while every session
+    # issued before the reset stays valid. Presenting a valid token already proves
+    # takeover capability, so revoking before the write concedes nothing.
+    user = service.resolve_valid_token(data.token)
     store.set_user_valid_after(user.id, datetime.now(UTC))
+    service.reset_password(data.token, data.new_password)
+
     log_password_reset_completed(user.id, request)
 
 

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -346,10 +346,4 @@ def get_me(current_user: CurrentUser) -> UserResponse:
     :param current_user: User from JWT token
     :return: User profile data
     """
-    return UserResponse(
-        id=str(current_user.id),
-        email=current_user.email,
-        first_name=current_user.first_name,
-        last_name=current_user.last_name,
-        photo_url=current_user.photo_url,
-    )
+    return UserResponse.from_user(current_user)

--- a/api/routes/projects.py
+++ b/api/routes/projects.py
@@ -13,6 +13,7 @@ from api.auth.dependencies import CurrentUser
 from api.dependencies import (
     ProjectAdmin,
     ProjectMember,
+    get_calculation_service,
     get_project_membership_service,
     get_project_query_service,
     get_project_service,
@@ -26,6 +27,7 @@ from api.schemas.project import (
     ProjectWithRoleResponse,
     TransferOwnershipRequest,
 )
+from api.services.calculation_service import CalculationService
 from api.services.project_membership_service import ProjectMembershipService
 from api.services.project_query_service import ProjectQueryService
 from api.services.project_service import ProjectService
@@ -214,16 +216,19 @@ def remove_member(
     membership_service: Annotated[
         ProjectMembershipService, Depends(get_project_membership_service)
     ],
+    calculation_service: Annotated[CalculationService, Depends(get_calculation_service)],
 ) -> None:
     """Remove a member from project. Only admin can remove members.
 
-    Admin cannot remove themselves (use delete project instead).
+    Admin cannot remove themselves (use delete project instead). The member's opinion
+    is discarded along with their membership, so the result is recalculated without it.
     MemberNotFoundError is handled by centralized exception middleware.
 
     :param project: Project (verified admin)
     :param user_id: User UUID to remove
     :param current_user: Authenticated user
     :param membership_service: Membership service
+    :param calculation_service: Calculation service (result no longer counts the member)
     :raises HTTPException: 400 if removing self
     """
     if user_id == current_user.id:
@@ -232,4 +237,5 @@ def remove_member(
             detail="Admin cannot remove themselves. Delete the project instead.",
         )
 
-    membership_service.remove_member(project.id, user_id)
+    if membership_service.remove_member(project.id, user_id):
+        calculation_service.recalculate(project.id)

--- a/api/routes/users.py
+++ b/api/routes/users.py
@@ -38,7 +38,11 @@ from api.services.project_membership_service import ProjectMembershipService
 from api.services.project_service import ProjectService
 from api.services.storage import validation
 from api.services.storage.base import StorageService
-from api.services.storage.exceptions import StorageDeleteError, StorageUploadError
+from api.services.storage.exceptions import (
+    StorageDeleteError,
+    StorageError,
+    StorageUploadError,
+)
 from api.services.user_service import UserService
 from api.utils.upload import UploadTooLarge, read_within_limit
 
@@ -127,12 +131,13 @@ def change_password(
     :param service: User service
     :param store: Revocation store (invalidates sessions issued before the change)
     """
-    service.change_password(
-        user=current_user,
-        current_password=data.current_password,
-        new_password=data.new_password,
-    )
+    # Order matters: verify, then close the session window, then write. Revoking before
+    # the write means a store fault surfaces as a 503 with the password unchanged, rather
+    # than committing the new password while old sessions stay valid. Verifying first
+    # keeps a mistyped current password from logging the user out everywhere.
+    service.verify_current_password(current_user, data.current_password)
     store.set_user_valid_after(current_user.id, datetime.now(UTC))
+    service.set_password(current_user, data.new_password)
 
     log_password_change(current_user.id, request)
 
@@ -357,7 +362,15 @@ def get_user_photo(
     if user is None or not user.photo_url:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Photo not found")
 
-    result = storage_service.open(user.photo_url)
+    # A storage fault must not surface here: this endpoint is public, and the raw
+    # exception text carries the bucket host and object key.
+    try:
+        result = storage_service.open(user.photo_url)
+    except StorageError as err:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Photo not found"
+        ) from err
+
     if result is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Photo not found")
 

--- a/api/schemas/auth.py
+++ b/api/schemas/auth.py
@@ -53,7 +53,7 @@ class RegisterRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     email: EmailStr = Field(..., max_length=255, description="Email address")
-    password: str = Field(..., min_length=12, max_length=128, description="Password")
+    password: str = Field(..., min_length=12, max_length=128, description="Password", repr=False)
     first_name: str = Field(..., min_length=1, max_length=100, description="First name")
     last_name: str = Field(..., min_length=1, max_length=100, description="Last name")
 
@@ -85,10 +85,14 @@ class RegisterRequest(BaseModel):
 
 
 class TokenResponse(BaseModel):
-    """JWT token response with optional refresh token."""
+    """JWT token response with optional refresh token.
 
-    access_token: str
-    refresh_token: str | None = None
+    The token values carry ``repr=False`` so a frame local holding this response
+    cannot leak a session into a log record or an error-tracker event.
+    """
+
+    access_token: str = Field(..., repr=False)
+    refresh_token: str | None = Field(None, repr=False)
     token_type: str = "bearer"  # noqa: S105 -- OAuth2 scheme name, not a credential
     expires_in: int = 0  # Access token lifetime in seconds
 
@@ -98,7 +102,7 @@ class RefreshTokenRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    refresh_token: str = Field(..., description="Refresh token")
+    refresh_token: str = Field(..., description="Refresh token", repr=False)
 
 
 class UserResponse(BaseModel):
@@ -156,8 +160,10 @@ class ChangePasswordRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    current_password: str = Field(..., min_length=1, description="Current password")
-    new_password: str = Field(..., min_length=12, max_length=128, description="New password")
+    current_password: str = Field(..., min_length=1, description="Current password", repr=False)
+    new_password: str = Field(
+        ..., min_length=12, max_length=128, description="New password", repr=False
+    )
 
     @field_validator("new_password")
     @classmethod
@@ -187,8 +193,10 @@ class ResetPasswordRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    token: str = Field(..., min_length=1, max_length=512, description="Reset token")
-    new_password: str = Field(..., min_length=12, max_length=128, description="New password")
+    token: str = Field(..., min_length=1, max_length=512, description="Reset token", repr=False)
+    new_password: str = Field(
+        ..., min_length=12, max_length=128, description="New password", repr=False
+    )
 
     @field_validator("new_password")
     @classmethod

--- a/api/services/email/console_email_sender.py
+++ b/api/services/email/console_email_sender.py
@@ -59,8 +59,10 @@ class ConsoleEmailSender(EmailSender):
     async def send_password_reset(self, *, to_email: str, reset_url: str) -> None:
         """Log the reset link; perform no network call.
 
-        The INFO record masks the single-use token so an aggregated log never
-        captures it; the full link stays at DEBUG for the local dev flow.
+        The log record masks the single-use token, so a rotating file or a log drain
+        never captures a redeemable link. The dev flow still needs a usable one, so the
+        full link is written straight to stdout instead of through the ``api`` logger
+        tree -- no handler, present or future, can ship it off the machine.
 
         :param to_email: Recipient email address.
         :param reset_url: Full frontend reset link (carries the raw token).
@@ -72,9 +74,5 @@ class ConsoleEmailSender(EmailSender):
             _mask_token(reset_url),
             extra={"event": "password_reset_email", "email_hash": email_hash},
         )
-        logger.debug(
-            "Password reset link (full, console sender) for %s: %s",
-            email_hash,
-            reset_url,
-            extra={"event": "password_reset_email", "email_hash": email_hash},
-        )
+        # Deliberately not a log record -- see the docstring.
+        print(f"[console email] password reset link for {email_hash}: {reset_url}")

--- a/api/services/email/console_email_sender.py
+++ b/api/services/email/console_email_sender.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
+from api.auth.logging import hash_email
 from api.services.email.base import EmailSender
 
 if TYPE_CHECKING:
@@ -42,9 +43,11 @@ class ConsoleEmailSender(EmailSender):
     """Log the password-reset link instead of sending an email.
 
     Used in development, CI, and tests: the flow works offline and the reset
-    link is read straight from the application log. Never selected in
-    production, so the link (and its token) only ever reaches a
-    developer-visible log.
+    link is read straight from the application log. The deployed profiles reject
+    an unconfigured email provider at startup (``Settings._validate_deploy_invariants``),
+    so this sender cannot be selected there -- the link and its token only ever
+    reach a developer-visible log. Recipients are tagged with the same
+    :func:`hash_email` digest the security log uses, never the raw address.
 
     :param settings: Application settings (kept for a uniform sender signature).
     """
@@ -62,15 +65,16 @@ class ConsoleEmailSender(EmailSender):
         :param to_email: Recipient email address.
         :param reset_url: Full frontend reset link (carries the raw token).
         """
+        email_hash = hash_email(to_email)
         logger.info(
             "Password reset link (console sender) for %s: %s",
-            to_email,
+            email_hash,
             _mask_token(reset_url),
-            extra={"event": "password_reset_email", "to_email": to_email},
+            extra={"event": "password_reset_email", "email_hash": email_hash},
         )
         logger.debug(
             "Password reset link (full, console sender) for %s: %s",
-            to_email,
+            email_hash,
             reset_url,
-            extra={"event": "password_reset_email", "to_email": to_email},
+            extra={"event": "password_reset_email", "email_hash": email_hash},
         )

--- a/api/services/password_reset_service.py
+++ b/api/services/password_reset_service.py
@@ -92,8 +92,28 @@ class PasswordResetService(BaseService):
         )
         return f"{settings.frontend_base_url}/reset-password?token={raw_token}"
 
+    def resolve_valid_token(self, token: str) -> User:
+        """Resolve a reset token to its user without consuming it.
+
+        Split out of :meth:`reset_password` so a caller can place its own side effects
+        between validation and the write. The reset route records the session cutoff in
+        that gap: doing it first means a revocation-store fault leaves the password
+        unchanged and the token unspent, instead of committing a new password while
+        every pre-reset session stays valid.
+
+        :param token: The raw reset token from the reset link.
+        :return: The user the token belongs to.
+        :raises InvalidResetTokenError: If the token is unknown or already used.
+        :raises ResetTokenExpiredError: If the token has expired.
+        """
+        record = self._get_valid_record(token)
+        return self._get_token_user(record)
+
     def reset_password(self, token: str, new_password: str) -> User:
         """Consume a reset token and set the user's new password.
+
+        The token is re-validated here, so a caller that already ran
+        :meth:`resolve_valid_token` still cannot redeem one that was spent in between.
 
         :param token: The raw reset token from the reset link.
         :param new_password: The new plaintext password (already strength-checked).
@@ -101,18 +121,8 @@ class PasswordResetService(BaseService):
         :raises InvalidResetTokenError: If the token is unknown or already used.
         :raises ResetTokenExpiredError: If the token has expired.
         """
-        record = self._session.exec(
-            select(PasswordResetToken).where(PasswordResetToken.token_hash == _hash_token(token))
-        ).first()
-
-        if record is None or record.used_at is not None:
-            raise InvalidResetTokenError(_INVALID_MESSAGE)
-        if ensure_utc(record.expires_at) < utc_now():
-            raise ResetTokenExpiredError(_INVALID_MESSAGE)
-
-        user = self._session.get(User, record.user_id)
-        if user is None:
-            raise InvalidResetTokenError(_INVALID_MESSAGE)
+        record = self._get_valid_record(token)
+        user = self._get_token_user(record)
 
         user.hashed_password = hash_password(new_password)
         record.used_at = utc_now()
@@ -128,6 +138,36 @@ class PasswordResetService(BaseService):
             "Password reset completed",
             extra={"event": "password_reset_completed", "user_id": str(user.id)},
         )
+        return user
+
+    def _get_valid_record(self, token: str) -> PasswordResetToken:
+        """Look up a reset token and reject it unless it is unused and unexpired.
+
+        :param token: The raw reset token from the reset link.
+        :return: The matching token record.
+        :raises InvalidResetTokenError: If the token is unknown or already used.
+        :raises ResetTokenExpiredError: If the token has expired.
+        """
+        record = self._session.exec(
+            select(PasswordResetToken).where(PasswordResetToken.token_hash == _hash_token(token))
+        ).first()
+
+        if record is None or record.used_at is not None:
+            raise InvalidResetTokenError(_INVALID_MESSAGE)
+        if ensure_utc(record.expires_at) < utc_now():
+            raise ResetTokenExpiredError(_INVALID_MESSAGE)
+        return record
+
+    def _get_token_user(self, record: PasswordResetToken) -> User:
+        """Load the user a token record points at.
+
+        :param record: A validated reset-token record.
+        :return: The user that requested the reset.
+        :raises InvalidResetTokenError: If the user no longer exists.
+        """
+        user = self._session.get(User, record.user_id)
+        if user is None:
+            raise InvalidResetTokenError(_INVALID_MESSAGE)
         return user
 
     def _get_user_by_email(self, email: str) -> User | None:

--- a/api/services/project_membership_service.py
+++ b/api/services/project_membership_service.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 from sqlmodel import col, select
 
-from api.db.models import MemberRole, ProjectMember, User
+from api.db.models import ExpertOpinion, MemberRole, ProjectMember, User
 from api.exceptions import MemberNotFoundError
 from api.schemas.internal import MemberWithUser
 from api.services.base import BaseService
@@ -40,26 +40,45 @@ class ProjectMembershipService(BaseService):
         results = self._session.exec(statement).all()
         return [MemberWithUser(membership=membership, user=user) for membership, user in results]
 
-    def remove_member(self, project_id: UUID, user_id: UUID) -> None:
-        """Remove a member from project.
+    def remove_member(self, project_id: UUID, user_id: UUID) -> bool:
+        """Remove a member from project, discarding the opinion they submitted.
+
+        The opinion goes in the same transaction as the membership. It carries the
+        member's identity -- name, email, position -- and is served to every remaining
+        member and embedded in every export, while ``RequireProjectAccess`` stops the
+        ex-member from withdrawing it themselves once their membership row is gone.
 
         :param project_id: Project ID
         :param user_id: User ID to remove
+        :return: True when an opinion was discarded, so the caller can recalculate
         :raises MemberNotFoundError: If user is not a member of the project
         """
         membership = self._get_membership(project_id, user_id)
         if not membership:
             raise MemberNotFoundError(f"User {user_id} is not a member of project {project_id}")
 
-        self._delete_and_commit(membership)
+        opinion = self._session.exec(
+            select(ExpertOpinion).where(
+                ExpertOpinion.project_id == project_id,
+                ExpertOpinion.user_id == user_id,
+            )
+        ).first()
+
+        self._session.delete(membership)
+        if opinion is not None:
+            self._session.delete(opinion)
+        self._session.commit()
+
         logger.info(
             "Member removed",
             extra={
                 "event": "member_removed",
                 "project_id": str(project_id),
                 "user_id": str(user_id),
+                "opinion_discarded": opinion is not None,
             },
         )
+        return opinion is not None
 
     def is_member(self, project_id: UUID, user_id: UUID) -> bool:
         """Check if user is a member of the project.

--- a/api/services/user_service.py
+++ b/api/services/user_service.py
@@ -140,6 +140,35 @@ class UserService(BaseService):
         self._invalidate_cache(saved.id)
         return saved
 
+    def verify_current_password(self, user: User, current_password: str) -> None:
+        """Check a password against the stored hash without writing anything.
+
+        Split out of :meth:`change_password` so a caller can place its own side effects
+        between the check and the write -- the password-change route revokes existing
+        sessions in that gap, which must not happen when the check fails.
+
+        :param user: User whose password to verify
+        :param current_password: Password to compare against the stored hash
+        :raises InvalidCredentialsError: If current password is incorrect
+        """
+        if not verify_password(current_password, user.hashed_password):
+            raise InvalidCredentialsError(
+                "Current password is incorrect",
+                reason="invalid_current_password",
+            )
+
+    def set_password(self, user: User, new_password: str) -> User:
+        """Store a new password hash without verifying the previous one.
+
+        :param user: User to update
+        :param new_password: New password
+        :return: Updated User instance
+        """
+        user.hashed_password = hash_password(new_password)
+        saved = self._save_and_refresh(user)
+        self._invalidate_cache(saved.id)
+        return saved
+
     def change_password(self, user: User, current_password: str, new_password: str) -> User:
         """Change user password.
 
@@ -149,16 +178,8 @@ class UserService(BaseService):
         :return: Updated User instance
         :raises InvalidCredentialsError: If current password is incorrect
         """
-        if not verify_password(current_password, user.hashed_password):
-            raise InvalidCredentialsError(
-                "Current password is incorrect",
-                reason="invalid_current_password",
-            )
-
-        user.hashed_password = hash_password(new_password)
-        saved = self._save_and_refresh(user)
-        self._invalidate_cache(saved.id)
-        return saved
+        self.verify_current_password(user, current_password)
+        return self.set_password(user, new_password)
 
     def delete_user(self, user: User) -> None:
         """Delete user account.

--- a/api/utils/client_ip.py
+++ b/api/utils/client_ip.py
@@ -37,7 +37,9 @@ def get_client_ip(request: Request | None) -> str:
     secret = get_settings().cloudflare_origin_secret
     if secret:
         verify = request.headers.get("X-Origin-Verify")
-        if verify and hmac.compare_digest(verify, secret):
+        # Compare as bytes: compare_digest raises TypeError on a non-ASCII str, which
+        # would turn a junk header into a 500 instead of the unverified-origin path.
+        if verify and hmac.compare_digest(verify.encode(), secret.encode()):
             cloudflare_ip = request.headers.get("CF-Connecting-IP")
             if cloudflare_ip:
                 return cloudflare_ip.strip()

--- a/docs/quality-report.md
+++ b/docs/quality-report.md
@@ -8,7 +8,7 @@
 | ruff check | Pass | No issues |
 | ruff format | Pass | All files formatted |
 | pytest | Pass | 1249 tests passed |
-| coverage | Pass | 100% on `src/`, 99% on `src/`+`api/` overall |
+| coverage | Pass | 100% on `src/` (197 statements), 98% on `src/`+`api/` (3414 statements, 53 uncovered) |
 
 ## Running Checks
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -132,9 +132,19 @@ Logs are structured JSON in the deployed profiles. Each request is tagged with a
 `api.*` log record through contextvars (`api/logging_context.py`), so a service or security
 log line can be traced back to a request without threading identifiers by hand. Personal
 data is kept out of the logs: email addresses are recorded as a truncated SHA-256 hash
-(`email_hash`), not in the clear. Unhandled errors hit a catch-all `500` handler and, when `SENTRY_DSN` is
-configured, Sentry -- with `send_default_pii=False` so request bodies and headers are not
-shipped to the error tracker.
+(`email_hash`), not in the clear. Unhandled errors hit a catch-all `500` handler and, when
+`SENTRY_DSN` is configured, Sentry.
+
+Two separate switches keep credentials out of the tracker, and both are needed.
+`send_default_pii=False` drops the client IP, cookies, headers, and request bodies.
+`include_local_variables=False` drops the frame locals of every traceback frame, which
+`send_default_pii` does not cover and which default to on: the auth handlers bind the parsed
+request body to a local, so with locals enabled a fault anywhere under `register`,
+`change-password`, or `reset-password` would ship `repr()` of that model -- the plaintext
+passwords, or a reset token that is still redeemable -- to the tracker. Sentry's own scrubber
+does not catch this, because it matches local *names* against a denylist and the leaking
+local is called `data`. As a second layer, the credential fields in `api/schemas/auth.py` are
+declared `repr=False`, so those values stay out of any `repr()` regardless of who calls it.
 
 ## Secrets
 
@@ -166,6 +176,35 @@ still admins -- transfer it to another member, or delete it -- and the account i
 only once each owned project has been dealt with. That keeps one person's erasure from
 silently taking a whole panel's opinions with it. The profile-photo blob is deleted from
 object storage as part of the same operation, so erasure covers stored media too.
+
+When an admin removes a member from a project, that member's opinion is deleted in the same
+transaction and the project result is recalculated without it (`remove_member` in
+`api/services/project_membership_service.py`). Otherwise the row would outlive the
+membership: it carries the person's name, email, and stated position, it is served to every
+remaining member and embedded in every export, and `RequireProjectAccess` would no longer
+let the person concerned withdraw it themselves.
+
+## Accepted risks
+
+Two properties are known, deliberate, and reviewed. They are recorded here so a future audit
+does not re-litigate them.
+
+**Registration and invitation disclose whether an address has an account.** `POST /auth/register`
+answers `409 Email already registered` for a taken address, and inviting by email answers
+`404` for an address that has no account. Both are inherent to the flows: registration has to
+tell a returning user that they already have an account, and an invitation cannot be created
+for a user row that does not exist. Closing them means a deferred-activation signup with
+email verification, where the distinguishing branch moves into the mailbox -- a feature, not
+a patch. The bit disclosed is one the caller already supplied, and the login path is
+separately hardened against enumeration (uniform 401, equalized timing), as is
+forgot-password (uniform 202).
+
+**Login and refresh also return the refresh token in the JSON body.** The browser client
+never reads it -- it uses the `HttpOnly` cookie -- but programmatic clients can only obtain
+the token this way, and `POST /auth/refresh` accepts it in the request body for exactly that
+reason. Reading the body value requires script execution on the origin, which the CSP
+(`script-src 'self'`), the explicit CORS allow-list, and `SameSite=Strict` are there to
+prevent; rotation with reuse detection then caps the value of a token that does leak.
 
 ## Database
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -30,7 +30,10 @@ access token and a longer-lived refresh token. Refresh tokens rotate: each refre
 fresh pair tied to a rotation family (a `sid` claim). Presenting a refresh token that has
 already been rotated is treated as theft and revokes the entire family, so a stolen token
 stops working the moment the legitimate client refreshes. Changing the password stamps a
-per-user cutoff that rejects every token issued before it, and the cutoff itself expires
+per-user cutoff that rejects every token issued before it. Both the change and the reset
+route record that cutoff *before* they write the new password, so a revocation-store fault
+aborts the operation instead of leaving a fresh password with every old session still
+alive. The cutoff itself expires
 once the longest-lived token would have, so it is not stored forever.
 
 Passwords are hashed with bcrypt. Because bcrypt silently truncates input at 72 bytes, the

--- a/tests/integration/api/auth/test_auth.py
+++ b/tests/integration/api/auth/test_auth.py
@@ -1069,6 +1069,19 @@ class TestCookieAuth:
 
         assert resp.status_code == 403
 
+    def test_cookie_mutation_with_high_byte_csrf_header_is_rejected(self, cookie_client):
+        """A CSRF header carrying bytes above ASCII is rejected with 403, not a 500.
+
+        Sent as raw bytes because that is how it arrives on the wire; Starlette decodes
+        the header as latin-1, yielding a non-ASCII str. compare_digest raises TypeError
+        on such a str, which would turn a junk header into a 500.
+        """
+        self._register_and_login(cookie_client)
+
+        resp = cookie_client.post("/api/v1/auth/logout", headers={"X-CSRF-Token": b"wr\xc3\xb8ng"})
+
+        assert resp.status_code == 403
+
     def test_refresh_via_cookie_without_body(self, cookie_client):
         """The SPA refreshes using only the refresh cookie (no body) plus the CSRF header."""
         self._register_and_login(cookie_client)

--- a/tests/integration/api/auth/test_password_reset.py
+++ b/tests/integration/api/auth/test_password_reset.py
@@ -6,10 +6,12 @@ sender captures the raw reset token, which the API never returns in a response.
 
 import hashlib
 from datetime import timedelta
+from unittest.mock import patch
 
 import pytest
 from sqlmodel import select
 
+from api.auth.revocation_store import RevocationStoreError
 from api.db.models import PasswordResetToken, User
 from api.db.utils import utc_now
 from api.dependencies import get_email_service
@@ -177,6 +179,43 @@ class TestResetPassword:
 
         # THEN the old access token is rejected
         assert client.get("/api/v1/auth/me", headers=auth_header(access)).status_code == 401
+
+    def test_store_fault_leaves_the_password_and_token_untouched(self, client, fake_email):
+        """A revocation-store fault aborts the reset instead of half-applying it.
+
+        Writing the password first would leave it changed with every pre-reset session
+        still valid -- the exact outcome someone resetting a compromised account is
+        trying to avoid. Recording the cutoff first makes the fault a clean abort.
+        """
+        # GIVEN a user holding a valid reset link, and a store that cannot record the cutoff
+        _register(client, "resetfault@example.com")
+        client.post("/api/v1/auth/forgot-password", json={"email": "resetfault@example.com"})
+        token = _captured_token(fake_email)
+
+        # WHEN the reset runs into the store fault
+        with patch(
+            "api.auth.revocation_store.InMemoryRevocationStore.set_user_valid_after",
+            side_effect=RevocationStoreError("store is down"),
+        ):
+            response = client.post(
+                "/api/v1/auth/reset-password",
+                json={"token": token, "new_password": NEW_PASSWORD},
+            )
+
+        # THEN the request fails, the old password still works, and the link is unspent
+        assert response.status_code == 503
+
+        old_login = client.post(
+            "/api/v1/auth/login",
+            data={"username": "resetfault@example.com", "password": DEFAULT_TEST_PASSWORD},
+        )
+        assert old_login.status_code == 200
+
+        retry = client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": token, "new_password": NEW_PASSWORD},
+        )
+        assert retry.status_code == 204
 
     def test_rejects_unknown_token(self, client):
         """An unknown token is rejected with 400."""

--- a/tests/integration/api/routes/test_photo.py
+++ b/tests/integration/api/routes/test_photo.py
@@ -10,7 +10,11 @@ from sqlmodel import Session
 from api.db.session import get_session
 from api.dependencies import get_storage_service
 from api.services.storage.base import StorageService
-from api.services.storage.exceptions import StorageDeleteError, StorageUploadError
+from api.services.storage.exceptions import (
+    StorageDeleteError,
+    StorageError,
+    StorageUploadError,
+)
 from tests.integration.api.conftest import auth_header, create_test_app, register_and_login
 
 # Valid JPEG magic bytes (minimal valid JPEG header)
@@ -348,6 +352,34 @@ class TestPhotoProxy:
 
         # THEN
         assert response.status_code == 404
+
+    def test_storage_fault_does_not_leak_the_bucket_details(self, client_with_mock_storage):
+        """A storage read fault answers 404 without echoing the underlying error.
+
+        This endpoint is public (image tags cannot send auth headers), and the wrapped
+        botocore message carries the bucket host and object key.
+        """
+        # GIVEN - a user with a photo, and storage that fails on read
+        client, mock_storage = client_with_mock_storage
+        token = register_and_login(client, "fault@example.com")
+        user_id = client.get("/api/v1/users/me", headers=auth_header(token)).json()["id"]
+        client.post(
+            "/api/v1/users/me/photo",
+            headers=auth_header(token),
+            files={"file": ("photo.jpg", VALID_JPEG_BYTES, "image/jpeg")},
+        )
+        mock_storage.open.side_effect = StorageError(
+            "Failed to read file: Could not connect to the endpoint URL: "
+            f"https://private-bucket.example/{UPLOADED_KEY}"
+        )
+
+        # WHEN
+        response = client.get(f"/api/v1/users/{user_id}/photo")
+
+        # THEN
+        assert response.status_code == 404
+        assert response.json() == {"detail": "Photo not found"}
+        assert "private-bucket" not in response.text
 
 
 class TestAccountDeletionRemovesPhoto:

--- a/tests/integration/api/routes/test_projects.py
+++ b/tests/integration/api/routes/test_projects.py
@@ -3,7 +3,12 @@
 from unittest.mock import patch
 
 from api.services.project_membership_service import ProjectMembershipService
-from tests.integration.api.conftest import auth_header, create_project, register_and_login
+from tests.integration.api.conftest import (
+    auth_header,
+    create_project,
+    register_and_login,
+    submit_opinion,
+)
 
 
 def _add_expert(client, owner_token, project_id, email):
@@ -487,6 +492,44 @@ class TestListMembers:
 
 class TestRemoveMember:
     """Tests for DELETE /api/v1/projects/{id}/members/{user_id}."""
+
+    def test_removal_discards_the_opinion_and_recalculates(self, client):
+        """Removing a member drops their opinion and the result stops counting them.
+
+        The opinion carries the ex-member's email, name, and position, it is served
+        to every remaining member and embedded in exports, and after removal the
+        person concerned can no longer delete it themselves (the project 404s for them).
+        """
+        # GIVEN a project where both the admin and an expert submitted an opinion
+        owner = register_and_login(client, "owner@example.com")
+        project = create_project(client, owner)
+        submit_opinion(client, owner, project["id"], 30.0, 50.0, 70.0)
+        expert, expert_id = _add_expert(client, owner, project["id"], "expert@example.com")
+        submit_opinion(client, expert, project["id"], 10.0, 20.0, 30.0)
+
+        before = client.get(
+            f"/api/v1/projects/{project['id']}/result", headers=auth_header(owner)
+        ).json()
+        assert before["num_experts"] == 2
+
+        # WHEN the admin removes the expert
+        response = client.delete(
+            f"/api/v1/projects/{project['id']}/members/{expert_id}",
+            headers=auth_header(owner),
+        )
+
+        # THEN the opinion is gone from the listing and from the recalculated result
+        assert response.status_code == 204
+
+        opinions = client.get(
+            f"/api/v1/projects/{project['id']}/opinions", headers=auth_header(owner)
+        ).json()
+        assert [item["user_email"] for item in opinions] == ["owner@example.com"]
+
+        after = client.get(
+            f"/api/v1/projects/{project['id']}/result", headers=auth_header(owner)
+        ).json()
+        assert after["num_experts"] == 1
 
     def test_remove_member_self_fails(self, client):
         """Admin cannot remove themselves."""

--- a/tests/integration/api/routes/test_users.py
+++ b/tests/integration/api/routes/test_users.py
@@ -1,7 +1,10 @@
 """Tests for DELETE /api/v1/users/me endpoint."""
 
+from unittest.mock import patch
+
 from fastapi import status
 
+from api.auth.revocation_store import RevocationStoreError
 from tests.integration.api.conftest import (
     DEFAULT_TEST_PASSWORD,
     auth_header,
@@ -275,3 +278,35 @@ class TestChangePasswordRevokesSessions:
 
         # THEN the old token no longer works
         assert client.get("/api/v1/auth/me", headers=auth_header(token)).status_code == 401
+
+    def test_store_fault_leaves_the_old_password_in_place(self, client):
+        """When the session cutoff cannot be written, the password is not changed either.
+
+        Otherwise the caller sees a failure while the new password is already live and
+        every session issued before it stays valid.
+        """
+        # GIVEN a logged-in user and a revocation store that cannot record the cutoff
+        token = register_and_login(client, "storefault@example.com")
+
+        # WHEN the password change runs into the store fault
+        with patch(
+            "api.auth.revocation_store.InMemoryRevocationStore.set_user_valid_after",
+            side_effect=RevocationStoreError("store is down"),
+        ):
+            resp = client.put(
+                "/api/v1/users/me/password",
+                headers=auth_header(token),
+                json={
+                    "current_password": DEFAULT_TEST_PASSWORD,
+                    "new_password": "NewSecurePass456!",
+                },
+            )
+
+        # THEN the request fails and the original password still authenticates
+        assert resp.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
+        login = client.post(
+            "/api/v1/auth/login",
+            data={"username": "storefault@example.com", "password": DEFAULT_TEST_PASSWORD},
+        )
+        assert login.status_code == status.HTTP_200_OK

--- a/tests/unit/api/schemas/test_auth.py
+++ b/tests/unit/api/schemas/test_auth.py
@@ -5,7 +5,9 @@ from pydantic import ValidationError
 
 from api.schemas.auth import (
     ChangePasswordRequest,
+    RefreshTokenRequest,
     RegisterRequest,
+    ResetPasswordRequest,
     UpdateUserRequest,
     validate_name_format,
     validate_password_strength,
@@ -339,3 +341,87 @@ class TestChangePasswordRequest:
                 current_password="old_password",
                 new_password="weakpassword1!",
             )
+
+
+class TestCredentialFieldsStayOutOfRepr:
+    """Credential values must never appear in a model repr.
+
+    Anything that reprs a request model -- a log record, a debugger, a traceback frame
+    shipped to an error tracker -- would otherwise carry live credentials. The field
+    values stay reachable through attribute access, only the repr drops them.
+    """
+
+    def test_register_request_hides_password(self):
+        """
+        GIVEN a registration request carrying a password
+        WHEN the model is repr'd
+        THEN the password value is absent while the email is still shown
+        """
+        # GIVEN
+        request = RegisterRequest(
+            email="user@example.com",
+            password="SecurePass123!",
+            first_name="Test",
+            last_name="User",
+        )
+
+        # WHEN
+        rendered = repr(request)
+
+        # THEN
+        assert "SecurePass123!" not in rendered
+        assert "user@example.com" in rendered
+        assert request.password == "SecurePass123!"
+
+    def test_change_password_request_hides_both_passwords(self):
+        """
+        GIVEN a password-change request
+        WHEN the model is repr'd
+        THEN neither the current nor the new password appears
+        """
+        # GIVEN
+        request = ChangePasswordRequest(
+            current_password="old_password",
+            new_password="NewSecure123!",
+        )
+
+        # WHEN
+        rendered = repr(request)
+
+        # THEN
+        assert "old_password" not in rendered
+        assert "NewSecure123!" not in rendered
+
+    def test_reset_password_request_hides_token_and_password(self):
+        """
+        GIVEN a reset-password request carrying a single-use token
+        WHEN the model is repr'd
+        THEN neither the token nor the new password appears
+        """
+        # GIVEN
+        request = ResetPasswordRequest(
+            token="a-live-single-use-reset-token",
+            new_password="NewSecure123!",
+        )
+
+        # WHEN
+        rendered = repr(request)
+
+        # THEN
+        assert "a-live-single-use-reset-token" not in rendered
+        assert "NewSecure123!" not in rendered
+
+    def test_refresh_token_request_hides_the_token(self):
+        """
+        GIVEN a refresh request carrying a long-lived token
+        WHEN the model is repr'd
+        THEN the token value is absent
+        """
+        # GIVEN
+        request = RefreshTokenRequest(refresh_token="a-long-lived-refresh-token")
+
+        # WHEN
+        rendered = repr(request)
+
+        # THEN
+        assert "a-long-lived-refresh-token" not in rendered

--- a/tests/unit/api/services/test_email.py
+++ b/tests/unit/api/services/test_email.py
@@ -30,7 +30,7 @@ class TestConsoleEmailSender:
     _RAW_TOKEN = "S3cret-Reset-Token-abcdefghijklmnop-1234567890"
     _RESET_URL = f"https://app.example/reset-password?token={_RAW_TOKEN}"
 
-    def _send(self, mock_logger_attr: str = "logger"):
+    def _send(self):
         """Send a reset email through the console sender with the logger patched."""
         sender = ConsoleEmailSender(_settings())
         with patch("api.services.email.console_email_sender.logger") as mock_logger:
@@ -54,18 +54,39 @@ class TestConsoleEmailSender:
         assert self._RAW_TOKEN not in info_str
         assert "..." in info_str
 
-    def test_debug_log_keeps_the_full_link_for_local_dev(self):
+    def test_no_log_record_carries_the_redeemable_link(self):
         """
         GIVEN a console email sender
         WHEN a password reset email is sent
-        THEN the full link stays available at DEBUG so the dev flow still works
+        THEN no record reaches the logger with the full link
+
+        Records travel to the rotating file handler and, when configured, to the
+        Better Stack drain. A redeemable token must not ride along on either.
         """
         # WHEN
         mock_logger = self._send()
 
         # THEN
-        mock_logger.debug.assert_called_once()
-        assert self._RESET_URL in str(mock_logger.debug.call_args)
+        for method in (mock_logger.debug, mock_logger.info, mock_logger.warning):
+            for call in method.call_args_list:
+                assert self._RAW_TOKEN not in str(call)
+
+    def test_full_link_goes_to_stdout_for_local_dev(self, capsys):
+        """
+        GIVEN a console email sender
+        WHEN a password reset email is sent
+        THEN the full link is printed, so the offline dev flow still works
+        """
+        # GIVEN
+        sender = ConsoleEmailSender(_settings())
+
+        # WHEN
+        asyncio.run(
+            sender.send_password_reset(to_email="user@example.com", reset_url=self._RESET_URL)
+        )
+
+        # THEN
+        assert self._RESET_URL in capsys.readouterr().out
 
 
 class TestMaskToken:

--- a/tests/unit/api/services/test_password_reset.py
+++ b/tests/unit/api/services/test_password_reset.py
@@ -118,6 +118,86 @@ class TestCreateResetToken:
         assert first.used_at is not None
 
 
+class TestResolveValidToken:
+    """Tests for resolving a reset token without consuming it."""
+
+    def test_returns_the_user_without_touching_the_token(self, session):
+        """
+        GIVEN a valid reset token
+        WHEN the token is resolved
+        THEN its user is returned, the password is unchanged, and the token stays unused
+        """
+        # GIVEN
+        user = _make_user(session)
+        original_hash = user.hashed_password
+        service = PasswordResetService(session)
+        token = _token_from_url(service.create_reset_token(user.email))
+
+        # WHEN
+        resolved = service.resolve_valid_token(token)
+
+        # THEN
+        assert resolved.id == user.id
+        assert resolved.hashed_password == original_hash
+        record = session.exec(
+            select(PasswordResetToken).where(PasswordResetToken.token_hash == _hash(token))
+        ).first()
+        assert record is not None
+        assert record.used_at is None
+
+    def test_raises_for_unknown_token(self, session):
+        """
+        GIVEN a token that does not exist
+        WHEN it is resolved
+        THEN InvalidResetTokenError is raised
+        """
+        # GIVEN
+        service = PasswordResetService(session)
+
+        # WHEN / THEN
+        with pytest.raises(InvalidResetTokenError):
+            service.resolve_valid_token("garbage-token")
+
+    def test_raises_for_already_used_token(self, session):
+        """
+        GIVEN a token that has already been redeemed
+        WHEN it is resolved
+        THEN InvalidResetTokenError is raised
+        """
+        # GIVEN
+        user = _make_user(session)
+        service = PasswordResetService(session)
+        token = _token_from_url(service.create_reset_token(user.email))
+        service.reset_password(token, "NewSecurePass123!")
+
+        # WHEN / THEN
+        with pytest.raises(InvalidResetTokenError):
+            service.resolve_valid_token(token)
+
+    def test_raises_for_expired_token(self, session):
+        """
+        GIVEN a token whose expiry is in the past
+        WHEN it is resolved
+        THEN ResetTokenExpiredError is raised
+        """
+        # GIVEN
+        user = _make_user(session)
+        raw = "expired-raw-token-value"
+        session.add(
+            PasswordResetToken(
+                user_id=user.id,
+                token_hash=_hash(raw),
+                expires_at=utc_now() - timedelta(hours=1),
+            )
+        )
+        session.commit()
+        service = PasswordResetService(session)
+
+        # WHEN / THEN
+        with pytest.raises(ResetTokenExpiredError):
+            service.resolve_valid_token(raw)
+
+
 class TestResetPassword:
     """Tests for redeeming reset tokens."""
 

--- a/tests/unit/api/services/test_project_membership.py
+++ b/tests/unit/api/services/test_project_membership.py
@@ -1,11 +1,11 @@
 """Unit tests for ProjectMembershipService."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 from uuid import uuid4
 
 import pytest
 
-from api.db.models import MemberRole, ProjectMember, User
+from api.db.models import ExpertOpinion, MemberRole, ProjectMember, User
 from api.exceptions import MemberNotFoundError
 from api.services.project_membership_service import ProjectMembershipService
 
@@ -67,15 +67,42 @@ class TestProjectMembershipServiceRemoveMember:
             role=MemberRole.EXPERT,
         )
         mock_session = MagicMock()
-        mock_session.exec.return_value.first.return_value = membership
+        # Second lookup is the member's opinion; this member submitted none.
+        mock_session.exec.return_value.first.side_effect = [membership, None]
         service = ProjectMembershipService(mock_session)
 
         # WHEN
-        service.remove_member(project_id, user_id)
+        discarded = service.remove_member(project_id, user_id)
 
         # THEN
         mock_session.delete.assert_called_once_with(membership)
         mock_session.commit.assert_called_once()
+        assert discarded is False
+
+    def test_discards_opinion_with_the_membership(self):
+        """The removed member's opinion is deleted in the same transaction."""
+        # GIVEN
+        project_id = uuid4()
+        user_id = uuid4()
+        membership = ProjectMember(project_id=project_id, user_id=user_id, role=MemberRole.EXPERT)
+        opinion = ExpertOpinion(
+            project_id=project_id,
+            user_id=user_id,
+            lower_bound=1.0,
+            peak=2.0,
+            upper_bound=3.0,
+        )
+        mock_session = MagicMock()
+        mock_session.exec.return_value.first.side_effect = [membership, opinion]
+        service = ProjectMembershipService(mock_session)
+
+        # WHEN
+        discarded = service.remove_member(project_id, user_id)
+
+        # THEN
+        assert mock_session.delete.call_args_list == [call(membership), call(opinion)]
+        mock_session.commit.assert_called_once()
+        assert discarded is True
 
     def test_raises_error_when_not_member(self):
         """MemberNotFoundError is raised when user is not a member."""
@@ -95,7 +122,7 @@ class TestProjectMembershipServiceRemoveMember:
         user_id = uuid4()
         membership = ProjectMember(project_id=project_id, user_id=user_id, role=MemberRole.EXPERT)
         mock_session = MagicMock()
-        mock_session.exec.return_value.first.return_value = membership
+        mock_session.exec.return_value.first.side_effect = [membership, None]
         service = ProjectMembershipService(mock_session)
 
         # WHEN
@@ -107,6 +134,7 @@ class TestProjectMembershipServiceRemoveMember:
         assert extra["event"] == "member_removed"
         assert extra["project_id"] == str(project_id)
         assert extra["user_id"] == str(user_id)
+        assert extra["opinion_discarded"] is False
 
 
 class TestProjectMembershipServiceIsMember:

--- a/tests/unit/api/test_config.py
+++ b/tests/unit/api/test_config.py
@@ -195,6 +195,8 @@ class TestEnvironmentResolution:
         monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
         monkeypatch.setenv("CLOUDFLARE_ORIGIN_SECRET", "an-origin-verify-secret")
         monkeypatch.setenv("CORS_ORIGINS", '["https://app.example.com"]')
+        monkeypatch.setenv("EMAIL_PROVIDER", "http")
+        monkeypatch.setenv("EMAIL_API_KEY", "a-resend-api-key")
 
         # WHEN
         settings = Settings()
@@ -328,6 +330,8 @@ class TestProductionInvariants:
         monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
         monkeypatch.setenv("CLOUDFLARE_ORIGIN_SECRET", "an-origin-verify-secret")
         monkeypatch.setenv("CORS_ORIGINS", '["https://app.example.com"]')
+        monkeypatch.setenv("EMAIL_PROVIDER", "http")
+        monkeypatch.setenv("EMAIL_API_KEY", "a-resend-api-key")
 
         # WHEN
         settings = Settings()
@@ -405,6 +409,48 @@ class TestProductionInvariants:
         with pytest.raises(ValidationError, match="cors_origins"):
             Settings()
 
+    def test_rejects_unconfigured_email_in_production(self, monkeypatch, tmp_path):
+        """
+        GIVEN the production profile with the HTTP email provider but no API key
+        WHEN Settings is constructed
+        THEN validation fails, so the console sender cannot silently take over and
+            write reset links to the log instead of delivering them
+        """
+        # GIVEN
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("SECRET_KEY", "a-sufficiently-strong-secret-value")
+        monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@host:5432/db")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        monkeypatch.setenv("CLOUDFLARE_ORIGIN_SECRET", "an-origin-verify-secret")
+        monkeypatch.setenv("CORS_ORIGINS", '["https://app.example.com"]')
+        monkeypatch.setenv("EMAIL_PROVIDER", "http")
+        monkeypatch.delenv("EMAIL_API_KEY", raising=False)
+
+        # WHEN / THEN
+        with pytest.raises(ValidationError, match="email_api_key is required"):
+            Settings()
+
+    def test_rejects_console_email_provider_in_production(self, monkeypatch, tmp_path):
+        """
+        GIVEN the production profile left on the console email provider
+        WHEN Settings is constructed
+        THEN validation fails
+        """
+        # GIVEN
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("SECRET_KEY", "a-sufficiently-strong-secret-value")
+        monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@host:5432/db")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        monkeypatch.setenv("CLOUDFLARE_ORIGIN_SECRET", "an-origin-verify-secret")
+        monkeypatch.setenv("CORS_ORIGINS", '["https://app.example.com"]')
+        monkeypatch.setenv("EMAIL_PROVIDER", "console")
+
+        # WHEN / THEN
+        with pytest.raises(ValidationError, match="email_api_key is required"):
+            Settings()
+
 
 class TestStagingInvariants:
     """The staging (TEST) profile enforces the same core invariants as prod."""
@@ -422,6 +468,8 @@ class TestStagingInvariants:
         monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@host:5432/db")
         monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
         monkeypatch.setenv("CORS_ORIGINS", '["https://staging.example.com"]')
+        monkeypatch.setenv("EMAIL_PROVIDER", "http")
+        monkeypatch.setenv("EMAIL_API_KEY", "a-resend-api-key")
 
     def test_accepts_fully_configured_staging_without_cloudflare(self, monkeypatch, tmp_path):
         """
@@ -493,6 +541,20 @@ class TestStagingInvariants:
 
         # WHEN / THEN
         with pytest.raises(ValidationError, match="SQLite"):
+            Settings()
+
+    def test_rejects_unconfigured_email_in_staging(self, monkeypatch, tmp_path):
+        """
+        GIVEN the deployed staging profile with no email API key
+        WHEN Settings is constructed
+        THEN validation fails
+        """
+        # GIVEN
+        self._configure_staging(monkeypatch, tmp_path)
+        monkeypatch.delenv("EMAIL_API_KEY", raising=False)
+
+        # WHEN / THEN
+        with pytest.raises(ValidationError, match="email_api_key is required"):
             Settings()
 
 

--- a/tests/unit/api/test_logging_config.py
+++ b/tests/unit/api/test_logging_config.py
@@ -30,6 +30,8 @@ def _settings(
         redis_url="redis://localhost:6379/0",
         cloudflare_origin_secret="an-origin-verify-secret-for-tests",
         cors_origins=["https://app.example.com"],
+        email_provider="http",
+        email_api_key="a-resend-api-key-for-tests",
     )
 
 

--- a/tests/unit/api/test_main.py
+++ b/tests/unit/api/test_main.py
@@ -1,5 +1,10 @@
 """Tests for application factory wiring in api.main."""
 
+from unittest.mock import patch
+
+# Not a credential: the host is unroutable and the key is a literal placeholder.
+_FAKE_DSN = "https://placeholder@localhost/0"
+
 
 def _prod_env(monkeypatch, tmp_path) -> None:
     """Configure a valid production environment for Settings."""
@@ -10,6 +15,8 @@ def _prod_env(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
     monkeypatch.setenv("CLOUDFLARE_ORIGIN_SECRET", "an-origin-verify-secret")
     monkeypatch.setenv("CORS_ORIGINS", '["https://app.example.com"]')
+    monkeypatch.setenv("EMAIL_PROVIDER", "http")
+    monkeypatch.setenv("EMAIL_API_KEY", "a-resend-api-key")
 
 
 class TestDocsExposure:
@@ -37,3 +44,52 @@ class TestDocsExposure:
             assert app.redoc_url is None
         finally:
             get_settings.cache_clear()
+
+
+class TestSentryInit:
+    """Sentry is initialised so no credential can ride along on an event."""
+
+    def test_is_a_no_op_without_a_dsn(self):
+        """
+        GIVEN no Sentry DSN is configured
+        WHEN _init_sentry runs
+        THEN no client is created, keeping development and tests offline
+        """
+        # GIVEN
+        from api.config import Settings
+        from api.main import _init_sentry
+
+        settings = Settings(sentry_dsn="")
+
+        # WHEN
+        with patch("api.main.sentry_sdk.init") as mock_init:
+            _init_sentry(settings)
+
+        # THEN
+        mock_init.assert_not_called()
+
+    def test_disables_frame_locals_and_pii(self):
+        """
+        GIVEN a configured Sentry DSN
+        WHEN _init_sentry runs
+        THEN frame locals are off as well as default PII
+
+        include_local_variables is a separate switch that send_default_pii does not
+        govern, and it defaults to on. The auth handlers bind the parsed request body
+        to a local, so with locals enabled any fault under register / change-password /
+        reset-password would ship plaintext passwords and reset tokens to the tracker.
+        """
+        # GIVEN
+        from api.config import Settings
+        from api.main import _init_sentry
+
+        settings = Settings(sentry_dsn=_FAKE_DSN)
+
+        # WHEN
+        with patch("api.main.sentry_sdk.init") as mock_init:
+            _init_sentry(settings)
+
+        # THEN
+        kwargs = mock_init.call_args.kwargs
+        assert kwargs["include_local_variables"] is False
+        assert kwargs["send_default_pii"] is False

--- a/tests/unit/api/test_route_authorization.py
+++ b/tests/unit/api/test_route_authorization.py
@@ -1,0 +1,98 @@
+"""Structural guard: every project-scoped route declares an access check.
+
+Migration ``c83186b79ad7`` deliberately dropped row-level security, so tenant
+isolation rests entirely on ``RequireProjectAccess`` being wired into each route that
+takes a ``project_id``. Nothing in the framework enforces that. A route added without
+the dependency would read and write another tenant's data with no second line of
+defence, and it would look perfectly ordinary in review -- hence this test.
+"""
+
+from collections.abc import Iterable, Iterator
+
+from fastapi.dependencies.models import Dependant
+from fastapi.routing import APIRoute
+
+from api.dependencies import RequireProjectAccess
+from api.main import create_app
+
+PROJECT_ID_PARAM = "{project_id}"
+
+
+def _declares_project_access(dependant: Dependant) -> bool:
+    """Report whether a route's dependency tree contains a project access check.
+
+    :param dependant: The route's resolved dependency tree.
+    :return: True when ``RequireProjectAccess`` appears anywhere in the tree.
+    """
+    if isinstance(dependant.call, RequireProjectAccess):
+        return True
+    return any(_declares_project_access(sub) for sub in dependant.dependencies)
+
+
+def _iter_api_routes(routes: Iterable[object]) -> Iterator[APIRoute]:
+    """Walk a route list and yield every ``APIRoute``, descending into sub-routers.
+
+    ``app.routes`` does not necessarily hold the endpoints directly: FastAPI wraps an
+    included router in a container that keeps the real router under
+    ``original_router``. Both shapes are handled so the walk does not depend on that
+    internal layout.
+
+    :param routes: Routes or route containers to walk.
+    :return: Iterator over the concrete API routes found.
+    """
+    for route in routes:
+        if isinstance(route, APIRoute):
+            yield route
+            continue
+        nested = getattr(route, "routes", None)
+        if nested is None:
+            inner_router = getattr(route, "original_router", None)
+            nested = getattr(inner_router, "routes", None)
+        if nested is not None:
+            yield from _iter_api_routes(nested)
+
+
+def _project_scoped_routes() -> list[APIRoute]:
+    """Collect every route whose path carries a ``project_id`` segment.
+
+    :return: The project-scoped API routes of the application.
+    """
+    return [
+        route for route in _iter_api_routes(create_app().routes) if PROJECT_ID_PARAM in route.path
+    ]
+
+
+class TestProjectScopedRoutesAreGuarded:
+    """Tenant isolation is enforced on the routes that can cross tenants."""
+
+    def test_there_are_project_scoped_routes_to_check(self):
+        """
+        GIVEN the application factory
+        WHEN project-scoped routes are collected
+        THEN some are found, so the guard below is not vacuously true
+        """
+        # WHEN
+        routes = _project_scoped_routes()
+
+        # THEN
+        assert routes, "no {project_id} routes found -- the guard below would pass vacuously"
+
+    def test_every_project_scoped_route_requires_project_access(self):
+        """
+        GIVEN every route that takes a project_id
+        WHEN its dependency tree is inspected
+        THEN RequireProjectAccess is part of it
+
+        Add the ProjectMember or ProjectAdmin dependency to a failing route rather
+        than relaxing this test: without it, any authenticated caller reaches another
+        tenant's project.
+        """
+        # WHEN
+        unguarded = [
+            f"{sorted(route.methods)} {route.path}"
+            for route in _project_scoped_routes()
+            if not _declares_project_access(route.dependant)
+        ]
+
+        # THEN
+        assert not unguarded, f"project-scoped routes without an access check: {unguarded}"

--- a/tests/unit/api/utils/test_client_ip.py
+++ b/tests/unit/api/utils/test_client_ip.py
@@ -111,6 +111,16 @@ class TestOriginSecretConfigured:
             request = _request({"X-Origin-Verify": "nope", "CF-Connecting-IP": "1.2.3.4"})
             assert get_client_ip(request) == "unverified-origin"
 
+    def test_non_ascii_verify_header_is_unverified(self):
+        """GIVEN a non-ASCII verify header WHEN extracting THEN the sentinel is returned.
+
+        compare_digest raises TypeError on a non-ASCII str, which would surface as a
+        500 from every request carrying such a header instead of this quiet rejection.
+        """
+        with _with_secret(_SECRET):
+            request = _request({"X-Origin-Verify": "secrét", "CF-Connecting-IP": "1.2.3.4"})
+            assert get_client_ip(request) == "unverified-origin"
+
 
 def test_returns_unknown_for_none_request():
     """GIVEN no request WHEN extracting THEN it is 'unknown'."""


### PR DESCRIPTION
## Why

A security review over the whole codebase produced one finding that survived adversarial verification, plus several gaps worth closing while the code was open. The confirmed one sends live user credentials to an external service.

## The leak

`sentry_sdk.init()` set `send_default_pii=False` but not `include_local_variables=False`. That second switch defaults to on and is resolved independently of the first, so every traceback frame shipped `repr()` of its locals. The auth handlers bind the parsed request body to a local named `data`:

- `RegisterRequest` — plaintext password and email
- `ChangePasswordRequest` — old and new plaintext passwords
- `ResetPasswordRequest` — a reset token that is still redeemable, plus the new password

Sentry's own scrubber does not catch this: it matches local *names* against a denylist, exactly and non-recursively, and the leaking local is called `data` (`new_password` would not match `password` either). Two capture paths reach the tracker — `logger.error(..., exc_info=exc)` in the exception handlers, and Starlette's `ServerErrorMiddleware`, which re-raises after sending the 500.

No attacker is needed to trigger it. A Redis fault makes `store.set_user_valid_after(...)` raise inside `change_password` / `reset_password`, and the 503 handler logs it with the frame still holding `data`.

Fixed by turning frame locals off, and by marking the credential fields `repr=False` as a second layer that also covers log records and any future integration. The comment in `main.py`, `docs/security.md`, and the `sentry-observability` skill all asserted the wrong thing and are corrected.

## Also in this PR

| Change | Why |
|---|---|
| All four storage exceptions mapped in `EXCEPTION_MAP`; `StorageError` caught in the photo route | It was the one storage exception with neither a catch nor a mapping, so raw botocore text (bucket host, object key) reached the **public** photo endpoint. The map matches types exactly, so each subclass needs its own entry. |
| `change_password` revokes sessions before writing; `UserService` split into `verify_current_password` + `set_password` | A store fault used to leave the new password committed with old sessions alive. Splitting the verification keeps a mistyped current password from logging the user out everywhere — a plain reorder would have done exactly that. |
| `remove_member` discards the member's opinion in the same transaction, then recalculates | The row outlived the membership: it kept serving the person's name, email, and position to remaining members and to every export, and `RequireProjectAccess` left them unable to withdraw it (GDPR Art. 17). |
| Deployed profiles reject an unconfigured email provider at startup; console sender hashes recipients | `EMAIL_API_KEY` empty meant a silent fallback to the console sender: no mail delivered, and recipient addresses logged in the clear against the `email_hash`-only invariant. The key was verified present on dev/staging/prod before adding the check. |
| CSRF and origin-verify headers compared as bytes | `compare_digest` raises `TypeError` on a non-ASCII `str`, so a header carrying high bytes returned 500 instead of 403. |
| `/auth/me` builds its response through `UserResponse.from_user` | It hand-rolled the model and returned the raw object key instead of the photo proxy URL, unlike every sibling endpoint. |

## Not changed, on purpose

Registration and invite-by-email disclose whether an address has an account, and login/refresh also return the refresh token in the JSON body. Both were checked and both come out as accepted risks — the first needs a full email-verification flow rather than a patch, the second is the contract programmatic clients depend on. `docs/security.md` now records them so the next review does not re-litigate them.

## Verification

- `pytest tests/unit tests/integration` — 1249 passed; coverage 100% on `src/`, 98% on `src/`+`api/`
- `ruff check` / `ruff format --check` / `mypy` (96 files) / `bandit` (0 medium+) / `detect-secrets` — all clean
- New tests cover each fix, including a structural one asserting all 13 `{project_id}` routes declare an access check. Row-level security is deliberately off, so that dependency is the only thing between a new route and a cross-tenant read.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens credential handling and several adjacent security-sensitive flows.

- Disables Sentry frame-local capture and marks authentication credentials as excluded from model representations.
- Sanitizes storage failures, hashes console-email recipients, validates deployed email configuration, and compares security headers as bytes.
- Changes password-update sequencing, removes departed members' opinions with recalculation, and normalizes the `/auth/me` response.
- Adds integration and unit coverage for the updated security and authorization behavior.

<h3>Confidence Score: 2/5</h3>

The PR should not merge until live reset-token logging and the two newly non-atomic state transitions are corrected.

A DEBUG configuration can still disclose a redeemable reset token, member removal can leave a persisted result inconsistent with committed opinions, and a failed password write can revoke every session without changing the password.

**Files Needing Attention:** api/services/email/console_email_sender.py, api/services/project_membership_service.py, api/routes/projects.py, api/routes/users.py

<details open><summary><h3>Security Review</h3></summary>

The console email sender still emits the complete live reset URL at DEBUG level, and `APP_ENV=dev` remains able to select that sender in a deployed environment.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| api/services/email/console_email_sender.py | Hashes recipient addresses and masks INFO output, but retains a DEBUG record containing the complete live reset token. |
| api/services/project_membership_service.py | Deletes a member and opinion together, but commits before the route performs the required result recalculation. |
| api/routes/projects.py | Adds recalculation after member removal as a separate, non-atomic operation. |
| api/routes/users.py | Prevents password writes after revocation-store failure but can apply revocation alone when the subsequent password write fails. |
| api/main.py | Correctly disables Sentry frame-local capture in addition to default PII collection. |
| api/middleware/exception_handlers.py | Adds opaque mappings for all storage exception types to prevent raw provider details reaching clients. |
| api/schemas/auth.py | Excludes password and token fields from Pydantic representations as defense in depth. |
| api/config.py | Rejects console or incompletely configured email delivery in staging and production, but intentionally leaves development unrestricted. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Admin
  participant Route
  participant Membership
  participant DB
  participant Calculation
  Admin->>Route: DELETE project member
  Route->>Membership: remove_member(project, user)
  Membership->>DB: Delete membership and opinion
  Membership->>DB: Commit
  Membership-->>Route: opinion discarded
  Route->>Calculation: recalculate(project)
  Calculation->>DB: Update or delete persisted result
```
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. `api/services/project_membership_service.py`, line 87-90 ([link](https://github.com/caitlon/become/blob/50befe1805c1478735235b6eee52f606e0171e30/api/services/project_membership_service.py#L87-L90)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Result update is non-atomic**

   When recalculation raises after a member with an opinion is removed, this commit permanently deletes the membership and opinion before the route updates the persisted result. The request then fails while the old result remains readable and still includes the removed member's contribution.

   **Rule Used:** Services collaborate through constructor injection... ([source](.greptile))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: api/services/project_membership_service.py
   Line: 87-90
   
   Comment:
   **Result update is non-atomic**
   
   When recalculation raises after a member with an opinion is removed, this commit permanently deletes the membership and opinion before the route updates the persisted result. The request then fails while the old result remains readable and still includes the removed member's contribution.
   
   **Rule Used:** Services collaborate through constructor injection... ([source](.greptile))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
api/services/email/console_email_sender.py:75-80
**Live reset token remains logged**

When the console provider runs with `LOG_LEVEL=DEBUG`, this record writes the complete, still-redeemable reset URL to console, file, or configured Better Stack output. `APP_ENV=dev` skips the new email-provider invariant and can select this sender in the deployed development environment, so the token remains exposed outside the intended email flow.

**How this was verified:** The freshly generated raw token reaches this unmasked DEBUG sink while the development profile permits the console sender.

### Issue 2 of 3
api/services/project_membership_service.py:87-90
**Result update is non-atomic**

When recalculation raises after a member with an opinion is removed, this commit permanently deletes the membership and opinion before the route updates the persisted result. The request then fails while the old result remains readable and still includes the removed member's contribution.

### Issue 3 of 3
api/routes/users.py:138-140
**Revocation precedes password commit**

When the revocation-store write succeeds but hashing or committing the new password raises, this ordering invalidates every existing session while leaving the old password unchanged. The request returns an error after applying only the revocation half of the password change, unexpectedly logging the user out everywhere.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: refresh the secrets baseline for ..."](https://github.com/caitlon/become/commit/50befe1805c1478735235b6eee52f606e0171e30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47406326)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Rule used - Keep endpoints thin. Business logic belongs in ser... ([source](.greptile))
- Rule used - Services collaborate through constructor injection... ([source](.greptile))
- File used - api/README.md ([source](api/README.md))
</details>


<!-- /greptile_comment -->