### PR TITLE
chore: send a CSP from the SPA and hold every deployed service to the invariants

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -7,9 +7,10 @@
 # Generate: openssl rand -hex 32
 SECRET_KEY=
 DATABASE_URL=postgresql://user:password@host:5432/become
-# Optional: privileged URL used only by Alembic migrations (DDL), so DATABASE_URL
-# above can run as a least-privilege role. Falls back to DATABASE_URL when unset.
-MIGRATION_DATABASE_URL=
+# Required here: privileged URL used only by Alembic migrations (DDL), so DATABASE_URL
+# above can run as a least-privilege role. Startup fails when it is unset here, so
+# the split is never silently lost; set it explicitly even if it matches DATABASE_URL.
+MIGRATION_DATABASE_URL=postgresql://migrator:password@host:5432/become
 DEBUG=false
 CORS_ORIGINS=["https://your-domain.example"]
 API_PUBLIC_URL=https://api.becomify.app

--- a/.env.test.example
+++ b/.env.test.example
@@ -6,9 +6,10 @@
 # Generate: openssl rand -hex 32 (set in the staging platform, never commit it)
 SECRET_KEY=
 DATABASE_URL=postgresql://user:password@host:5432/become_staging
-# Optional: privileged URL used only by Alembic migrations (DDL), so DATABASE_URL
-# above can run as a least-privilege role. Falls back to DATABASE_URL when unset.
-MIGRATION_DATABASE_URL=
+# Required here: privileged URL used only by Alembic migrations (DDL), so DATABASE_URL
+# above can run as a least-privilege role. Startup fails when it is unset here, so
+# the split is never silently lost; set it explicitly even if it matches DATABASE_URL.
+MIGRATION_DATABASE_URL=postgresql://migrator:password@host:5432/become
 DEBUG=false
 CORS_ORIGINS=["https://staging.your-domain.example"]
 API_PUBLIC_URL=https://test-backend-staging.up.railway.app

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -981,39 +981,39 @@
     ],
     "tests/unit/api/test_config.py": [
       {
+        "type": "Basic Auth Credentials",
+        "filename": "tests/unit/api/test_config.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
         "type": "Secret Keyword",
         "filename": "tests/unit/api/test_config.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 18
+        "line_number": 33
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/api/test_config.py",
         "hashed_secret": "d4e0e04792fd434b5dc9c4155c178f66edcf4ed3",
         "is_verified": false,
-        "line_number": 41
+        "line_number": 56
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/api/test_config.py",
         "hashed_secret": "557b77739581647a2cc6a60d7a72bfd2dfcf1762",
         "is_verified": false,
-        "line_number": 156
-      },
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "tests/unit/api/test_config.py",
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_verified": false,
-        "line_number": 194
+        "line_number": 171
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/api/test_config.py",
         "hashed_secret": "0fda60f593b23b78f2b02d07152b82593abdab52",
         "is_verified": false,
-        "line_number": 281
+        "line_number": 297
       }
     ],
     "tests/unit/api/test_logging_config.py": [
@@ -1056,5 +1056,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-26T22:23:33Z"
+  "generated_at": "2026-07-27T14:48:01Z"
 }

--- a/api/README.md
+++ b/api/README.md
@@ -183,11 +183,12 @@ Environment variables (can use `.env` file):
 |----------|---------|-------------|
 | `APP_ENV` | `dev` | Deployment profile: `dev`, `test`, or `prod`. Selects the `.env.<APP_ENV>` overlay; deployed profiles reject a weak secret, SQLite, a missing Redis, or localhost CORS at startup. See the root README "Environment profiles". |
 | `DATABASE_URL` | `sqlite:///./become.db` | Database connection string. On deployed environments this is the least-privilege `become_app` role. |
-| `MIGRATION_DATABASE_URL` | *optional* | Privileged connection used only by Alembic migrations (DDL); falls back to `DATABASE_URL` when unset. |
+| `MIGRATION_DATABASE_URL` | *required when deployed* | Privileged connection used only by Alembic migrations (DDL); falls back to `DATABASE_URL` locally, but startup fails without it on a deployed service so the least-privilege split is never silently lost. |
 | `SECRET_KEY` | *required* | JWT signing key (generate with `openssl rand -hex 32`) |
+| `LOG_HASH_KEY` | *optional* | Key for the email tags in security logs; falls back to `SECRET_KEY`. Set it separately to keep tags comparable across a secret rotation. |
 | `ACCESS_TOKEN_EXPIRE_MINUTES` | `15` | Access token TTL |
 | `REFRESH_TOKEN_EXPIRE_DAYS` | `7` | Refresh token TTL |
-| `DEBUG` | `false` | Debug mode |
+| `DEBUG` | `false` | Debug mode; must stay off on a deployed service (startup fails otherwise) |
 | `API_VERSION` | `1.0.0b1` | API version (auto-read from pyproject.toml) |
 | `CORS_ORIGINS` | `http://localhost:3000,http://localhost:8080` | Allowed CORS origins |
 | `REDIS_URL` | *required when deployed* | Redis for rate limiting, token revocation, and auth throttles |

--- a/api/auth/logging.py
+++ b/api/auth/logging.py
@@ -1,10 +1,12 @@
 """Security event logging for authentication operations."""
 
-import hashlib
+import hmac
 import logging
+from hashlib import sha256
 from typing import TYPE_CHECKING
 from uuid import UUID
 
+from api.config import get_settings
 from api.utils.client_ip import get_client_ip
 
 if TYPE_CHECKING:
@@ -13,18 +15,32 @@ if TYPE_CHECKING:
 # Configure security logger
 logger = logging.getLogger("api.security")
 
+# Length of the hex tag written to logs. Enough to correlate attempts on one account
+# without carrying the full digest around.
+_EMAIL_TAG_LENGTH = 16
+
 
 def hash_email(email: str) -> str:
-    """Return a short, non-reversible tag for an email.
+    """Return a short, keyed tag for an email.
 
     Security events log this instead of the raw address so a log drain or Sentry
     breach cannot harvest a registry of user emails, while repeated attempts on the
     same account can still be correlated (log data-minimization, GDPR).
 
