### PR TITLE
fix: register the typography plugin and clear stale UI defects

### DIFF
--- a/frontend/e2e/wcag-audit.spec.ts
+++ b/frontend/e2e/wcag-audit.spec.ts
@@ -102,7 +102,9 @@ test.describe('WCAG Audit — Dark Theme', () => {
     const page = await context.newPage();
     await page.addInitScript(() => {
       localStorage.setItem('become-language', 'en');
-      localStorage.setItem('vite-ui-theme', 'dark');
+      // `main.tsx` wires ThemeProvider with storageKey="become-theme"; seeding
+      // `vite-ui-theme` left these audits running against the light theme.
+      localStorage.setItem('become-theme', 'dark');
     });
 
     await page.goto('/');
@@ -123,7 +125,9 @@ test.describe('WCAG Audit — Dark Theme', () => {
     const page = await context.newPage();
     await page.addInitScript(() => {
       localStorage.setItem('become-language', 'en');
-      localStorage.setItem('vite-ui-theme', 'dark');
+      // `main.tsx` wires ThemeProvider with storageKey="become-theme"; seeding
+      // `vite-ui-theme` left these audits running against the light theme.
+      localStorage.setItem('become-theme', 'dark');
     });
 
     await page.goto('/login');

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -87,7 +87,7 @@ export function Navbar() {
           to="/"
           className="font-display text-2xl font-medium tracking-tight"
         >
-          BeCoMe
+          {t("brand.name")}
         </Link>
 
         {/* Desktop Navigation */}
@@ -198,7 +198,7 @@ export function Navbar() {
                 to={to}
                 /* v8 ignore next */
                 aria-current={isActive(to) ? "page" : undefined}
-                className={cn("block py-2 hover:text-foreground", /* v8 ignore next */ isActive(to) ? "text-foreground font-medium" : "text-muted-foreground")}
+                className={cn("block py-2 pl-3 border-l-2 hover:text-foreground", /* v8 ignore next */ isActive(to) ? "text-foreground font-medium border-primary" : "text-muted-foreground border-transparent")}
                 onClick={() => setIsMenuOpen(false)}
               >
                 {label}
@@ -212,7 +212,7 @@ export function Navbar() {
                     to={to}
                     /* v8 ignore next */
                     aria-current={isActive(to) ? "page" : undefined}
-                    className={cn("block py-2 hover:text-foreground", /* v8 ignore next */ isActive(to) ? "text-foreground font-medium" : "text-muted-foreground")}
+                    className={cn("block py-2 pl-3 border-l-2 hover:text-foreground", /* v8 ignore next */ isActive(to) ? "text-foreground font-medium border-primary" : "text-muted-foreground border-transparent")}
                     onClick={() => setIsMenuOpen(false)}
                   >
                     {label}

--- a/frontend/src/components/visualizations/CentroidBarChart.tsx
+++ b/frontend/src/components/visualizations/CentroidBarChart.tsx
@@ -104,7 +104,9 @@ export function CentroidBarChart({ opinions, result, scaleUnit }: CentroidBarCha
     },
     compromise: {
       label: tCommon("centroidChart.compromiseLine"),
-      theme: { light: "rgb(0, 0, 0)", dark: "rgb(255, 255, 255)" },
+      // `--primary` already resolves to black in light and white in dark, which is
+      // what the literal pair here spelled out by hand.
+      color: "hsl(var(--primary))",
     },
   };
 

--- a/frontend/src/i18n/locales/cs/profile.json
+++ b/frontend/src/i18n/locales/cs/profile.json
@@ -54,7 +54,6 @@
     "profileUpdated": "Profil aktualizován",
     "updateFailed": "Nepodařilo se aktualizovat profil",
     "passwordsNoMatch": "Hesla se neshodují",
-    "passwordMin": "Heslo musí mít alespoň 8 znaků",
     "passwordUpdated": "Heslo aktualizováno",
     "passwordFailed": "Nepodařilo se změnit heslo",
     "accountDeleted": "Účet smazán",

--- a/frontend/src/i18n/locales/cs/projects.json
+++ b/frontend/src/i18n/locales/cs/projects.json
@@ -85,7 +85,6 @@
     "experts": "Experti",
     "responses": "odpovědí",
     "scale": "Škála",
-    "edit": "Upravit",
     "inviteExperts": "Pozvat experty",
     "inviteExpert": "Pozvat experta",
     "delete": "Smazat",

--- a/frontend/src/i18n/locales/en/profile.json
+++ b/frontend/src/i18n/locales/en/profile.json
@@ -54,7 +54,6 @@
     "profileUpdated": "Profile updated",
     "updateFailed": "Failed to update profile",
     "passwordsNoMatch": "Passwords do not match",
-    "passwordMin": "Password must be at least 8 characters",
     "passwordUpdated": "Password updated",
     "passwordFailed": "Failed to change password",
     "accountDeleted": "Account deleted",

--- a/frontend/src/i18n/locales/en/projects.json
+++ b/frontend/src/i18n/locales/en/projects.json
@@ -85,7 +85,6 @@
     "experts": "Experts",
     "responses": "responses",
     "scale": "Scale",
-    "edit": "Edit",
     "inviteExperts": "Invite Experts",
     "inviteExpert": "Invite Expert",
     "delete": "Delete",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,10 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 
+/* Tailwind v4 registers plugins from CSS; without this the `prose` classes on
+   About are silently inert. */
+@plugin '@tailwindcss/typography';
+
 @custom-variant dark (&:is(.dark *));
 
 @utility container {

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -170,7 +170,7 @@ const Profile = () => {
     if (!allPasswordRequirementsMet) {
       toast({
         title: t("toast.error"),
-        description: t("toast.passwordMin"),
+        description: tAuth("validation.passwordMin"),
         variant: "destructive",
       });
       return;
@@ -299,7 +299,7 @@ const Profile = () => {
               <CardTitle>{t("editProfile.title")}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div className="space-y-1">
                   <Label htmlFor="firstName">{t("editProfile.firstName")}</Label>
                   <Input
@@ -350,7 +350,7 @@ const Profile = () => {
               <CardTitle>{t("changePassword.title")}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
-              <div>
+              <div className="space-y-2">
                 <Label htmlFor="currentPassword">
                   {t("changePassword.currentPassword")}
                 </Label>
@@ -379,7 +379,7 @@ const Profile = () => {
                 />
               </div>
 
-              <div>
+              <div className="space-y-2">
                 <Label htmlFor="confirmPassword">
                   {t("changePassword.confirmPassword")}
                 </Label>

--- a/frontend/src/pages/ProjectDetail.tsx
+++ b/frontend/src/pages/ProjectDetail.tsx
@@ -7,7 +7,6 @@ import {
   ArrowLeft,
   Loader2,
   Users,
-  Edit,
   UserPlus,
   Trash2,
   ChevronDown,
@@ -336,10 +335,6 @@ const ProjectDetail = () => {
             </span>
             {isAdmin && (
               <div className="flex gap-2">
-                <Button variant="outline" size="sm" className="gap-2">
-                  <Edit className="h-4 w-4" />
-                  {t("detail.edit")}
-                </Button>
                 <Button
                   variant="outline"
                   size="sm"

--- a/frontend/tests/pages/ProjectDetail.test.tsx
+++ b/frontend/tests/pages/ProjectDetail.test.tsx
@@ -178,7 +178,6 @@ describe('ProjectDetail', () => {
     render(<ProjectDetail />);
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /invite experts/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
     });
@@ -190,7 +189,7 @@ describe('ProjectDetail', () => {
     render(<ProjectDetail />);
 
     await waitFor(() => {
-      expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /invite experts/i })).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
First of three PRs on UI consistency. This one is only the isolated defects — the page shell and the heading scale come next.

## Two real bugs

**The typography plugin was never registered.** Tailwind v4 loads plugins from CSS, and the `@plugin` directive was not added during the v4 migration — so `prose prose-neutral dark:prose-invert` on About had been doing nothing. Verified in the browser: after the fix `--tw-prose-body` and `--tw-prose-headings` exist, and the column `max-width` is 65ch where it was `none`.

**The dark-theme WCAG audits were auditing the light theme.** `e2e/wcag-audit.spec.ts` seeded `vite-ui-theme`, but `main.tsx` wires `ThemeProvider` with `storageKey="become-theme"`. Both tests under "WCAG Audit — Dark Theme" passed without ever rendering dark. The same fix landed in `visual-regression.spec.ts` earlier — it even left an explanatory comment — but was not carried across to this file.

## Everything else

- **Removed the Edit button on ProjectDetail.** It had no `onClick` yet rendered and styled exactly like the working buttons beside it. Project editing is a feature in its own right, tracked in #319. The orphaned import and the `detail.edit` keys in both locales went with it.
- **The password-length message contradicted the policy.** `profile.json` promised at least 8 characters in both en and cs while 12 is enforced. Dropped the duplicate key and pointed the call at `auth.json`, whose wording matches `PASSWORD_MIN_LENGTH`.
- **First and last name on Profile** sat in a `grid-cols-2` with no breakpoint and cramped on narrow viewports → `grid-cols-1 sm:grid-cols-2`.
- **Password field spacing was uneven:** `newPassword` had `space-y-2`, `currentPassword` and `confirmPassword` had none.
- **The compromise series in the centroid chart** used literal `rgb(0, 0, 0)` / `rgb(255, 255, 255)` — the only place in the app where a colour bypassed the token system, sitting in the same config object as siblings that correctly use `hsl(var(--…))`. Moved onto `--primary`, which already resolves to that exact pair per theme; `ChartStyle` falls back to `color` when `theme` is absent, so the rendered output is unchanged.
- **The navbar wordmark was hard-coded** even though the footer renders the same brand through `t("brand.name")`.
- **The active item in the mobile menu** was marked by colour and weight alone, while desktop uses a `border-b-2 border-primary` underline. Both now use a rule in `--primary`, each along its own axis; inactive items carry a transparent rule of the same width so nothing shifts.

## Verification

`lint` and `typecheck` clean. `test:coverage`: 994 tests, thresholds met (statements 98.51 / branches 95.49 / functions 97.84 / lines 98.75). `ci-local fast`: 1271 backend + 994 frontend green.

Two tests in `ProjectDetail.test.tsx` were repointed from Edit to "Invite Experts". The "hides admin buttons for expert users" case probed the Edit button, which is now absent for everyone — the assertion would have passed without proving anything.

Checked live: About for the typography plugin, and the mobile menu at 375px in both themes.
