### PR TITLE
refactor: give every page one shell and one heading scale

### DIFF
--- a/frontend/e2e/wcag-audit.spec.ts
+++ b/frontend/e2e/wcag-audit.spec.ts
@@ -102,7 +102,9 @@ test.describe('WCAG Audit — Dark Theme', () => {
     const page = await context.newPage();
     await page.addInitScript(() => {
       localStorage.setItem('become-language', 'en');
-      localStorage.setItem('vite-ui-theme', 'dark');
+      // `main.tsx` wires ThemeProvider with storageKey="become-theme"; seeding
+      // `vite-ui-theme` left these audits running against the light theme.
+      localStorage.setItem('become-theme', 'dark');
     });
 
     await page.goto('/');
@@ -123,7 +125,9 @@ test.describe('WCAG Audit — Dark Theme', () => {
     const page = await context.newPage();
     await page.addInitScript(() => {
       localStorage.setItem('become-language', 'en');
-      localStorage.setItem('vite-ui-theme', 'dark');
+      // `main.tsx` wires ThemeProvider with storageKey="become-theme"; seeding
+      // `vite-ui-theme` left these audits running against the light theme.
+      localStorage.setItem('become-theme', 'dark');
     });
 
     await page.goto('/login');

--- a/frontend/src/components/NotFoundState.tsx
+++ b/frontend/src/components/NotFoundState.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 
-import { Navbar } from "@/components/layout/Navbar";
+import { PageShell } from "@/components/layout/PageShell";
 
 /**
  * Shared not-found screen, used both for unmatched routes (`NotFound`) and
@@ -12,19 +12,19 @@ export function NotFoundState() {
   const { t } = useTranslation();
 
   return (
-    <div className="min-h-screen bg-background">
-      <Navbar />
-      <main id="main-content" className="flex min-h-[calc(100vh-4rem)] items-center justify-center">
-        <div className="text-center">
-          <h1 className="font-display text-4xl font-normal tracking-tight mb-4">{t("notFound.code")}</h1>
-          <p className="mb-4 text-xl text-muted-foreground">
-            {t("notFound.description")}
-          </p>
-          <Link to="/" className="text-primary underline hover:text-primary/80">
-            {t("notFound.backHome")}
-          </Link>
-        </div>
-      </main>
-    </div>
+    <PageShell
+      variant="content"
+      mainClassName="flex min-h-[calc(100vh-4rem)] items-center justify-center"
+    >
+      <div className="text-center">
+        <h1 className="font-display text-4xl font-normal tracking-tight mb-4">{t("notFound.code")}</h1>
+        <p className="mb-4 text-xl text-muted-foreground">
+          {t("notFound.description")}
+        </p>
+        <Link to="/" className="text-primary underline hover:text-primary/80">
+          {t("notFound.backHome")}
+        </Link>
+      </div>
+    </PageShell>
   );
 }

--- a/frontend/src/components/layout/AuthLayout.tsx
+++ b/frontend/src/components/layout/AuthLayout.tsx
@@ -1,7 +1,7 @@
 import { motion } from "framer-motion";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Navbar } from "@/components/layout/Navbar";
+import { PageShell } from "@/components/layout/PageShell";
 
 interface AuthLayoutProps {
   title: string;
@@ -10,9 +10,7 @@ interface AuthLayoutProps {
 
 export function AuthLayout({ title, children }: Readonly<AuthLayoutProps>) {
   return (
-    <div className="min-h-screen flex flex-col">
-      <Navbar />
-      <main id="main-content" className="flex-1 flex items-center justify-center py-12 px-6">
+    <PageShell variant="content" mainClassName="flex-1 flex items-center justify-center py-12 px-6">
         <motion.div
           className="w-full max-w-md"
           initial={{ opacity: 0, y: 20 }}
@@ -28,7 +26,6 @@ export function AuthLayout({ title, children }: Readonly<AuthLayoutProps>) {
             <CardContent className="pt-6">{children}</CardContent>
           </Card>
         </motion.div>
-      </main>
-    </div>
+    </PageShell>
   );
 }

--- a/frontend/src/components/layout/HeroSection.tsx
+++ b/frontend/src/components/layout/HeroSection.tsx
@@ -1,6 +1,7 @@
 import { motion } from "framer-motion";
 
 import { cn } from "@/lib/utils";
+import { fadeInUp } from "@/lib/motion";
 
 interface HeroSectionProps {
   readonly title: string;
@@ -10,21 +11,29 @@ interface HeroSectionProps {
    * column (About). "left" matches the flush-left headings on Docs and FAQ.
    */
   readonly align?: "left" | "center";
+  /**
+   * "compact" trims the bottom padding for pages that open straight into a
+   * sidebar layout rather than a full-width first section.
+   */
+  readonly spacing?: "default" | "compact";
 }
 
-export function HeroSection({ title, subtitle, align = "center" }: HeroSectionProps) {
+const SPACING_CLASSES = {
+  default: "pt-24 pb-12 md:pt-32 md:pb-16",
+  compact: "pt-24 pb-8 md:pt-32 md:pb-12",
+} as const;
+
+export function HeroSection({
+  title,
+  subtitle,
+  align = "center",
+  spacing = "default",
+}: HeroSectionProps) {
   return (
-    <section className="pt-24 pb-12 md:pt-32 md:pb-16 bg-secondary/30">
+    <section className={cn(SPACING_CLASSES[spacing], "bg-secondary/30")}>
       <div className="container mx-auto px-6">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-          className={cn("max-w-3xl", align === "center" && "mx-auto")}
-        >
-          <h1 className="font-display text-3xl md:text-5xl font-normal mb-4">
-            {title}
-          </h1>
+        <motion.div {...fadeInUp} className={cn("max-w-3xl", align === "center" && "mx-auto")}>
+          <h1 className="text-page-title mb-4">{title}</h1>
           <p className="text-lg text-muted-foreground">{subtitle}</p>
         </motion.div>
       </div>

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -87,7 +87,7 @@ export function Navbar() {
           to="/"
           className="font-display text-2xl font-medium tracking-tight"
         >
-          BeCoMe
+          {t("brand.name")}
         </Link>
 
         {/* Desktop Navigation */}
@@ -198,7 +198,7 @@ export function Navbar() {
                 to={to}
                 /* v8 ignore next */
                 aria-current={isActive(to) ? "page" : undefined}
-                className={cn("block py-2 hover:text-foreground", /* v8 ignore next */ isActive(to) ? "text-foreground font-medium" : "text-muted-foreground")}
+                className={cn("block py-2 pl-3 border-l-2 hover:text-foreground", /* v8 ignore next */ isActive(to) ? "text-foreground font-medium border-primary" : "text-muted-foreground border-transparent")}
                 onClick={() => setIsMenuOpen(false)}
               >
                 {label}
@@ -212,7 +212,7 @@ export function Navbar() {
                     to={to}
                     /* v8 ignore next */
                     aria-current={isActive(to) ? "page" : undefined}
-                    className={cn("block py-2 hover:text-foreground", /* v8 ignore next */ isActive(to) ? "text-foreground font-medium" : "text-muted-foreground")}
+                    className={cn("block py-2 pl-3 border-l-2 hover:text-foreground", /* v8 ignore next */ isActive(to) ? "text-foreground font-medium border-primary" : "text-muted-foreground border-transparent")}
                     onClick={() => setIsMenuOpen(false)}
                   >
                     {label}

--- a/frontend/src/components/layout/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader.tsx
@@ -1,0 +1,31 @@
+import { motion } from "framer-motion";
+
+import { cn } from "@/lib/utils";
+
+interface PageHeaderProps {
+  readonly title: string;
+  readonly description?: string;
+  /** Meta row under the description — badges, actions, a back link. */
+  readonly children?: React.ReactNode;
+  readonly className?: string;
+}
+
+/**
+ * The h1 block for pages inside the app. Public pages use HeroSection instead,
+ * which carries the larger marketing scale and its own tinted band.
+ */
+export function PageHeader({ title, description, children, className }: PageHeaderProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      className={cn("mb-8", className)}
+    >
+      <h1 className={cn("text-app-title", description || children ? "mb-2" : undefined)}>
+        {title}
+      </h1>
+      {description && <p className="text-muted-foreground mb-4">{description}</p>}
+      {children}
+    </motion.div>
+  );
+}

--- a/frontend/src/components/layout/PageShell.tsx
+++ b/frontend/src/components/layout/PageShell.tsx
@@ -1,0 +1,59 @@
+import { cn } from "@/lib/utils";
+import { Footer } from "@/components/layout/Footer";
+import { Navbar } from "@/components/layout/Navbar";
+
+/**
+ * "app" hangs the shared container and the offset that clears the fixed navbar
+ * on <main>. "content" leaves spacing to the page's own <section>s, which is how
+ * the marketing and documentation pages are built. "centered" is the single-block
+ * layout the loading and error states use.
+ */
+type PageShellVariant = "app" | "content" | "centered";
+
+const MAIN_CLASSES: Record<PageShellVariant, string> = {
+  app: "container mx-auto px-6 pt-24 pb-16",
+  content: "",
+  centered: "pt-24 flex items-center justify-center",
+};
+
+interface PageShellProps {
+  readonly variant?: PageShellVariant;
+  readonly footer?: boolean;
+  /** Appended to the variant's own classes, not a replacement for them. */
+  readonly mainClassName?: string;
+  /**
+   * Rendered between the navbar and <main>. For fixed page chrome that sits
+   * outside the content landmark — Onboarding's progress bar is the one case.
+   */
+  readonly beforeMain?: React.ReactNode;
+  /** Rendered after </main>, for fixed chrome that belongs below the content. */
+  readonly afterMain?: React.ReactNode;
+  readonly children: React.ReactNode;
+}
+
+/**
+ * The page frame every route shares: the background, the navbar, the
+ * `#main-content` landmark that RouteAnnouncer moves focus to, and optionally
+ * the footer. Loading and error branches go through it too — building them by
+ * hand is how they ended up on a different background than the loaded page.
+ */
+export function PageShell({
+  variant = "app",
+  footer = false,
+  mainClassName,
+  beforeMain,
+  afterMain,
+  children,
+}: PageShellProps) {
+  return (
+    <div className={cn("min-h-screen bg-background", variant === "content" && "flex flex-col")}>
+      <Navbar />
+      {beforeMain}
+      <main id="main-content" className={cn(MAIN_CLASSES[variant], mainClassName)}>
+        {children}
+      </main>
+      {afterMain}
+      {footer && <Footer />}
+    </div>
+  );
+}

--- a/frontend/src/components/onboarding/StepComplete.tsx
+++ b/frontend/src/components/onboarding/StepComplete.tsx
@@ -31,7 +31,7 @@ export function StepComplete() {
 
       <motion.h1
         {...fadeInUp}
-        className="font-display text-3xl md:text-4xl font-normal mb-4"
+        className="text-app-title mb-4"
       >
         {t("steps.complete.title")}
       </motion.h1>

--- a/frontend/src/components/onboarding/StepHeader.tsx
+++ b/frontend/src/components/onboarding/StepHeader.tsx
@@ -25,7 +25,7 @@ export function StepHeader({ icon: Icon, titleKey, descriptionKey }: StepHeaderP
 
       <motion.h2
         {...fadeInUp}
-        className="font-display text-2xl md:text-3xl font-normal mb-2 text-center"
+        className="text-section-title mb-2 text-center"
       >
         {t(titleKey)}
       </motion.h2>

--- a/frontend/src/components/onboarding/StepWelcome.tsx
+++ b/frontend/src/components/onboarding/StepWelcome.tsx
@@ -19,7 +19,7 @@ export function StepWelcome() {
 
       <motion.h1
         {...fadeInUp}
-        className="font-display text-3xl md:text-4xl font-normal mb-2"
+        className="text-app-title mb-2"
       >
         {t("steps.welcome.title")}
       </motion.h1>

--- a/frontend/src/components/visualizations/CentroidBarChart.tsx
+++ b/frontend/src/components/visualizations/CentroidBarChart.tsx
@@ -104,7 +104,9 @@ export function CentroidBarChart({ opinions, result, scaleUnit }: CentroidBarCha
     },
     compromise: {
       label: tCommon("centroidChart.compromiseLine"),
-      theme: { light: "rgb(0, 0, 0)", dark: "rgb(255, 255, 255)" },
+      // `--primary` already resolves to black in light and white in dark, which is
+      // what the literal pair here spelled out by hand.
+      color: "hsl(var(--primary))",
     },
   };
 

--- a/frontend/src/i18n/locales/cs/profile.json
+++ b/frontend/src/i18n/locales/cs/profile.json
@@ -54,7 +54,6 @@
     "profileUpdated": "Profil aktualizován",
     "updateFailed": "Nepodařilo se aktualizovat profil",
     "passwordsNoMatch": "Hesla se neshodují",
-    "passwordMin": "Heslo musí mít alespoň 8 znaků",
     "passwordUpdated": "Heslo aktualizováno",
     "passwordFailed": "Nepodařilo se změnit heslo",
     "accountDeleted": "Účet smazán",

--- a/frontend/src/i18n/locales/cs/projects.json
+++ b/frontend/src/i18n/locales/cs/projects.json
@@ -85,7 +85,6 @@
     "experts": "Experti",
     "responses": "odpovědí",
     "scale": "Škála",
-    "edit": "Upravit",
     "inviteExperts": "Pozvat experty",
     "inviteExpert": "Pozvat experta",
     "delete": "Smazat",

--- a/frontend/src/i18n/locales/en/profile.json
+++ b/frontend/src/i18n/locales/en/profile.json
@@ -54,7 +54,6 @@
     "profileUpdated": "Profile updated",
     "updateFailed": "Failed to update profile",
     "passwordsNoMatch": "Passwords do not match",
-    "passwordMin": "Password must be at least 8 characters",
     "passwordUpdated": "Password updated",
     "passwordFailed": "Failed to change password",
     "accountDeleted": "Account deleted",

--- a/frontend/src/i18n/locales/en/projects.json
+++ b/frontend/src/i18n/locales/en/projects.json
@@ -85,7 +85,6 @@
     "experts": "Experts",
     "responses": "responses",
     "scale": "Scale",
-    "edit": "Edit",
     "inviteExperts": "Invite Experts",
     "inviteExpert": "Invite Expert",
     "delete": "Delete",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -18,21 +18,37 @@
   }
 }
 
+/*
+  Heading scale. Two registers: the marketing page (Landing) runs one step larger
+  than the working pages, so hero and section each get their own entry. Every
+  page heading picks one of these -- no page sets a size of its own.
+*/
+@utility text-page-hero {
+  @apply font-display font-normal tracking-tight text-4xl md:text-6xl lg:text-7xl;
+}
+
+@utility text-page-title {
+  @apply font-display font-normal text-3xl md:text-5xl;
+}
+
+@utility text-app-title {
+  @apply font-display font-normal text-3xl md:text-4xl;
+}
+
+@utility text-section-title {
+  @apply font-display font-normal text-2xl md:text-3xl;
+}
+
+/* Landing's sections, sized to sit under its larger hero. Matches text-app-title
+   today; kept separate so the two registers can move independently. */
+@utility text-section-title-lg {
+  @apply font-display font-normal text-3xl md:text-4xl;
+}
+
 @theme {
   --font-sans: Inter, system-ui, sans-serif;
   --font-display: Playfair Display, Georgia, serif;
   --font-mono: JetBrains Mono, monospace;
-
-  --text-display-1: 3rem;
-  --text-display-1--line-height: 1.1;
-  /* Playfair Display has no 300 weight; 400 is its lightest cut */
-  --text-display-1--font-weight: 400;
-  --text-display-2: 2rem;
-  --text-display-2--line-height: 1.2;
-  --text-display-2--font-weight: 400;
-  --text-display-3: 1.5rem;
-  --text-display-3--line-height: 1.3;
-  --text-display-3--font-weight: 500;
 
   --color-border: hsl(var(--border));
   --color-input: hsl(var(--input));
@@ -361,19 +377,18 @@
     font-family: 'JetBrains Mono', monospace;
   }
   
-  /* Heading Styles */
-  h1, .h1 {
-    @apply font-display text-5xl font-normal tracking-tight;
+  /*
+    Headings inherit the display family and nothing else. Sizes come from the
+    text-page-hero / text-page-title / text-app-title / text-section-title
+    utilities above, so a heading that forgets one reads at body size and the
+    omission is visible rather than papered over by a global default.
+  */
+  h1,
+  h2,
+  h3 {
+    @apply font-display font-normal;
   }
-  
-  h2, .h2 {
-    @apply font-display text-3xl font-normal;
-  }
-  
-  h3, .h3 {
-    @apply font-display text-2xl font-medium;
-  }
-  
+
   /* Focus styles */
   .focus-ring {
     @apply focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,10 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 
+/* Tailwind v4 registers plugins from CSS; without this the `prose` classes on
+   About are silently inert. */
+@plugin '@tailwindcss/typography';
+
 @custom-variant dark (&:is(.dark *));
 
 @utility container {

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -5,8 +5,7 @@ import { useTranslation } from "react-i18next";
 import { ArrowRight, BookOpen, FileText } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Navbar } from "@/components/layout/Navbar";
-import { Footer } from "@/components/layout/Footer";
+import { PageShell } from "@/components/layout/PageShell";
 import { HeroSection } from "@/components/layout/HeroSection";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { fadeInUp } from "@/lib/motion";
@@ -21,9 +20,7 @@ const About = () => {
   }, []);
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <Navbar />
-      <main id="main-content">
+    <PageShell variant="content" footer>
       <HeroSection title={t("hero.title")} subtitle={t("hero.subtitle")} />
 
       {/* Introduction */}
@@ -31,7 +28,7 @@ const About = () => {
         <div className="container mx-auto px-6">
           <div className="max-w-3xl mx-auto">
             <motion.div {...fadeInUp}>
-              <h2 className="font-display text-2xl md:text-3xl font-normal mb-6">
+              <h2 className="text-section-title mb-6">
                 {t("challenge.title")}
               </h2>
               <div className="prose prose-neutral dark:prose-invert">
@@ -57,7 +54,7 @@ const About = () => {
               viewport={{ once: true }}
               transition={{ duration: 0.5 }}
             >
-              <h2 className="font-display text-2xl md:text-3xl font-normal mb-6">
+              <h2 className="text-section-title mb-6">
                 {t("method.title")}
               </h2>
               <div className="prose prose-neutral dark:prose-invert">
@@ -89,7 +86,7 @@ const About = () => {
               viewport={{ once: true }}
               transition={{ duration: 0.5 }}
             >
-              <h2 className="font-display text-2xl md:text-3xl font-normal mb-6">
+              <h2 className="text-section-title mb-6">
                 {t("applications.title")}
               </h2>
               <p className="text-muted-foreground leading-relaxed mb-6">
@@ -130,7 +127,7 @@ const About = () => {
               viewport={{ once: true }}
               transition={{ duration: 0.5 }}
             >
-              <h2 className="font-display text-2xl md:text-3xl font-normal mb-6">
+              <h2 className="text-section-title mb-6">
                 {t("authors.title")}
               </h2>
               <Card>
@@ -168,7 +165,7 @@ const About = () => {
       {/* CTA Section */}
       <section className="py-16 bg-primary text-primary-foreground">
         <div className="container mx-auto px-6 text-center">
-          <h2 className="font-display text-2xl md:text-3xl font-normal mb-4">
+          <h2 className="text-section-title mb-4">
             {t("cta.title")}
           </h2>
           <p className="text-primary-foreground/80 mb-8 max-w-xl mx-auto">
@@ -192,10 +189,7 @@ const About = () => {
           </div>
         </div>
       </section>
-
-      </main>
-      <Footer />
-    </div>
+    </PageShell>
   );
 };
 

--- a/frontend/src/pages/CaseStudies.tsx
+++ b/frontend/src/pages/CaseStudies.tsx
@@ -1,8 +1,7 @@
 import { useEffect } from "react";
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
-import { Navbar } from "@/components/layout/Navbar";
-import { Footer } from "@/components/layout/Footer";
+import { PageShell } from "@/components/layout/PageShell";
 import { HeroSection } from "@/components/layout/HeroSection";
 import { CaseStudyCard } from "@/components/CaseStudyCard";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
@@ -19,9 +18,7 @@ const CaseStudies = () => {
   }, []);
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <Navbar />
-      <main id="main-content">
+    <PageShell variant="content" footer>
         <HeroSection
           title={t("listing.title")}
           subtitle={t("listing.subtitle")}
@@ -47,9 +44,7 @@ const CaseStudies = () => {
             </div>
           </div>
         </section>
-      </main>
-      <Footer />
-    </div>
+    </PageShell>
   );
 };
 

--- a/frontend/src/pages/CaseStudy.tsx
+++ b/frontend/src/pages/CaseStudy.tsx
@@ -11,8 +11,7 @@ import {
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Navbar } from "@/components/layout/Navbar";
-import { Footer } from "@/components/layout/Footer";
+import { PageShell } from "@/components/layout/PageShell";
 import { NotFoundState } from "@/components/NotFoundState";
 import {
   useLocalizedCaseStudyById,
@@ -40,9 +39,7 @@ const CaseStudy = () => {
   const IconComponent = caseStudy.icon;
 
   return (
-    <div className="min-h-screen flex flex-col bg-background">
-      <Navbar />
-      <main id="main-content">
+    <PageShell variant="content" footer>
       {/* Hero Section */}
       <section className="pt-24 pb-12 md:pt-32 md:pb-16 bg-secondary/30">
         <div className="container mx-auto px-6">
@@ -73,7 +70,7 @@ const CaseStudy = () => {
               </div>
             </div>
 
-            <h1 className="font-display text-3xl md:text-5xl font-normal mb-4">
+            <h1 className="text-page-title mb-4">
               {caseStudy.title}
             </h1>
             <p className="text-lg text-muted-foreground max-w-3xl">
@@ -377,7 +374,7 @@ const CaseStudy = () => {
       {/* CTA Section */}
       <section className="py-16 bg-secondary/30">
         <div className="container mx-auto px-6 text-center">
-          <h2 className="font-display text-2xl md:text-3xl font-normal mb-4">
+          <h2 className="text-section-title mb-4">
             {t("common.ctaTitle")}
           </h2>
           <p className="text-muted-foreground mb-8 max-w-xl mx-auto">
@@ -388,10 +385,7 @@ const CaseStudy = () => {
           </Button>
         </div>
       </section>
-
-      </main>
-      <Footer />
-    </div>
+    </PageShell>
   );
 };
 

--- a/frontend/src/pages/Documentation.tsx
+++ b/frontend/src/pages/Documentation.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from "react";
-import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import {
   BookOpen,
@@ -10,12 +9,11 @@ import {
   FileText,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Navbar } from "@/components/layout/Navbar";
-import { Footer } from "@/components/layout/Footer";
+import { HeroSection } from "@/components/layout/HeroSection";
+import { PageShell } from "@/components/layout/PageShell";
 import { SidebarNav, type SidebarNavItem } from "@/components/layout/SidebarNav";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { useScrollSpy } from "@/hooks/useScrollSpy";
-import { fadeInUp } from "@/lib/motion";
 
 const sectionIds = ["getting-started", "expert-opinions", "results", "visualization", "glossary"] as const;
 
@@ -39,20 +37,8 @@ const Documentation = () => {
   ];
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <Navbar />
-
-      {/* Hero Section */}
-      <section className="pt-24 pb-8 md:pt-32 md:pb-12 bg-secondary/30">
-        <div className="container mx-auto px-6">
-          <motion.div {...fadeInUp} className="max-w-3xl">
-            <h1 className="font-display text-3xl md:text-5xl font-normal mb-4">
-              {t("title")}
-            </h1>
-            <p className="text-lg text-muted-foreground">{t("subtitle")}</p>
-          </motion.div>
-        </div>
-      </section>
+    <PageShell variant="content" footer mainClassName="flex-1 flex flex-col">
+      <HeroSection title={t("title")} subtitle={t("subtitle")} align="left" spacing="compact" />
 
       {/* Main Content */}
       <section className="flex-1 py-8 md:py-12">
@@ -66,10 +52,10 @@ const Documentation = () => {
             />
 
             {/* Content */}
-            <main id="main-content" className="flex-1 max-w-3xl">
+            <div className="flex-1 max-w-3xl">
               {/* Getting Started */}
               <section id="getting-started" className="mb-12">
-                <h2 className="font-display text-2xl md:text-3xl font-normal mb-4">
+                <h2 className="text-section-title mb-4">
                   {t("gettingStarted.title")}
                 </h2>
                 <p className="text-muted-foreground mb-6">
@@ -130,7 +116,7 @@ const Documentation = () => {
 
               {/* Expert Opinions */}
               <section id="expert-opinions" className="mb-12">
-                <h2 className="font-display text-2xl md:text-3xl font-normal mb-4">
+                <h2 className="text-section-title mb-4">
                   {t("expertOpinions.title")}
                 </h2>
                 <p className="text-muted-foreground mb-6">
@@ -250,7 +236,7 @@ const Documentation = () => {
 
               {/* Results */}
               <section id="results" className="mb-12">
-                <h2 className="font-display text-2xl md:text-3xl font-normal mb-4">
+                <h2 className="text-section-title mb-4">
                   {t("results.title")}
                 </h2>
                 <p className="text-muted-foreground mb-6">{t("results.intro")}</p>
@@ -320,7 +306,7 @@ const Documentation = () => {
 
               {/* Visualization */}
               <section id="visualization" className="mb-12">
-                <h2 className="font-display text-2xl md:text-3xl font-normal mb-4">
+                <h2 className="text-section-title mb-4">
                   {t("visualization.title")}
                 </h2>
                 <p className="text-muted-foreground mb-6">
@@ -359,7 +345,7 @@ const Documentation = () => {
 
               {/* Glossary */}
               <section id="glossary" className="mb-12">
-                <h2 className="font-display text-2xl md:text-3xl font-normal mb-4">
+                <h2 className="text-section-title mb-4">
                   {t("glossary.title")}
                 </h2>
 
@@ -382,13 +368,11 @@ const Documentation = () => {
                   )}
                 </div>
               </section>
-            </main>
+            </div>
           </div>
         </div>
       </section>
-
-      <Footer />
-    </div>
+    </PageShell>
   );
 };
 

--- a/frontend/src/pages/FAQ.tsx
+++ b/frontend/src/pages/FAQ.tsx
@@ -19,12 +19,11 @@ import {
 } from "@/components/ui/accordion";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Navbar } from "@/components/layout/Navbar";
-import { Footer } from "@/components/layout/Footer";
+import { HeroSection } from "@/components/layout/HeroSection";
+import { PageShell } from "@/components/layout/PageShell";
 import { SidebarNav, type SidebarNavItem } from "@/components/layout/SidebarNav";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { useScrollSpy } from "@/hooks/useScrollSpy";
-import { fadeInUp } from "@/lib/motion";
 
 const categories = [
   { id: "method", icon: BookOpen, labelKey: "categories.method" },
@@ -64,20 +63,8 @@ const FAQ = () => {
   }));
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <Navbar />
-
-      {/* Hero Section */}
-      <section className="pt-24 pb-8 md:pt-32 md:pb-12 bg-secondary/30">
-        <div className="container mx-auto px-6">
-          <motion.div {...fadeInUp} className="max-w-3xl">
-            <h1 className="font-display text-3xl md:text-5xl font-normal mb-4">
-              {t("title")}
-            </h1>
-            <p className="text-lg text-muted-foreground">{t("subtitle")}</p>
-          </motion.div>
-        </div>
-      </section>
+    <PageShell variant="content" footer mainClassName="flex-1 flex flex-col">
+      <HeroSection title={t("title")} subtitle={t("subtitle")} align="left" spacing="compact" />
 
       {/* Main Content */}
       <section className="flex-1 py-8 md:py-12">
@@ -91,7 +78,7 @@ const FAQ = () => {
             />
 
             {/* FAQ Content */}
-            <main id="main-content" className="flex-1 max-w-3xl">
+            <div className="flex-1 max-w-3xl">
               {categories.map((cat) => (
                 <motion.section
                   key={cat.id}
@@ -102,7 +89,7 @@ const FAQ = () => {
                   viewport={{ once: true }}
                   transition={{ duration: 0.5 }}
                 >
-                  <h2 className="font-display text-2xl md:text-3xl font-normal mb-4 flex items-center gap-3">
+                  <h2 className="text-section-title mb-4 flex items-center gap-3">
                     <cat.icon className="h-6 w-6 text-primary" />
                     {t(cat.labelKey)}
                   </h2>
@@ -127,7 +114,7 @@ const FAQ = () => {
                   </Card>
                 </motion.section>
               ))}
-            </main>
+            </div>
           </div>
         </div>
       </section>
@@ -135,7 +122,7 @@ const FAQ = () => {
       {/* CTA Section */}
       <section className="py-16 bg-primary text-primary-foreground">
         <div className="container mx-auto px-6 text-center">
-          <h2 className="font-display text-2xl md:text-3xl font-normal mb-4">
+          <h2 className="text-section-title mb-4">
             {t("cta.title")}
           </h2>
           <p className="text-primary-foreground/80 mb-8 max-w-xl mx-auto">
@@ -163,9 +150,7 @@ const FAQ = () => {
           </div>
         </div>
       </section>
-
-      <Footer />
-    </div>
+    </PageShell>
   );
 };
 

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -4,8 +4,7 @@ import { useTranslation } from "react-i18next";
 import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { Navbar } from "@/components/layout/Navbar";
-import { Footer } from "@/components/layout/Footer";
+import { PageShell } from "@/components/layout/PageShell";
 import { FuzzyTriangleSVG } from "@/components/visualizations/FuzzyTriangleSVG";
 import { CaseStudyCard } from "@/components/CaseStudyCard";
 import { ArrowRight, Users, Calculator, Target } from "lucide-react";
@@ -44,9 +43,7 @@ const Landing = () => {
   }, [location.hash]);
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <Navbar />
-      <main id="main-content">
+    <PageShell variant="content" footer>
       
       {/* Hero Section */}
       <section className="pt-32 pb-20 md:pt-40 md:pb-32 bg-gradient-to-b from-background via-background to-muted/20">
@@ -58,7 +55,7 @@ const Landing = () => {
             variants={stagger}
           >
             <motion.h1
-              className="font-display text-4xl md:text-6xl lg:text-7xl font-normal tracking-tight mb-6"
+              className="text-page-hero mb-6"
               variants={fadeInUp}
             >
               {t("hero.title1")}
@@ -105,7 +102,7 @@ const Landing = () => {
             viewport={{ once: true }}
             transition={{ duration: 0.5 }}
           >
-            <h2 className="font-display text-3xl md:text-4xl font-normal mb-4">
+            <h2 className="text-section-title-lg mb-4">
               {t("howItWorks.title")}
             </h2>
             <p className="text-muted-foreground max-w-xl mx-auto">
@@ -182,7 +179,7 @@ const Landing = () => {
             viewport={{ once: true }}
             transition={{ duration: 0.5 }}
           >
-            <h2 className="font-display text-3xl md:text-4xl font-normal mb-4">
+            <h2 className="text-section-title-lg mb-4">
               {t("caseStudies.title")}
             </h2>
             <p className="text-muted-foreground max-w-xl mx-auto">
@@ -220,7 +217,7 @@ const Landing = () => {
             viewport={{ once: true }}
             transition={{ duration: 0.5 }}
           >
-            <h2 className="font-display text-3xl md:text-4xl font-normal mb-6">
+            <h2 className="text-section-title-lg mb-6">
               {t("cta.title")}
             </h2>
             <p className="text-primary-foreground/80 mb-8">{t("cta.subtitle")}</p>
@@ -233,10 +230,7 @@ const Landing = () => {
           </motion.div>
         </div>
       </section>
-
-      </main>
-      <Footer />
-    </div>
+    </PageShell>
   );
 };
 

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -5,7 +5,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { ChevronLeft, ChevronRight, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
-import { Navbar } from "@/components/layout/Navbar";
+import { PageShell } from "@/components/layout/PageShell";
 import {
   StepWelcome,
   StepCreateProject,
@@ -89,36 +89,85 @@ const Onboarding = () => {
   const CurrentStepComponent = steps[currentStep].component;
 
   return (
-    <div className="min-h-screen flex flex-col bg-background">
-      <Navbar />
-
-      {/* Progress Header */}
-      <div className="fixed top-16 left-0 right-0 z-40 bg-background/95 backdrop-blur-sm border-b">
-        <div className="container mx-auto px-6 py-3">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-sm text-muted-foreground">
-              {t("progress", { current: currentStep + 1, total: totalSteps })}
-            </span>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={navigateToProjects}
-              className="text-muted-foreground hover:text-foreground"
-            >
-              <X className="h-4 w-4 mr-1" />
-              {t("buttons.skip")}
-            </Button>
+    <PageShell
+      variant="content"
+      mainClassName="flex-1 pt-32 pb-24 overflow-hidden"
+      beforeMain={
+        /* Progress Header */
+        <div className="fixed top-16 left-0 right-0 z-40 bg-background/95 backdrop-blur-sm border-b">
+          <div className="container mx-auto px-6 py-3">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm text-muted-foreground">
+                {t("progress", { current: currentStep + 1, total: totalSteps })}
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={navigateToProjects}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <X className="h-4 w-4 mr-1" />
+                {t("buttons.skip")}
+              </Button>
+            </div>
+            <Progress
+              value={((currentStep + 1) / totalSteps) * 100}
+              className="h-1"
+              aria-label={t("progress", { current: currentStep + 1, total: totalSteps })}
+            />
           </div>
-          <Progress
-            value={((currentStep + 1) / totalSteps) * 100}
-            className="h-1"
-            aria-label={t("progress", { current: currentStep + 1, total: totalSteps })}
-          />
         </div>
-      </div>
+      }
+      afterMain={
+        /* Navigation Footer */
+        <div className="fixed bottom-0 left-0 right-0 bg-background/95 backdrop-blur-sm border-t">
+          <div className="container mx-auto px-6 py-4">
+            <div className="flex items-center justify-between">
+              <Button
+                variant="outline"
+                onClick={goToPrevious}
+                disabled={isFirstStep}
+                className="gap-2"
+              >
+                <ChevronLeft className="h-4 w-4" />
+                {t("buttons.previous")}
+              </Button>
 
-      {/* Step Content */}
-      <main id="main-content" className="flex-1 pt-32 pb-24 overflow-hidden">
+              {/* Step indicators */}
+              <nav aria-label={tCommon("a11y.stepNavigation")} className="hidden sm:flex items-center gap-1">
+                {steps.map((step, index) => (
+                  <button
+                    key={step.id}
+                    type="button"
+                    onClick={() => {
+                      setDirection(index > currentStep ? 1 : -1);
+                      setCurrentStep(index);
+                    }}
+                    className="p-2 rounded-full"
+                    aria-label={t("buttons.goToStep", { step: index + 1 })}
+                    aria-current={index === currentStep ? "step" : undefined}
+                  >
+                    <span className={`block h-2 rounded-full transition-all ${getStepIndicatorClass(index, currentStep)}`} />
+                  </button>
+                ))}
+              </nav>
+
+              {isLastStep ? (
+                <Button onClick={navigateToProjects} className="gap-2">
+                  {t("buttons.finish")}
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              ) : (
+                <Button onClick={goToNext} className="gap-2">
+                  {isFirstStep ? t("buttons.getStarted") : t("buttons.next")}
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      }
+    >
         <div className="container mx-auto px-6 h-full">
           <AnimatePresence mode="wait" custom={direction}>
             <motion.div
@@ -138,56 +187,7 @@ const Onboarding = () => {
             </motion.div>
           </AnimatePresence>
         </div>
-      </main>
-
-      {/* Navigation Footer */}
-      <div className="fixed bottom-0 left-0 right-0 bg-background/95 backdrop-blur-sm border-t">
-        <div className="container mx-auto px-6 py-4">
-          <div className="flex items-center justify-between">
-            <Button
-              variant="outline"
-              onClick={goToPrevious}
-              disabled={isFirstStep}
-              className="gap-2"
-            >
-              <ChevronLeft className="h-4 w-4" />
-              {t("buttons.previous")}
-            </Button>
-
-            {/* Step indicators */}
-            <nav aria-label={tCommon("a11y.stepNavigation")} className="hidden sm:flex items-center gap-1">
-              {steps.map((step, index) => (
-                <button
-                  key={step.id}
-                  type="button"
-                  onClick={() => {
-                    setDirection(index > currentStep ? 1 : -1);
-                    setCurrentStep(index);
-                  }}
-                  className="p-2 rounded-full"
-                  aria-label={t("buttons.goToStep", { step: index + 1 })}
-                  aria-current={index === currentStep ? "step" : undefined}
-                >
-                  <span className={`block h-2 rounded-full transition-all ${getStepIndicatorClass(index, currentStep)}`} />
-                </button>
-              ))}
-            </nav>
-
-            {isLastStep ? (
-              <Button onClick={navigateToProjects} className="gap-2">
-                {t("buttons.finish")}
-                <ChevronRight className="h-4 w-4" />
-              </Button>
-            ) : (
-              <Button onClick={goToNext} className="gap-2">
-                {isFirstStep ? t("buttons.getStarted") : t("buttons.next")}
-                <ChevronRight className="h-4 w-4" />
-              </Button>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
+    </PageShell>
   );
 };
 

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -9,7 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Navbar } from "@/components/layout/Navbar";
+import { PageShell } from "@/components/layout/PageShell";
 import { DeleteAccountDialog } from "@/components/modals/DeleteAccountDialog";
 import { ValidationChecklist } from "@/components/forms";
 import { useAuth } from "@/contexts/AuthContext";
@@ -225,20 +225,16 @@ const Profile = () => {
 
   if (!user) {
     return (
-      <div className="min-h-screen">
-        <Navbar />
-        <div className="pt-24 flex items-center justify-center" role="status" aria-label={tCommon("a11y.loading")}>
+      <PageShell variant="centered">
+        <output aria-label={tCommon("a11y.loading")}>
           <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-        </div>
-      </div>
+        </output>
+      </PageShell>
     );
   }
 
   return (
-    <div className="min-h-screen bg-background">
-      <Navbar />
-
-      <main id="main-content" className="container mx-auto px-6 pt-24 pb-16">
+    <PageShell>
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
@@ -287,7 +283,7 @@ const Profile = () => {
                 )}
               </div>
             </div>
-            <h1 className="font-display text-3xl font-normal">
+            <h1 className="text-app-title">
               {user.first_name} {user.last_name}
             </h1>
             <p className="text-muted-foreground">{user.email}</p>
@@ -461,7 +457,6 @@ const Profile = () => {
             </CardContent>
           </Card>
         </motion.div>
-      </main>
 
       <DeleteAccountDialog
         open={deleteModalOpen}
@@ -469,7 +464,7 @@ const Profile = () => {
         currentUserId={user.id}
         onConfirmed={handleAccountDeleted}
       />
-    </div>
+    </PageShell>
   );
 };
 

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -170,7 +170,7 @@ const Profile = () => {
     if (!allPasswordRequirementsMet) {
       toast({
         title: t("toast.error"),
-        description: t("toast.passwordMin"),
+        description: tAuth("validation.passwordMin"),
         variant: "destructive",
       });
       return;
@@ -299,7 +299,7 @@ const Profile = () => {
               <CardTitle>{t("editProfile.title")}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div className="space-y-1">
                   <Label htmlFor="firstName">{t("editProfile.firstName")}</Label>
                   <Input
@@ -350,7 +350,7 @@ const Profile = () => {
               <CardTitle>{t("changePassword.title")}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
-              <div>
+              <div className="space-y-2">
                 <Label htmlFor="currentPassword">
                   {t("changePassword.currentPassword")}
                 </Label>
@@ -379,7 +379,7 @@ const Profile = () => {
                 />
               </div>
 
-              <div>
+              <div className="space-y-2">
                 <Label htmlFor="confirmPassword">
                   {t("changePassword.confirmPassword")}
                 </Label>

--- a/frontend/src/pages/ProjectDetail.tsx
+++ b/frontend/src/pages/ProjectDetail.tsx
@@ -7,7 +7,6 @@ import {
   ArrowLeft,
   Loader2,
   Users,
-  Edit,
   UserPlus,
   Trash2,
   ChevronDown,
@@ -336,10 +335,6 @@ const ProjectDetail = () => {
             </span>
             {isAdmin && (
               <div className="flex gap-2">
-                <Button variant="outline" size="sm" className="gap-2">
-                  <Edit className="h-4 w-4" />
-                  {t("detail.edit")}
-                </Button>
                 <Button
                   variant="outline"
                   size="sm"

--- a/frontend/src/pages/ProjectDetail.tsx
+++ b/frontend/src/pages/ProjectDetail.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from "react";
 import { useParams, Link, useNavigate } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
-import { motion } from "framer-motion";
 import {
   ArrowLeft,
   Loader2,
@@ -20,7 +19,8 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { Navbar } from "@/components/layout/Navbar";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { PageShell } from "@/components/layout/PageShell";
 import { InviteExpertModal } from "@/components/modals/InviteExpertModal";
 import { DeleteConfirmModal } from "@/components/modals/DeleteConfirmModal";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
@@ -236,15 +236,12 @@ const ProjectDetail = () => {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen">
-        <Navbar />
-        <main id="main-content" className="pt-24 flex items-center justify-center">
-          <output aria-label={tCommon("a11y.loading")}>
-            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-            <span className="sr-only">{tCommon("common.loading")}</span>
-          </output>
-        </main>
-      </div>
+      <PageShell variant="centered">
+        <output aria-label={tCommon("a11y.loading")}>
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          <span className="sr-only">{tCommon("common.loading")}</span>
+        </output>
+      </PageShell>
     );
   }
 
@@ -302,10 +299,7 @@ const ProjectDetail = () => {
   );
 
   return (
-    <div className="min-h-screen bg-background">
-      <Navbar />
-
-      <main id="main-content" className="container mx-auto px-6 pt-24 pb-16">
+    <PageShell>
         {/* Breadcrumb */}
         <div className="mb-6">
           <Link
@@ -317,18 +311,7 @@ const ProjectDetail = () => {
           </Link>
         </div>
 
-        {/* Header */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="mb-8"
-        >
-          <h1 className="font-display text-3xl md:text-4xl font-normal mb-2">
-            {project.name}
-          </h1>
-          {project.description && (
-            <p className="text-muted-foreground mb-4">{project.description}</p>
-          )}
+        <PageHeader title={project.name} description={project.description ?? undefined}>
           <div className="flex flex-wrap items-center gap-4">
             <span className="font-mono text-sm bg-muted px-3 py-1 rounded">
               {t("detail.scale")}: {project.scale_min} — {project.scale_max} {project.scale_unit}
@@ -361,7 +344,7 @@ const ProjectDetail = () => {
               </div>
             )}
           </div>
-        </motion.div>
+        </PageHeader>
 
         {isDesktop ? (
           <>
@@ -419,7 +402,6 @@ const ProjectDetail = () => {
             <TabsContent value="team">{teamTable}</TabsContent>
           </Tabs>
         )}
-      </main>
 
       <InviteExpertModal
         open={inviteModalOpen}
@@ -459,7 +441,7 @@ const ProjectDetail = () => {
         opinion={profileOpinion}
         onOpenChange={(open) => !open && setProfileMember(null)}
       />
-    </div>
+    </PageShell>
   );
 };
 

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -15,7 +15,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Navbar } from "@/components/layout/Navbar";
+import { PageHeader } from "@/components/layout/PageHeader";
+import { PageShell } from "@/components/layout/PageShell";
 import { CreateProjectModal } from "@/components/modals/CreateProjectModal";
 import { InviteExpertModal } from "@/components/modals/InviteExpertModal";
 import { DeleteConfirmModal } from "@/components/modals/DeleteConfirmModal";
@@ -146,27 +147,19 @@ const Projects = () => {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen">
-        <Navbar />
-        <main id="main-content" className="pt-24 flex items-center justify-center">
-          <output aria-label={tCommon("a11y.loading")}>
-            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-            <span className="sr-only">{tCommon("common.loading")}</span>
-          </output>
-        </main>
-      </div>
+      <PageShell variant="centered">
+        <output aria-label={tCommon("a11y.loading")}>
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          <span className="sr-only">{tCommon("common.loading")}</span>
+        </output>
+      </PageShell>
     );
   }
 
   if (hasLoadError) {
     return (
-      <div className="min-h-screen">
-        <Navbar />
-        <main
-          id="main-content"
-          role="alert"
-          className="pt-24 flex flex-col items-center justify-center gap-4 p-6 text-center"
-        >
+      <PageShell variant="centered">
+        <div role="alert" className="flex flex-col items-center gap-4 p-6 text-center">
           <AlertTriangle className="h-8 w-8 text-muted-foreground" />
           <h1 className="font-display font-medium text-lg">{t("error.title")}</h1>
           <p className="text-muted-foreground max-w-sm">{t("error.description")}</p>
@@ -178,17 +171,14 @@ const Projects = () => {
           >
             {tCommon("errors.retry")}
           </Button>
-        </main>
-      </div>
+        </div>
+      </PageShell>
     );
   }
 
   return (
-    <div className="min-h-screen bg-background">
-      <Navbar />
-      
-      <main id="main-content" className="container mx-auto px-6 pt-24 pb-16">
-        <h1 className="sr-only">{t("heading")}</h1>
+    <PageShell>
+        <PageHeader title={t("heading")} />
         <Tabs defaultValue="projects" className="space-y-6">
           <div className="flex items-center justify-between">
             <TabsList>
@@ -422,7 +412,6 @@ const Projects = () => {
             )}
           </TabsContent>
         </Tabs>
-      </main>
 
       <CreateProjectModal
         open={createModalOpen}
@@ -451,7 +440,7 @@ const Projects = () => {
         confirmText={t("deleteModal.confirm")}
         loadingText={t("deleteModal.deleting")}
       />
-    </div>
+    </PageShell>
   );
 };
 

--- a/frontend/tests/pages/ProjectDetail.test.tsx
+++ b/frontend/tests/pages/ProjectDetail.test.tsx
@@ -178,7 +178,6 @@ describe('ProjectDetail', () => {
     render(<ProjectDetail />);
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /invite experts/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
     });
@@ -190,7 +189,7 @@ describe('ProjectDetail', () => {
     render(<ProjectDetail />);
 
     await waitFor(() => {
-      expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /invite experts/i })).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
Second of three PRs on UI consistency. **Branched off `fix/ui-consistency-bugs` (#318) — merge that first.** No visual redesign: every size and spacing value here is one already in the code, moved to a single place.

## The page shell

All fifteen pages assembled `min-h-screen` + `Navbar` + `<main id="main-content">` + an offset to clear the fixed navbar by hand, and the offsets had drifted (`pt-24` in the app, `pt-24 md:pt-32` on content pages). A shared constant for this was described in the PR7 UI-audit roadmap but never landed.

`PageShell` now owns that frame in three variants — `app` (shared container plus the navbar offset), `content` (spacing left to the page's own sections), `centered` (the single-block loading and error states). Loading and error branches go through it too: building them separately is exactly how `Projects`, `ProjectDetail` and `Profile` ended up rendering their loading state on a different background than the loaded page, and how `Profile`'s loading branch lost the `<main>` landmark entirely.

`Onboarding` keeps its fixed progress bar and nav footer through `beforeMain`/`afterMain`, so its DOM is byte-for-byte what it was.

Three components still build their own frame, deliberately: `ErrorBoundary` renders after React has thrown and must not depend on Navbar's contexts, and `ProtectedRoute`/`ServiceUnavailable` render before auth resolves.

## The heading scale

Six different sizes claimed the role of page title, while `--text-display-1/2/3` — declared in `@theme` for exactly this — were never referenced once. The global `h1/h2/h3` rules were overridden on every single page, so they only applied where a class had been forgotten, masking the omission rather than exposing it.

Five utilities now carry the scale, in two registers — the marketing page runs one step above the working pages:

| Utility | Size | Used by |
|---|---|---|
| `text-page-hero` | `4xl / 6xl / 7xl` | Landing h1 |
| `text-page-title` | `3xl / 5xl` | public content h1 (via HeroSection) |
| `text-app-title` | `3xl / 4xl` | h1 inside the app |
| `text-section-title` | `2xl / 3xl` | h2 everywhere but Landing |
| `text-section-title-lg` | `3xl / 4xl` | Landing h2 |

The global rules keep the display family and drop the sizes, so a heading that forgets a utility now reads at body size and the mistake is visible. Only one heading relied on the old global size and it was `sr-only`. The dead `--text-display-*` tokens are removed — leaving a second, unfinished scale beside the real one is worse than either.

`NotFoundState`'s "404", `CardTitle`, the auth card title and the navbar wordmark keep their own sizes: none of them is a page heading. On an auth page the card *is* the page, so its title matching `CardTitle` is correct rather than a collapsed hierarchy.

## Fixed along the way

- **Documentation and FAQ** hand-rolled a copy of `HeroSection` with different bottom padding. Both now use the component, with a `spacing` prop preserving their tighter gap. This also fixes a real a11y defect: their `#main-content` sat *after* the hero and so excluded the `h1`, meaning the focus `RouteAnnouncer` moves on every navigation landed on a landmark without the page title.
- **Projects had no visible page title** — the `h1` was `sr-only`, so the app's main screen never said where you were.
- **Profile's title** gains the responsive step every other page title already had.

## Verification

`lint`, `typecheck` clean. `test:coverage`: 994 tests, thresholds met (98.51 / 95.44 / 97.85 / 98.75). `ci-local fast`: 1271 backend + 994 frontend green.

Checked live in the browser, computed styles rather than eyeballing:

- h1 at 1280px — Landing 72px; About, Case Studies, Docs, FAQ all 48px (they had diverged); Login 24px.
- h1/h2 at 375px — Landing 36/30px, working pages 30/24px. The two registers stay distinct, no horizontal overflow.
- Docs and FAQ hero padding stays at its compact 48px bottom while About keeps 64px — the prop preserved the difference instead of flattening it.
- `#main-content` contains the `h1` on every route, exactly one `<main>` per page.

**Visual baselines:** structural DOM changed while computed layout did not, so the amd64 snapshots should hold — but this cannot be confirmed on an arm64 Mac. If E2E visual regression fails in CI, regenerate through `regen-snapshots.yml` (#306) or harvest the `-actual` PNGs per #307.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Consolidates route framing and heading typography across the frontend.
- Introduces shared PageShell, PageHeader, and heading-scale utilities.
- Migrates public, application, loading, error, authentication, and onboarding layouts to the shared shell.
- Moves Documentation and FAQ heroes inside the main landmark through HeroSection.
- Updates related localization cleanup, responsive profile layout, chart theming, accessibility audits, and tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, contract, or security defects identified.

The shared shell preserves route landmarks and existing page chrome, explicit heading sizes cover the affected headings, and removed translation keys have valid replacements or no remaining callers.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/src/components/layout/PageShell.tsx | Introduces the shared page frame with app, content, and centered variants plus optional surrounding chrome and footer. |
| frontend/src/index.css | Registers the typography plugin and replaces global heading sizes with explicit reusable heading-scale utilities. |
| frontend/src/components/layout/HeroSection.tsx | Centralizes public-page hero typography, animation, alignment, and compact/default spacing. |
| frontend/src/pages/Documentation.tsx | Moves the hero and document content into one shared main landmark while retaining the sidebar layout. |
| frontend/src/pages/FAQ.tsx | Moves the hero and FAQ content into one shared main landmark while preserving compact spacing and navigation. |
| frontend/src/pages/ProjectDetail.tsx | Migrates loading and loaded states to PageShell and replaces the hand-built title block with PageHeader. |
| frontend/src/pages/Projects.tsx | Migrates all page states to PageShell and adds a visible shared application-page heading. |
| frontend/src/pages/Profile.tsx | Migrates loading and loaded states to PageShell, applies the responsive title scale, and reuses the auth password validation translation. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  R[Route component] --> S[PageShell]
  S --> N[Navbar]
  S --> B[beforeMain chrome]
  S --> M["main#main-content"]
  S --> A[afterMain chrome]
  S --> F[Optional Footer]
  M --> H{Page type}
  H -->|Public content| HS[HeroSection / text-page-title]
  H -->|Application| PH[PageHeader / text-app-title]
  H -->|Loading or error| C[Centered state]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: give every page one shell and ..."](https://github.com/caitlon/become/commit/0d4e0590fafa8085a6a41561ad7bb3192cfc5f54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48827080)</sub>

<!-- /greptile_comment -->