+    The tag is an HMAC, not a plain digest: a plain SHA-256 of an address is
+    reproducible by anyone holding the logs, so they could confirm whether a given
+    person has an account by hashing a guess. Keying it makes the tag meaningless
+    outside this application. The key is ``log_hash_key`` when set, otherwise
+    ``secret_key`` -- note that rotating the fallback also re-tags every future
+    record, so set ``LOG_HASH_KEY`` explicitly to keep tags stable across a rotation.
+
     :param email: The email address to tag.
-    :return: A truncated SHA-256 hex digest of the normalized email.
+    :return: A truncated hex HMAC-SHA-256 of the normalized email.
     """
-    return hashlib.sha256(email.strip().lower().encode()).hexdigest()[:16]
+    settings = get_settings()
+    key = settings.log_hash_key or settings.secret_key
+    tag = hmac.new(key.encode(), email.strip().lower().encode(), sha256)
+    return tag.hexdigest()[:_EMAIL_TAG_LENGTH]
 
 
 def log_login_success(user_id: UUID, email: str, request: "Request | None" = None) -> None:

--- a/api/config.py
+++ b/api/config.py
@@ -106,6 +106,14 @@ class Settings(BaseSettings):
     environment: Environment = Environment.DEV
     testing: bool = Field(default=False, validation_alias="TESTING")
 
+    # Set by Railway on every deployed service, absent locally and in CI. Used to
+    # decide whether the dev profile is a laptop or an internet-reachable service:
+    # the dev deploy has its own database and public URL, so it has to satisfy the
+    # same invariants as staging and production.
+    railway_environment_name: str | None = Field(
+        default=None, validation_alias="RAILWAY_ENVIRONMENT_NAME"
+    )
+
     # Database
     database_url: str = "sqlite:///./become.db"
 
@@ -113,6 +121,10 @@ class Settings(BaseSettings):
     # falls back to database_url, so the running app can use a least-privilege
     # role while migrations run as a privileged role.
     migration_database_url: str | None = None
+
+    # Key for the email tags in security logs (api/auth/logging.py). Falls back to
+    # secret_key; set it separately to keep tags comparable across a secret rotation.
+    log_hash_key: str | None = None
 
     # Auth
     secret_key: str  # Required, load from .env
@@ -219,26 +231,30 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def _validate_deploy_invariants(self) -> "Settings":
-        """Reject development defaults on the deployed (TEST/PROD) profiles.
+        """Reject development defaults on every deployed service.
 
         A strong secret, real PostgreSQL database, Redis-backed store, a real
-        (non-loopback) CORS origin, and a configured email provider are required on
-        both the staging (TEST) and production (PROD) deploys, since both serve real
-        browser traffic and share the rate-limit / revocation store. The Cloudflare
-        origin lock is required only in production, where the app sits behind
-        Cloudflare.
+        (non-loopback) CORS origin, a configured email provider, debug off, and an
+        explicit migration URL are required on anything that serves real traffic,
+        since those services share the rate-limit / revocation store and are reachable
+        from the internet. The Cloudflare origin lock is required only in production,
+        where the app sits behind Cloudflare.
 
         :return: The validated settings instance.
         :raises ValueError: If a deployed profile still carries a development
-            default, lacks a real email provider, or production lacks the
-            Cloudflare origin secret.
+            default, lacks a real email provider, runs with debug on, has no
+            migration URL, or production lacks the Cloudflare origin secret.
         """
         # Environment.TEST doubles as the pytest-runner profile (the conftests set
         # APP_ENV=test with TESTING=1 and weak throwaway secrets), so its invariants
         # apply only to the real deployed staging, where TESTING is unset. Production
-        # is never used by the test runner, so it is always enforced.
+        # is never used by the test runner, so it is always enforced. The dev profile
+        # counts too when it runs on Railway: that service has its own database and a
+        # public URL, so "dev" there means the data is separate, not that the service
+        # may be weakly configured. A laptop or a CI runner has no RAILWAY_* marker.
         is_deploy = self.environment is Environment.PROD or (
-            self.environment is Environment.TEST and not self.testing
+            not self.testing
+            and (self.environment is Environment.TEST or self.railway_environment_name is not None)
         )
         if not is_deploy:
             return self
@@ -271,7 +287,18 @@ class Settings(BaseSettings):
             raise ValueError(
                 f"email_api_key is required in the {profile} profile with "
                 "email_provider=http; without it the sender falls back to the console one, "
-                "which delivers no mail and writes reset links to the log instead"
+                "which delivers no mail and prints reset links to stdout instead"
+            )
+        if self.debug:
+            raise ValueError(
+                f"debug must be off in the {profile} profile; it turns on verbose "
+                "framework output that does not belong on a service serving real traffic"
+            )
+        if not self.migration_database_url:
+            raise ValueError(
+                f"migration_database_url is required in the {profile} profile so Alembic "
+                "runs as the privileged role and the app keeps its least-privilege one; "
+                "set it explicitly even when it matches database_url"
             )
         return self
 

--- a/api/middleware/request_logging.py
+++ b/api/middleware/request_logging.py
@@ -1,6 +1,7 @@
 """Request/response logging middleware with correlation IDs."""
 
 import logging
+import re
 import uuid
 from collections.abc import Awaitable, Callable
 from time import perf_counter
@@ -16,11 +17,39 @@ logger = logging.getLogger("api.request")
 
 REQUEST_ID_HEADER = "X-Request-ID"
 
+# An inbound correlation ID is echoed back on the response and written to every log
+# record of the request, so it is only reused when it looks like one: printable ASCII
+# from a conservative alphabet, and short. Anything else is replaced by a fresh UUID
+# rather than rejected, since a malformed header should not fail the request.
+_MAX_REQUEST_ID_LENGTH = 128
+_REQUEST_ID_PATTERN = re.compile(rf"\A[A-Za-z0-9._:-]{{1,{_MAX_REQUEST_ID_LENGTH}}}\Z")
+
 # Requests slower than this are logged at WARNING instead of INFO.
 _SLOW_REQUEST_MS = 1000.0
 
 # Noisy endpoints excluded from request logging.
 _SKIP_PATHS = frozenset({"/api/v1/health"})
+
+
+def _correlation_id(inbound: str | None) -> str:
+    """Return a usable correlation ID for this request.
+
+    The caller-supplied value is honoured only when it matches
+    :data:`_REQUEST_ID_PATTERN`, so an oversized or exotic header cannot be echoed
+    back on the response or smuggled into log records. Anything else silently
+    becomes a fresh UUID.
+
+    :param inbound: Raw ``X-Request-ID`` header value, or None when absent.
+    :return: The inbound ID when well-formed, otherwise a new UUID4 string.
+
+    >>> _correlation_id("abc-123")
+    'abc-123'
+    >>> _correlation_id("x" * 200) == "x" * 200
+    False
+    """
+    if inbound is not None and _REQUEST_ID_PATTERN.match(inbound):
+        return inbound
+    return str(uuid.uuid4())
 
 
 class RequestLoggingMiddleware(BaseHTTPMiddleware):
@@ -41,11 +70,12 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         """Log the request, delegate, then log the timed response.
 
         :param request: Incoming request; its ``X-Request-ID`` header is reused
-            as the correlation ID when present, otherwise a new one is generated.
+            as the correlation ID when it is well-formed, otherwise a new one is
+            generated.
         :param call_next: Downstream handler that produces the response.
         :return: The downstream response with the ``X-Request-ID`` header set.
         """
-        request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid.uuid4())
+        request_id = _correlation_id(request.headers.get(REQUEST_ID_HEADER))
         request.state.request_id = request_id
         path = request.url.path
         token = set_request_id(request_id)

--- a/api/middleware/security_headers.py
+++ b/api/middleware/security_headers.py
@@ -31,8 +31,10 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         # Prevent MIME type sniffing
         response.headers["X-Content-Type-Options"] = "nosniff"
 
-        # XSS protection for older browsers
-        response.headers["X-XSS-Protection"] = "1; mode=block"
+        # Explicitly off. The legacy auditor this enables is unreliable, browsers have
+        # dropped it, and its blocking mode has itself been an information-leak vector.
+        # The Content-Security-Policy below is what actually constrains injection.
+        response.headers["X-XSS-Protection"] = "0"
 
         # HTTP Strict Transport Security - only for HTTPS requests
         # Sending HSTS on HTTP can cause issues in dev/staging

--- a/docs/security.md
+++ b/docs/security.md
@@ -111,13 +111,20 @@ Article 20 requires the full dataset -- and that is documented at the call site.
 ## Configuration and profiles
 
 The app runs under one of three profiles selected by `APP_ENV`: `dev`, `test`, `prod`
-(`api/config.py`). Deployed profiles are held to invariants that fail startup rather than
+(`api/config.py`). Deployed services are held to invariants that fail startup rather than
 boot insecurely (`_validate_deploy_invariants`): the `SECRET_KEY` must be strong, SQLite is
-rejected in favor of PostgreSQL, `redis_url` must be set, and `CORS_ORIGINS` may not be
-localhost. Production additionally requires `cloudflare_origin_secret`. The pytest runner is
-distinguished from a deployed `test` (staging) environment by a `TESTING` flag, so the
-invariants guard staging without breaking the local suite. Interactive API docs (`/docs`)
-are served only outside production.
+rejected in favor of PostgreSQL, `redis_url` must be set, `CORS_ORIGINS` may not be
+localhost, a real email provider must be configured, `DEBUG` must be off, and
+`MIGRATION_DATABASE_URL` must be set explicitly so migrations keep running as the
+privileged role. Production additionally requires `cloudflare_origin_secret`.
+
+"Deployed" is not the same as "not dev". The dev *service* has its own database and a
+public URL, so it is held to the same invariants: anything running with a
+`RAILWAY_ENVIRONMENT_NAME` counts, whatever its `APP_ENV`. A laptop and a CI runner carry
+no such marker and stay unconstrained. The pytest runner is distinguished from a deployed
+`test` (staging) environment by a `TESTING` flag, so the invariants guard staging without
+breaking the local suite. Interactive API docs (`/docs`) are served only outside
+production.
 
 ## Network and edge
 
@@ -125,8 +132,23 @@ The public origin is `becomify.app`, served through Cloudflare. A Cloudflare Tra
 injects a shared secret header that the origin then requires (`cloudflare_origin_secret`),
 so the Railway origin cannot be reached directly, bypassing the edge. CORS is configured
 with explicit allowed origins and `allow_credentials=True` (required for the cookie
-session), and permits the `X-CSRF-Token` header. Standard security response headers are set
-by middleware.
+session), and permits the `X-CSRF-Token` header.
+
+Both tiers send security response headers: the API from middleware
+(`api/middleware/security_headers.py`), the SPA from nginx (`frontend/nginx.conf`). Their
+Content-Security-Policies match except where the SPA genuinely needs more -- its
+`connect-src` also names the API origin, which is cross-origin on the deploys, and the
+Sentry ingest hosts the browser SDK reports to. That origin is baked into the policy when
+the image is built, from the same `VITE_API_URL` build argument the bundle uses, so the
+served policy cannot drift from the URL the app actually calls. `X-XSS-Protection` is set
+to `0` on both tiers on purpose: the legacy auditor it enables is unreliable, browsers have
+dropped it, and its blocking mode has itself leaked cross-origin information. The CSP is
+what constrains injection.
+
+The correlation ID is not taken on trust either. An inbound `X-Request-ID` is echoed on the
+response and written to every log record of the request, so it is reused only when it looks
+like an ID -- a short, conservative alphabet -- and replaced with a fresh UUID otherwise
+(`api/middleware/request_logging.py`).
 
 ## Logging, observability, and privacy
 
@@ -134,9 +156,15 @@ Logs are structured JSON in the deployed profiles. Each request is tagged with a
 `X-Request-ID`, and a context filter binds that request id and the acting user id onto every
 `api.*` log record through contextvars (`api/logging_context.py`), so a service or security
 log line can be traced back to a request without threading identifiers by hand. Personal
-data is kept out of the logs: email addresses are recorded as a truncated SHA-256 hash
-(`email_hash`), not in the clear. Unhandled errors hit a catch-all `500` handler and, when
-`SENTRY_DSN` is configured, Sentry.
+data is kept out of the logs: email addresses are recorded as a truncated keyed digest
+(`email_hash`), not in the clear. The key matters -- a plain SHA-256 of an address is
+reproducible by anyone holding the logs, so they could confirm whether a given person has
+an account by hashing a guess. The tag is an HMAC keyed with `LOG_HASH_KEY` (falling back
+to `SECRET_KEY`), which makes it meaningless outside the application while still
+correlating repeated attempts on one account. Rotating the fallback re-tags every later
+record, so set `LOG_HASH_KEY` explicitly where that correlation has to survive a rotation.
+
+Unhandled errors hit a catch-all `500` handler and, when `SENTRY_DSN` is configured, Sentry.
 
 Two separate switches keep credentials out of the tracker, and both are needed.
 `send_default_pii=False` drops the client IP, cookies, headers, and request bodies.
@@ -148,6 +176,11 @@ passwords, or a reset token that is still redeemable -- to the tracker. Sentry's
 does not catch this, because it matches local *names* against a denylist and the leaking
 local is called `data`. As a second layer, the credential fields in `api/schemas/auth.py` are
 declared `repr=False`, so those values stay out of any `repr()` regardless of who calls it.
+
+The browser SDK needs its own guard, since the reset link carries its token in the query
+string: `frontend/src/main.tsx` installs `beforeSend` and `beforeBreadcrumb` hooks
+(`frontend/src/lib/sentry.ts`) that redact `token`, `access_token`, and `refresh_token`
+from event URLs and from navigation and fetch breadcrumbs.
 
 ## Secrets
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -27,6 +27,16 @@ COPY . .
 # Build the application
 RUN npm run build
 
+# Bake the API origin into the SPA's Content-Security-Policy. VITE_API_URL is
+# cross-origin on the deploys (https://api.<domain>/api/v1) and a relative path
+# locally, in which case the placeholder collapses to nothing and connect-src
+# stays at 'self'. Done here rather than at runtime so the served policy is fixed
+# in the image and cannot drift with the container environment.
+RUN API_ORIGIN="$(printf '%s' "${VITE_API_URL}" | sed -n 's#^\(https\{0,1\}://[^/]*\).*#\1#p')" && \
+    if [ -n "${API_ORIGIN}" ]; then REPLACEMENT=" ${API_ORIGIN}"; else REPLACEMENT=""; fi && \
+    sed -i "s#__API_ORIGIN__#${REPLACEMENT}#g" nginx.conf && \
+    ! grep -q '__API_ORIGIN__' nginx.conf
+
 # Production stage
 # nginx-unprivileged runs as the non-root "nginx" user (UID 101) and listens on 8080.
 FROM nginxinc/nginx-unprivileged:alpine
@@ -34,8 +44,9 @@ FROM nginxinc/nginx-unprivileged:alpine
 # Copy built files from builder stage (owned by the non-root nginx user)
 COPY --from=builder --chown=nginx:nginx /app/dist /usr/share/nginx/html
 
-# Copy nginx configuration (nginx user must be able to read it at startup)
-COPY --chown=nginx:nginx nginx.conf /etc/nginx/conf.d/default.conf
+# Copy nginx configuration from the builder, where the CSP placeholder was resolved
+# (nginx user must be able to read it at startup)
+COPY --from=builder --chown=nginx:nginx /app/nginx.conf /etc/nginx/conf.d/default.conf
 
 # Expose port 8080 (non-root nginx cannot bind privileged port 80)
 EXPOSE 8080

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -22,16 +22,25 @@ server {
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
-        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Frame-Options "DENY" always;
         add_header X-Content-Type-Options "nosniff" always;
-        add_header X-XSS-Protection "1; mode=block" always;
+        add_header X-XSS-Protection "0" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'__API_ORIGIN__ https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://*.ingest.us.sentry.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests" always;
     }
 
-    # Security headers
-    add_header X-Frame-Options "SAMEORIGIN" always;
+    # Security headers. The CSP mirrors the API's own policy
+    # (api/middleware/security_headers.py) with two deliberate differences:
+    #   - connect-src also names the API origin, which is cross-origin on the deploys
+    #     (VITE_API_URL is a build arg, substituted into __API_ORIGIN__ at image build),
+    #     plus the Sentry ingest hosts the browser SDK reports to;
+    #   - style-src allows inline styles, which Tailwind and the chart config need.
+    # X-XSS-Protection is 0 on purpose: the legacy auditor it enables is unreliable and
+    # has itself been a source of leaks. CSP is what actually blocks injection here.
+    add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
-    add_header X-XSS-Protection "1; mode=block" always;
+    add_header X-XSS-Protection "0" always;
+    add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'__API_ORIGIN__ https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://*.ingest.us.sentry.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests" always;
     # nginx serves the internal http hop, so add HSTS unconditionally (the client
     # reaches us over https via Cloudflare/Railway). No "preload" until the domain
     # is actually submitted to the HSTS preload list.

--- a/frontend/src/lib/sentry.ts
+++ b/frontend/src/lib/sentry.ts
@@ -20,7 +20,9 @@ const REDACTED = "[redacted]";
 export function scrubUrl(raw: string): string {
   let parsed: URL;
   try {
-    parsed = new URL(raw, "http://placeholder.invalid");
+    // Base only so relative URLs parse; nothing is ever requested from it. The
+    // .invalid TLD is reserved and can never resolve.
+    parsed = new URL(raw, "https://placeholder.invalid");
   } catch {
     return raw;
   }

--- a/frontend/src/lib/sentry.ts
+++ b/frontend/src/lib/sentry.ts
@@ -1,0 +1,64 @@
+import type { Breadcrumb, ErrorEvent } from "@sentry/react";
+
+/**
+ * Query parameters that carry a credential and must never reach the error tracker.
+ *
+ * The password-reset link is the live case: `/reset-password?token=<raw token>` is
+ * redeemable until it is used, and both the event's request URL and the navigation
+ * breadcrumbs would otherwise carry it verbatim.
+ */
+const SENSITIVE_PARAMS = ["token", "access_token", "refresh_token"];
+
+const REDACTED = "[redacted]";
+
+/**
+ * Replace the value of every credential-bearing query parameter in a URL.
+ *
+ * Relative URLs are preserved as relative; anything unparseable is returned as-is,
+ * since a scrubber must never be the reason an event fails to send.
+ */
+export function scrubUrl(raw: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw, "http://placeholder.invalid");
+  } catch {
+    return raw;
+  }
+
+  const present = SENSITIVE_PARAMS.filter((name) => parsed.searchParams.has(name));
+  if (present.length === 0) return raw;
+
+  for (const name of present) {
+    parsed.searchParams.set(name, REDACTED);
+  }
+
+  const isAbsolute = /^[a-z][a-z0-9+.-]*:/i.test(raw);
+  return isAbsolute ? parsed.toString() : `${parsed.pathname}${parsed.search}${parsed.hash}`;
+}
+
+/** Strip credentials from the URL an event reports. */
+export function scrubEvent(event: ErrorEvent): ErrorEvent {
+  if (event.request?.url) {
+    event.request.url = scrubUrl(event.request.url);
+  }
+  return event;
+}
+
+/**
+ * Strip credentials from a breadcrumb.
+ *
+ * Navigation crumbs keep the URLs under `data.from` / `data.to`; fetch and xhr
+ * crumbs keep the request URL under `data.url`.
+ */
+export function scrubBreadcrumb(breadcrumb: Breadcrumb): Breadcrumb {
+  const data = breadcrumb.data;
+  if (!data) return breadcrumb;
+
+  for (const key of ["from", "to", "url"]) {
+    const value = data[key];
+    if (typeof value === "string") {
+      data[key] = scrubUrl(value);
+    }
+  }
+  return breadcrumb;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import * as Sentry from "@sentry/react";
 import App from "./App.tsx";
+import { scrubBreadcrumb, scrubEvent } from "@/lib/sentry";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import "@/i18n";
 import "@fontsource/inter/400.css";
@@ -20,6 +21,10 @@ if (import.meta.env.VITE_SENTRY_DSN) {
     dsn: import.meta.env.VITE_SENTRY_DSN,
     environment: import.meta.env.VITE_APP_ENV ?? (import.meta.env.DEV ? "development" : "production"),
     tracesSampleRate: 0.1,
+    // The reset link carries a redeemable token in the query string, and it would
+    // otherwise reach the tracker through the event URL and the navigation crumbs.
+    beforeSend: scrubEvent,
+    beforeBreadcrumb: scrubBreadcrumb,
   });
 }
 

--- a/frontend/tests/lib/sentry.test.ts
+++ b/frontend/tests/lib/sentry.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import type { Breadcrumb, ErrorEvent } from '@sentry/react';
+import { scrubBreadcrumb, scrubEvent, scrubUrl } from '@/lib/sentry';
+
+const RESET_TOKEN = 'live-single-use-reset-token';
+
+describe('scrubUrl', () => {
+  it('redacts a reset token on a relative URL and keeps it relative', () => {
+    const result = scrubUrl(`/reset-password?token=${RESET_TOKEN}`);
+
+    expect(result).toBe('/reset-password?token=%5Bredacted%5D');
+    expect(result).not.toContain(RESET_TOKEN);
+  });
+
+  it('redacts a reset token on an absolute URL', () => {
+    const result = scrubUrl(`https://app.example/reset-password?token=${RESET_TOKEN}&lang=cs`);
+
+    expect(result).not.toContain(RESET_TOKEN);
+    expect(result).toContain('lang=cs');
+    expect(result.startsWith('https://app.example/reset-password')).toBe(true);
+  });
+
+  it('redacts oauth-style token parameters too', () => {
+    const result = scrubUrl('/callback?access_token=a&refresh_token=b');
+
+    expect(result).not.toContain('=a');
+    expect(result).not.toContain('=b');
+  });
+
+  it('leaves a URL without sensitive parameters untouched', () => {
+    const url = '/projects/42?tab=opinions';
+
+    expect(scrubUrl(url)).toBe(url);
+  });
+
+  it('returns unparseable input unchanged rather than throwing', () => {
+    // A malformed host makes the URL constructor throw; the scrubber must not be
+    // the reason an event fails to send.
+    const malformed = 'http://[/reset-password?token=abc';
+
+    expect(scrubUrl(malformed)).toBe(malformed);
+  });
+
+  it('keeps a relative URL relative when nothing needs redacting', () => {
+    expect(scrubUrl('://nonsense')).toBe('://nonsense');
+  });
+});
+
+describe('scrubEvent', () => {
+  it('redacts the token in the event request URL', () => {
+    const event = {
+      request: { url: `https://app.example/reset-password?token=${RESET_TOKEN}` },
+    } as ErrorEvent;
+
+    const result = scrubEvent(event);
+
+    expect(result.request?.url).not.toContain(RESET_TOKEN);
+  });
+
+  it('passes through an event with no request URL', () => {
+    const event = { message: 'boom' } as ErrorEvent;
+
+    expect(scrubEvent(event)).toBe(event);
+  });
+});
+
+describe('scrubBreadcrumb', () => {
+  it('redacts navigation crumbs carrying the token', () => {
+    const crumb = {
+      category: 'navigation',
+      data: { from: '/forgot-password', to: `/reset-password?token=${RESET_TOKEN}` },
+    } as Breadcrumb;
+
+    const result = scrubBreadcrumb(crumb);
+
+    expect(result.data?.to).not.toContain(RESET_TOKEN);
+    expect(result.data?.from).toBe('/forgot-password');
+  });
+
+  it('redacts the url of a fetch crumb', () => {
+    const crumb = {
+      category: 'fetch',
+      data: { url: `/api/v1/auth/reset-password?token=${RESET_TOKEN}`, status_code: 400 },
+    } as Breadcrumb;
+
+    const result = scrubBreadcrumb(crumb);
+
+    expect(result.data?.url).not.toContain(RESET_TOKEN);
+    expect(result.data?.status_code).toBe(400);
+  });
+
+  it('passes through a crumb with no data', () => {
+    const crumb = { category: 'ui.click' } as Breadcrumb;
+
+    expect(scrubBreadcrumb(crumb)).toBe(crumb);
+  });
+});

--- a/tests/unit/api/middleware/test_request_logging.py
+++ b/tests/unit/api/middleware/test_request_logging.py
@@ -69,6 +69,46 @@ class TestRequestId:
         # THEN
         assert response.headers["X-Request-ID"] == "client-123"
 
+    def test_replaces_an_oversized_request_id(self, client: TestClient):
+        """
+        GIVEN a request whose X-Request-ID header is far longer than a correlation ID
+        WHEN it is handled
+        THEN a fresh ID is used instead of echoing the caller's value back
+        """
+        # GIVEN
+        oversized = "a" * 500
+
+        # WHEN
+        response = client.get("/ping", headers={"X-Request-ID": oversized})
+
+        # THEN
+        assert response.headers["X-Request-ID"] != oversized
+        assert len(response.headers["X-Request-ID"]) < len(oversized)
+
+    def test_replaces_a_request_id_with_unexpected_characters(self, client: TestClient):
+        """
+        GIVEN a request whose X-Request-ID carries characters outside the ID alphabet
+        WHEN it is handled
+        THEN a fresh ID is used, so nothing exotic is echoed or written to the log
+        """
+        # WHEN
+        response = client.get("/ping", headers={"X-Request-ID": "id with spaces, and <html>"})
+
+        # THEN
+        assert response.headers["X-Request-ID"] != "id with spaces, and <html>"
+
+    def test_replaces_an_empty_request_id(self, client: TestClient):
+        """
+        GIVEN a request carrying an empty X-Request-ID header
+        WHEN it is handled
+        THEN a generated ID is used
+        """
+        # WHEN
+        response = client.get("/ping", headers={"X-Request-ID": ""})
+
+        # THEN
+        assert response.headers["X-Request-ID"]
+
     def test_exposes_request_id_on_request_state(self, client: TestClient):
         """
         GIVEN a request

--- a/tests/unit/api/middleware/test_security_headers.py
+++ b/tests/unit/api/middleware/test_security_headers.py
@@ -59,17 +59,20 @@ class TestSecurityHeadersMiddleware:
         # THEN
         assert response.headers.get("X-Content-Type-Options") == "nosniff"
 
-    def test_adds_x_xss_protection(self, http_client: TestClient):
+    def test_disables_the_legacy_xss_auditor(self, http_client: TestClient):
         """
         GIVEN a request to any endpoint
         WHEN the response is returned
-        THEN it includes X-XSS-Protection: 1; mode=block
+        THEN it includes X-XSS-Protection: 0
+
+        The legacy auditor is unreliable and its blocking mode has itself leaked
+        cross-origin information; the CSP is what constrains injection here.
         """
         # WHEN
         response = http_client.get("/test")
 
         # THEN
-        assert response.headers.get("X-XSS-Protection") == "1; mode=block"
+        assert response.headers.get("X-XSS-Protection") == "0"
 
     def test_skips_hsts_for_http(self, http_client: TestClient):
         """

--- a/tests/unit/api/test_config.py
+++ b/tests/unit/api/test_config.py
@@ -8,6 +8,21 @@ from pydantic import ValidationError
 from api.config import Environment, Settings
 
 
+def _configure_prod(monkeypatch, tmp_path) -> None:
+    """Set a fully valid production environment; each test then weakens one part."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("APP_ENV", "prod")
+    monkeypatch.setenv("SECRET_KEY", "a-sufficiently-strong-secret-value")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@host:5432/db")
+    monkeypatch.setenv("MIGRATION_DATABASE_URL", "postgresql://migrator:pass@host:5432/db")
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setenv("CLOUDFLARE_ORIGIN_SECRET", "an-origin-verify-secret")
+    monkeypatch.setenv("CORS_ORIGINS", '["https://app.example.com"]')
+    monkeypatch.setenv("EMAIL_PROVIDER", "http")
+    monkeypatch.setenv("EMAIL_API_KEY", "a-resend-api-key")
+    monkeypatch.setenv("DEBUG", "false")
+
+
 class TestStorageEnabled:
     """Tests for the storage_enabled property."""
 
@@ -197,6 +212,7 @@ class TestEnvironmentResolution:
         monkeypatch.setenv("CORS_ORIGINS", '["https://app.example.com"]')
         monkeypatch.setenv("EMAIL_PROVIDER", "http")
         monkeypatch.setenv("EMAIL_API_KEY", "a-resend-api-key")
+        monkeypatch.setenv("MIGRATION_DATABASE_URL", "postgresql://migrator:pass@host:5432/db")
 
         # WHEN
         settings = Settings()
@@ -332,6 +348,7 @@ class TestProductionInvariants:
         monkeypatch.setenv("CORS_ORIGINS", '["https://app.example.com"]')
         monkeypatch.setenv("EMAIL_PROVIDER", "http")
         monkeypatch.setenv("EMAIL_API_KEY", "a-resend-api-key")
+        monkeypatch.setenv("MIGRATION_DATABASE_URL", "postgresql://migrator:pass@host:5432/db")
 
         # WHEN
         settings = Settings()
@@ -451,6 +468,126 @@ class TestProductionInvariants:
         with pytest.raises(ValidationError, match="email_api_key is required"):
             Settings()
 
+    def test_rejects_debug_in_production(self, monkeypatch, tmp_path):
+        """
+        GIVEN a fully configured production profile with DEBUG on
+        WHEN Settings is constructed
+        THEN validation fails
+        """
+        # GIVEN
+        _configure_prod(monkeypatch, tmp_path)
+        monkeypatch.setenv("DEBUG", "true")
+
+        # WHEN / THEN
+        with pytest.raises(ValidationError, match="debug must be off"):
+            Settings()
+
+    def test_rejects_missing_migration_url_in_production(self, monkeypatch, tmp_path):
+        """
+        GIVEN a production profile with no MIGRATION_DATABASE_URL
+        WHEN Settings is constructed
+        THEN validation fails, so migrations cannot silently run as the app role
+        """
+        # GIVEN
+        _configure_prod(monkeypatch, tmp_path)
+        monkeypatch.delenv("MIGRATION_DATABASE_URL", raising=False)
+
+        # WHEN / THEN
+        with pytest.raises(ValidationError, match="migration_database_url is required"):
+            Settings()
+
+
+class TestDeployedDevInvariants:
+    """The dev profile is held to the deploy invariants when it runs on Railway.
+
+    A dev *service* has its own database and a public URL, so "dev" there means the
+    data is separate, not that the service may be weakly configured. A laptop and a
+    CI runner carry no RAILWAY_* marker and stay unconstrained.
+    """
+
+    def test_local_dev_stays_unconstrained(self, monkeypatch, tmp_path):
+        """
+        GIVEN the dev profile with development defaults and no Railway marker
+        WHEN Settings is constructed
+        THEN validation passes
+        """
+        # GIVEN
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("RAILWAY_ENVIRONMENT_NAME", raising=False)
+        monkeypatch.setenv("APP_ENV", "dev")
+        monkeypatch.setenv("SECRET_KEY", "weak")
+        monkeypatch.setenv("DATABASE_URL", "sqlite:///./become.db")
+
+        # WHEN
+        settings = Settings()
+
+        # THEN
+        assert settings.environment is Environment.DEV
+
+    def test_railway_dev_rejects_weak_secret(self, monkeypatch, tmp_path):
+        """
+        GIVEN the dev profile on a Railway service with a weak secret
+        WHEN Settings is constructed
+        THEN validation fails
+        """
+        # GIVEN
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("TESTING", raising=False)
+        monkeypatch.setenv("RAILWAY_ENVIRONMENT_NAME", "dev")
+        monkeypatch.setenv("APP_ENV", "dev")
+        monkeypatch.setenv("SECRET_KEY", "weak")
+        monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@host:5432/db")
+
+        # WHEN / THEN
+        with pytest.raises(ValidationError, match="secret_key"):
+            Settings()
+
+    def test_railway_dev_accepts_a_full_configuration(self, monkeypatch, tmp_path):
+        """
+        GIVEN the dev profile on Railway configured like a real deploy
+        WHEN Settings is constructed
+        THEN validation passes
+        """
+        # GIVEN
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("TESTING", raising=False)
+        monkeypatch.delenv("CLOUDFLARE_ORIGIN_SECRET", raising=False)
+        monkeypatch.setenv("RAILWAY_ENVIRONMENT_NAME", "dev")
+        monkeypatch.setenv("APP_ENV", "dev")
+        monkeypatch.setenv("SECRET_KEY", "a-sufficiently-strong-secret-value")
+        monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@host:5432/db")
+        monkeypatch.setenv("MIGRATION_DATABASE_URL", "postgresql://migrator:pass@host:5432/db")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        monkeypatch.setenv("CORS_ORIGINS", '["https://dev.your-domain.example"]')
+        monkeypatch.setenv("EMAIL_PROVIDER", "http")
+        monkeypatch.setenv("EMAIL_API_KEY", "a-resend-api-key")
+
+        # WHEN
+        settings = Settings()
+
+        # THEN
+        assert settings.environment is Environment.DEV
+
+    def test_pytest_profile_is_exempt_on_railway(self, monkeypatch, tmp_path):
+        """
+        GIVEN TESTING=1 alongside a Railway marker on the dev profile
+        WHEN Settings is constructed
+        THEN validation passes, so a CI job on Railway is not held to deploy rules
+        """
+        # GIVEN
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("TESTING", "1")
+        monkeypatch.setenv("RAILWAY_ENVIRONMENT_NAME", "dev")
+        monkeypatch.setenv("APP_ENV", "dev")
+        monkeypatch.setenv("SECRET_KEY", "weak")
+        monkeypatch.setenv("DATABASE_URL", "sqlite:///./become.db")
+
+        # WHEN
+        settings = Settings()
+
+        # THEN
+        assert settings.environment is Environment.DEV
+
 
 class TestStagingInvariants:
     """The staging (TEST) profile enforces the same core invariants as prod."""
@@ -470,6 +607,7 @@ class TestStagingInvariants:
         monkeypatch.setenv("CORS_ORIGINS", '["https://staging.example.com"]')
         monkeypatch.setenv("EMAIL_PROVIDER", "http")
         monkeypatch.setenv("EMAIL_API_KEY", "a-resend-api-key")
+        monkeypatch.setenv("MIGRATION_DATABASE_URL", "postgresql://migrator:pass@host:5432/db")
 
     def test_accepts_fully_configured_staging_without_cloudflare(self, monkeypatch, tmp_path):
         """

--- a/tests/unit/api/test_logging_config.py
+++ b/tests/unit/api/test_logging_config.py
@@ -32,6 +32,7 @@ def _settings(
         cors_origins=["https://app.example.com"],
         email_provider="http",
         email_api_key="a-resend-api-key-for-tests",
+        migration_database_url="postgresql://migrator:pass@host:5432/db",
     )
 
 

--- a/tests/unit/api/test_main.py
+++ b/tests/unit/api/test_main.py
@@ -17,6 +17,7 @@ def _prod_env(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("CORS_ORIGINS", '["https://app.example.com"]')
     monkeypatch.setenv("EMAIL_PROVIDER", "http")
     monkeypatch.setenv("EMAIL_API_KEY", "a-resend-api-key")
+    monkeypatch.setenv("MIGRATION_DATABASE_URL", "postgresql://migrator:pass@host:5432/db")
 
 
 class TestDocsExposure:


### PR DESCRIPTION
Continues the security work from #310. Five hardening items from the backlog, each verified against `develop` before being touched — most of what the backlog listed as open genuinely was.

## CSP for the SPA

The API sent a `Content-Security-Policy`; nginx served the SPA without one. The policies now match except where the SPA needs more: `connect-src` also names the API origin and the Sentry ingest hosts.

The API origin is cross-origin on the deploys (`VITE_API_URL` is a build arg), so it cannot be hardcoded and cannot be `'self'`. It is substituted into the policy at image build from the same argument the bundle uses, which keeps the served policy from drifting away from the URL the app actually calls. When the value is relative — local and docker-compose — the placeholder collapses and `connect-src` stays `'self'`. All three cases are exercised.

`X-XSS-Protection` goes to `0` on both tiers: the legacy auditor is unreliable, browsers have dropped it, and its blocking mode has itself leaked cross-origin data. `X-Frame-Options` on the SPA moves `SAMEORIGIN` → `DENY` to match the API and the new `frame-ancestors 'none'`.

## Deploy invariants now cover the dev service

`_validate_deploy_invariants` keyed off `APP_ENV`, so it covered production and staging but not the dev service — which has its own database and a public URL, and could legally boot with a weak `SECRET_KEY`, SQLite, no Redis and localhost CORS.

Anything carrying `RAILWAY_ENVIRONMENT_NAME` now counts as deployed whatever its `APP_ENV`; a laptop and a CI runner have no such marker and stay unconstrained. Two checks join the set: `DEBUG` must be off, and `MIGRATION_DATABASE_URL` must be set explicitly so migrations keep running as the privileged role instead of silently falling back to the app's least-privilege one.

**Before merging:** the deploys need `MIGRATION_DATABASE_URL` set, or startup will fail. `DEBUG` must be off. The dev service additionally has to satisfy the full set for the first time.

## Reflected correlation ID

An inbound `X-Request-ID` was echoed verbatim into the response and written into every log record of the request. It is now reused only when it looks like a correlation ID — short, conservative alphabet — and replaced with a fresh UUID otherwise. A malformed header does not fail the request.

## Log and tracker hygiene

The security log's email tag becomes an HMAC keyed with `LOG_HASH_KEY`, falling back to `SECRET_KEY`. A plain SHA-256 of an address is reproducible by anyone holding the logs, so it could be used to confirm whether a given person has an account; keying it makes the tag meaningless outside the application. `LOG_HASH_KEY` is optional — set it separately where tag correlation has to survive a `SECRET_KEY` rotation.

The browser SDK gets `beforeSend` / `beforeBreadcrumb` hooks. The reset link carries a redeemable token in its query string, and it would otherwise reach Sentry through the event URL and the navigation crumbs. The scrubber lives in `frontend/src/lib/sentry.ts` rather than in the entry point so it is testable, and it returns input unchanged when parsing fails — a scrubber must never be why an event fails to send.

## Verification

- Backend: 1264 tests pass. New coverage for both deploy checks, the deployed-dev rule, the `TESTING` exemption, request-ID replacement (oversized, exotic characters, empty), and the header change.
- Frontend: 994 tests pass; coverage 98.51 / 95.49 / 97.84 / 98.75 against thresholds 98 / 95 / 97 / 98. Ten new tests for the scrubber.
- `ruff format`, `ruff check`, `mypy` (96 files), `bandit` (0 medium+), `detect-secrets`, `eslint`, `tsc` all clean.
- CSP substitution checked for a relative URL, an absolute URL and an empty value.

The CSP itself is the one thing tests cannot fully prove — it needs a look at the browser console on a built image before this reaches a real environment.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens browser, deployment, logging, and telemetry security boundaries.
- Adds a build-time-generated CSP and aligned security headers to nginx-served SPA responses.
- Extends deployment validation to Railway dev services and requires debug mode off plus an explicit migration database URL.
- Validates inbound correlation IDs and replaces malformed values with UUIDs.
- Replaces unkeyed email hashes with HMAC tags and adds optional `LOG_HASH_KEY` configuration.
- Scrubs credential-bearing URL parameters from Sentry events and breadcrumbs.
- Adds focused backend and frontend tests and updates deployment and security documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defect identified.

The new CSP covers the frontend's current resource and network destinations, deployment validation aligns with documented runtime profiles, and the request-ID, HMAC, and Sentry changes preserve existing application contracts while strengthening security boundaries.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/Dockerfile | Extracts the configured API origin at build time and substitutes it into the nginx CSP. |
| frontend/nginx.conf | Adds consistent CSP, clickjacking, MIME-sniffing, HSTS, and legacy XSS-auditor headers to SPA and static responses. |
| frontend/src/lib/sentry.ts | Redacts sensitive query parameters from current Sentry event and breadcrumb URL fields. |
| frontend/src/main.tsx | Installs the new redaction hooks in the browser Sentry SDK configuration. |
| api/config.py | Extends deploy detection to Railway services and enforces debug and migration-role invariants. |
| api/auth/logging.py | Changes normalized email tags from an unkeyed digest to a configurable HMAC. |
| api/middleware/request_logging.py | Restricts reflected and logged request IDs to a bounded conservative alphabet. |
| api/middleware/security_headers.py | Explicitly disables the obsolete browser XSS auditor in favor of CSP protections. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Build[Vite image build] --> Substitute[Extract API origin]
    Substitute --> Nginx[nginx CSP]
    Browser[SPA browser] --> Nginx
    Browser --> API[API service]
    Browser --> Sentry[Sentry ingest]
    Railway[Railway environment] --> Validation[Deployment invariant validation]
    Validation --> API
    Request[Inbound request] --> RequestID[Correlation ID validation]
    RequestID --> API
    API --> SecurityLog[HMAC-tagged security logs]
    Browser --> Scrubber[Sentry URL scrubbers]
    Scrubber --> Sentry
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use an https base when parsing URLs..."](https://github.com/caitlon/become/commit/d8081483ff0e4c2174b8b417f760bc1b1b3ff429) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47878473)</sub>

<!-- /greptile_comment -->