### PR TITLE
refactor: put Profile on the shared form stack and dedupe page states

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -300,14 +300,14 @@
         "filename": "frontend/tests/pages/Profile.test.tsx",
         "hashed_secret": "813ab7bae6589d4b36cb7450559baac29add9e19",
         "is_verified": false,
-        "line_number": 213
+        "line_number": 214
       },
       {
         "type": "Secret Keyword",
         "filename": "frontend/tests/pages/Profile.test.tsx",
         "hashed_secret": "3d2ce02098f0ef75d0c680ff6e4d9a478d6c1c8f",
         "is_verified": false,
-        "line_number": 214
+        "line_number": 215
       }
     ],
     "scripts/ci/e2e-local.sh": [
@@ -1056,5 +1056,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-28T15:03:08Z"
+  "generated_at": "2026-07-30T20:45:28Z"
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,4 @@
 import { lazy, Suspense } from "react";
-import { useTranslation } from "react-i18next";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClientProvider } from "@tanstack/react-query";
@@ -9,8 +8,8 @@ import { AuthProvider } from "@/contexts/AuthContext";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { RouteAnnouncer } from "@/components/RouteAnnouncer";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { PageSpinner } from "@/components/PageSpinner";
 import { createQueryClient } from "@/lib/queryClient";
-import { Loader2 } from "lucide-react";
 
 const Landing = lazy(() => import("./pages/Landing"));
 const Login = lazy(() => import("./pages/Login"));
@@ -31,13 +30,9 @@ const NotFound = lazy(() => import("./pages/NotFound"));
 const queryClient = createQueryClient();
 
 function PageLoader() {
-  const { t } = useTranslation();
   return (
     <main id="main-content" tabIndex={-1} className="min-h-screen flex items-center justify-center">
-      <output>
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-        <span className="sr-only">{t("common.loading")}</span>
-      </output>
+      <PageSpinner />
     </main>
   );
 }

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,28 @@
+import { motion } from "framer-motion";
+import type { LucideIcon } from "lucide-react";
+
+interface EmptyStateProps {
+  readonly icon: LucideIcon;
+  readonly title: string;
+  readonly description: string;
+  /** Call to action. Omit where there is nothing for the user to do yet. */
+  readonly children?: React.ReactNode;
+}
+
+/** The "nothing here yet" block shown in place of a list or grid. */
+export function EmptyState({ icon: Icon, title, description, children }: EmptyStateProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      className="text-center py-16"
+    >
+      <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center mx-auto mb-4">
+        <Icon className="h-8 w-8 text-muted-foreground" />
+      </div>
+      <h3 className="font-display font-medium text-lg mb-2">{title}</h3>
+      <p className={`text-muted-foreground${children ? " mb-6" : ""}`}>{description}</p>
+      {children}
+    </motion.div>
+  );
+}

--- a/frontend/src/components/PageSpinner.tsx
+++ b/frontend/src/components/PageSpinner.tsx
@@ -1,0 +1,24 @@
+import { Loader2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { cn } from "@/lib/utils";
+
+interface PageSpinnerProps {
+  readonly className?: string;
+}
+
+/**
+ * The one loading indicator for a whole page or route. Uses <output>, which
+ * carries an implicit `status` role, so the label and the visually hidden text
+ * both reach a screen reader.
+ */
+export function PageSpinner({ className }: PageSpinnerProps) {
+  const { t } = useTranslation();
+
+  return (
+    <output aria-label={t("a11y.loading")} className={cn(className)}>
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      <span className="sr-only">{t("common.loading")}</span>
+    </output>
+  );
+}

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -1,8 +1,7 @@
 import { Navigate, useLocation } from "react-router";
-import { useTranslation } from "react-i18next";
 import { useAuth } from "@/contexts/AuthContext";
 import { ServiceUnavailable } from "@/components/auth/ServiceUnavailable";
-import { Loader2 } from "lucide-react";
+import { PageSpinner } from "@/components/PageSpinner";
 
 interface ProtectedRouteProps {
   readonly children: React.ReactNode;
@@ -11,17 +10,12 @@ interface ProtectedRouteProps {
 export function ProtectedRoute({ children }: ProtectedRouteProps) {
   const { isAuthenticated, isLoading, isServiceUnavailable, refreshUser } = useAuth();
   const location = useLocation();
-  const { t } = useTranslation();
 
   if (isLoading) {
     return (
-      <output
-        aria-label={t("a11y.loading")}
-        aria-live="polite"
-        className="min-h-screen flex items-center justify-center"
-      >
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-      </output>
+      <div className="min-h-screen flex items-center justify-center">
+        <PageSpinner />
+      </div>
     );
   }
 

--- a/frontend/src/components/forms/FormField.tsx
+++ b/frontend/src/components/forms/FormField.tsx
@@ -34,7 +34,7 @@ function FormFieldWrapper({ label, error, description, fieldId, children }: Form
         </p>
       )}
       {error && (
-        <p id={errorId} className="text-sm text-destructive">
+        <p id={errorId} role="alert" className="text-sm text-destructive">
           {error.message}
         </p>
       )}

--- a/frontend/src/components/forms/PasswordInput.tsx
+++ b/frontend/src/components/forms/PasswordInput.tsx
@@ -52,7 +52,7 @@ const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
           </button>
         </div>
         {error && (
-          <p id={errorId} className="text-sm text-destructive">
+          <p id={errorId} role="alert" className="text-sm text-destructive">
             {error.message}
           </p>
         )}

--- a/frontend/src/components/modals/CreateProjectModal.tsx
+++ b/frontend/src/components/modals/CreateProjectModal.tsx
@@ -71,6 +71,7 @@ export function CreateProjectModal({
     formState: { errors },
   } = useForm<z.input<typeof createProjectSchema>, unknown, CreateProjectFormData>({
     resolver: zodResolver(createProjectSchema),
+    mode: "onTouched",
     defaultValues: {
       scale_min: 0,
       scale_max: 100,
@@ -133,6 +134,7 @@ export function CreateProjectModal({
             label={t("create.description")}
             placeholder={t("create.descriptionPlaceholder")}
             rows={3}
+            error={errors.description}
             {...register("description")}
           />
 

--- a/frontend/src/i18n/locales/cs/profile.json
+++ b/frontend/src/i18n/locales/cs/profile.json
@@ -3,14 +3,16 @@
     "title": "Upravit profil",
     "firstName": "Jméno",
     "lastName": "Příjmení",
-    "save": "Uložit změny"
+    "save": "Uložit změny",
+    "saving": "Ukládání..."
   },
   "changePassword": {
     "title": "Změnit heslo",
     "currentPassword": "Současné heslo",
     "newPassword": "Nové heslo",
     "confirmPassword": "Potvrdit nové heslo",
-    "update": "Aktualizovat heslo"
+    "update": "Aktualizovat heslo",
+    "updating": "Aktualizace..."
   },
   "dataExport": {
     "title": "Stáhnout vaše data",
@@ -53,7 +55,6 @@
     "error": "Chyba",
     "profileUpdated": "Profil aktualizován",
     "updateFailed": "Nepodařilo se aktualizovat profil",
-    "passwordsNoMatch": "Hesla se neshodují",
     "passwordUpdated": "Heslo aktualizováno",
     "passwordFailed": "Nepodařilo se změnit heslo",
     "accountDeleted": "Účet smazán",

--- a/frontend/src/i18n/locales/en/profile.json
+++ b/frontend/src/i18n/locales/en/profile.json
@@ -3,14 +3,16 @@
     "title": "Edit Profile",
     "firstName": "First Name",
     "lastName": "Last Name",
-    "save": "Save Changes"
+    "save": "Save Changes",
+    "saving": "Saving..."
   },
   "changePassword": {
     "title": "Change Password",
     "currentPassword": "Current Password",
     "newPassword": "New Password",
     "confirmPassword": "Confirm New Password",
-    "update": "Update Password"
+    "update": "Update Password",
+    "updating": "Updating..."
   },
   "dataExport": {
     "title": "Download Your Data",
@@ -53,7 +55,6 @@
     "error": "Error",
     "profileUpdated": "Profile updated",
     "updateFailed": "Failed to update profile",
-    "passwordsNoMatch": "Passwords do not match",
     "passwordUpdated": "Password updated",
     "passwordFailed": "Failed to change password",
     "accountDeleted": "Account deleted",

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,4 +1,7 @@
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
+import { useForm, useWatch } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
@@ -6,22 +9,35 @@ import { Loader2, AlertTriangle, Camera, Trash2, Download } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { PageSpinner } from "@/components/PageSpinner";
 import { PageShell } from "@/components/layout/PageShell";
 import { DeleteAccountDialog } from "@/components/modals/DeleteAccountDialog";
-import { ValidationChecklist } from "@/components/forms";
+import {
+  FormField,
+  PasswordInput,
+  SubmitButton,
+  ValidationChecklist,
+} from "@/components/forms";
 import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
 import { downloadJson } from "@/lib/download";
 import { useToast } from "@/hooks/use-toast";
-import { cn } from "@/lib/utils";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
-import { getPasswordRequirements } from "@/lib/validation";
+import { buildPasswordSchema, getPasswordRequirements } from "@/lib/validation";
 
 const NAME_REGEX = /^[\p{L}\s'-]+$/u;
-const isValidName = (name: string) => !name || NAME_REGEX.test(name);
+
+interface ProfileFormData {
+  firstName: string;
+  lastName: string;
+}
+
+interface PasswordFormData {
+  currentPassword: string;
+  newPassword: string;
+  confirmPassword: string;
+}
 
 const Profile = () => {
   const { t } = useTranslation("profile");
@@ -33,40 +49,65 @@ const Profile = () => {
   const navigate = useNavigate();
 
   // Profile form
-  const [firstName, setFirstName] = useState(user?.first_name || "");
-  const [lastName, setLastName] = useState(user?.last_name || "");
   const [isSavingProfile, setIsSavingProfile] = useState(false);
-  const [firstNameError, setFirstNameError] = useState<string | null>(null);
-  const [lastNameError, setLastNameError] = useState<string | null>(null);
 
-  const handleFirstNameChange = (value: string) => {
-    setFirstName(value);
-    if (value && !isValidName(value)) {
-      setFirstNameError(tAuth("validation.nameFormat"));
-    } else {
-      setFirstNameError(null);
-    }
-  };
+  const profileSchema = useMemo(
+    () =>
+      z.object({
+        firstName: z
+          .string()
+          .min(1, tAuth("validation.firstNameRequired"))
+          .max(100)
+          .regex(NAME_REGEX, tAuth("validation.nameFormat")),
+        // Optional on this form: the API accepts a user with no surname.
+        lastName: z
+          .string()
+          .max(100)
+          .regex(NAME_REGEX, tAuth("validation.nameFormat"))
+          .or(z.literal("")),
+      }),
+    [tAuth]
+  );
 
-  const handleLastNameChange = (value: string) => {
-    setLastName(value);
-    if (value && !isValidName(value)) {
-      setLastNameError(tAuth("validation.nameFormat"));
-    } else {
-      setLastNameError(null);
-    }
-  };
-
-  const hasNameErrors = firstNameError !== null || lastNameError !== null;
+  const profileForm = useForm<ProfileFormData>({
+    resolver: zodResolver(profileSchema),
+    mode: "onTouched",
+    defaultValues: {
+      firstName: user?.first_name ?? "",
+      lastName: user?.last_name ?? "",
+    },
+  });
 
   // Password form
-  const [currentPassword, setCurrentPassword] = useState("");
-  const [newPassword, setNewPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
   const [isChangingPassword, setIsChangingPassword] = useState(false);
 
+  const passwordSchema = useMemo(
+    () =>
+      z
+        .object({
+          currentPassword: z.string().min(1, tAuth("validation.passwordRequired")),
+          newPassword: buildPasswordSchema(tAuth),
+          confirmPassword: z.string().min(1, tAuth("validation.passwordRequired")),
+        })
+        .refine((data) => data.newPassword === data.confirmPassword, {
+          error: tAuth("validation.passwordsMatch"),
+          path: ["confirmPassword"],
+        }),
+    [tAuth]
+  );
+
+  const passwordForm = useForm<PasswordFormData>({
+    resolver: zodResolver(passwordSchema),
+    mode: "onTouched",
+    defaultValues: { currentPassword: "", newPassword: "", confirmPassword: "" },
+  });
+
+  const newPassword = useWatch({
+    control: passwordForm.control,
+    name: "newPassword",
+    defaultValue: "",
+  });
   const passwordRequirements = getPasswordRequirements(newPassword, tAuth);
-  const allPasswordRequirementsMet = passwordRequirements.every((req) => req.met);
 
   // Delete account
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
@@ -134,13 +175,12 @@ const Profile = () => {
     ? `${user.first_name[0]}${user.last_name?.[0] || ""}`.toUpperCase()
     : "";
 
-  const handleSaveProfile = async () => {
+  const handleSaveProfile = async (data: ProfileFormData) => {
     setIsSavingProfile(true);
     try {
       await api.updateCurrentUser({
-        first_name: firstName,
-        /* v8 ignore next */
-        last_name: lastName || undefined,
+        first_name: data.firstName,
+        last_name: data.lastName || undefined,
       });
       await refreshUser();
       toast({ title: t("toast.profileUpdated") });
@@ -156,35 +196,14 @@ const Profile = () => {
     }
   };
 
-  const handleChangePassword = async () => {
-    if (newPassword !== confirmPassword) {
-      toast({
-        title: t("toast.error"),
-        description: t("toast.passwordsNoMatch"),
-        variant: "destructive",
-      });
-      return;
-    }
-
-    /* v8 ignore next 7 -- button is disabled when requirements are not met */
-    if (!allPasswordRequirementsMet) {
-      toast({
-        title: t("toast.error"),
-        description: tAuth("validation.passwordMin"),
-        variant: "destructive",
-      });
-      return;
-    }
-
+  const handleChangePassword = async (data: PasswordFormData) => {
     setIsChangingPassword(true);
     try {
       await api.changePassword({
-        current_password: currentPassword,
-        new_password: newPassword,
+        current_password: data.currentPassword,
+        new_password: data.newPassword,
       });
-      setCurrentPassword("");
-      setNewPassword("");
-      setConfirmPassword("");
+      passwordForm.reset();
       toast({ title: t("toast.passwordUpdated") });
     } catch (error) {
       toast({
@@ -226,9 +245,7 @@ const Profile = () => {
   if (!user) {
     return (
       <PageShell variant="centered">
-        <output aria-label={tCommon("a11y.loading")}>
-          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-        </output>
+        <PageSpinner />
       </PageShell>
     );
   }
@@ -294,49 +311,35 @@ const Profile = () => {
             <CardHeader>
               <CardTitle>{t("editProfile.title")}</CardTitle>
             </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div className="space-y-1">
-                  <Label htmlFor="firstName">{t("editProfile.firstName")}</Label>
-                  <Input
-                    id="firstName"
-                    value={firstName}
-                    onChange={(e) => handleFirstNameChange(e.target.value)}
-                    className={cn(firstNameError && "border-destructive")}
-                    aria-describedby={firstNameError ? "firstName-error" : undefined}
-                    aria-invalid={!!firstNameError}
-                  />
-                  {firstNameError && (
-                    <p id="firstName-error" role="alert" className="text-sm text-destructive">{firstNameError}</p>
-                  )}
-                </div>
-                <div className="space-y-1">
-                  <Label htmlFor="lastName">{t("editProfile.lastName")}</Label>
-                  <Input
-                    id="lastName"
-                    value={lastName}
-                    onChange={(e) => handleLastNameChange(e.target.value)}
-                    className={cn(lastNameError && "border-destructive")}
-                    aria-describedby={lastNameError ? "lastName-error" : undefined}
-                    aria-invalid={!!lastNameError}
-                  />
-                  {lastNameError && (
-                    <p id="lastName-error" role="alert" className="text-sm text-destructive">{lastNameError}</p>
-                  )}
-                </div>
-              </div>
-
-              <Button
-                onClick={handleSaveProfile}
-                disabled={isSavingProfile || !firstName || hasNameErrors}
-                className="w-full"
+            <CardContent>
+              <form
+                onSubmit={profileForm.handleSubmit(handleSaveProfile)}
+                className="space-y-4"
               >
-                {isSavingProfile ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  t("editProfile.save")
-                )}
-              </Button>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <FormField
+                    label={t("editProfile.firstName")}
+                    autoComplete="given-name"
+                    error={profileForm.formState.errors.firstName}
+                    {...profileForm.register("firstName")}
+                  />
+                  <FormField
+                    label={t("editProfile.lastName")}
+                    autoComplete="family-name"
+                    error={profileForm.formState.errors.lastName}
+                    {...profileForm.register("lastName")}
+                  />
+                </div>
+
+                <SubmitButton
+                  className="w-full"
+                  isLoading={isSavingProfile}
+                  loadingText={t("editProfile.saving")}
+                  disabled={!profileForm.formState.isValid}
+                >
+                  {t("editProfile.save")}
+                </SubmitButton>
+              </form>
             </CardContent>
           </Card>
 
@@ -345,65 +348,49 @@ const Profile = () => {
             <CardHeader>
               <CardTitle>{t("changePassword.title")}</CardTitle>
             </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="currentPassword">
-                  {t("changePassword.currentPassword")}
-                </Label>
-                <Input
-                  id="currentPassword"
-                  type="password"
-                  value={currentPassword}
-                  onChange={(e) => setCurrentPassword(e.target.value)}
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="newPassword">
-                  {t("changePassword.newPassword")}
-                </Label>
-                <Input
-                  id="newPassword"
-                  type="password"
-                  value={newPassword}
-                  onChange={(e) => setNewPassword(e.target.value)}
-                />
-                <ValidationChecklist
-                  title={tAuth("passwordRequirements.title")}
-                  requirements={passwordRequirements}
-                  show={!!newPassword}
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="confirmPassword">
-                  {t("changePassword.confirmPassword")}
-                </Label>
-                <Input
-                  id="confirmPassword"
-                  type="password"
-                  value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
-                />
-              </div>
-
-              <Button
-                onClick={handleChangePassword}
-                disabled={
-                  isChangingPassword ||
-                  !currentPassword ||
-                  !newPassword ||
-                  !confirmPassword ||
-                  !allPasswordRequirementsMet
-                }
-                className="w-full"
+            <CardContent>
+              <form
+                onSubmit={passwordForm.handleSubmit(handleChangePassword)}
+                className="space-y-4"
               >
-                {isChangingPassword ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  t("changePassword.update")
-                )}
-              </Button>
+                <PasswordInput
+                  label={t("changePassword.currentPassword")}
+                  autoComplete="current-password"
+                  error={passwordForm.formState.errors.currentPassword}
+                  {...passwordForm.register("currentPassword")}
+                />
+
+                <div>
+                  <PasswordInput
+                    label={t("changePassword.newPassword")}
+                    autoComplete="new-password"
+                    error={passwordForm.formState.errors.newPassword}
+                    {...passwordForm.register("newPassword")}
+                  />
+                  <ValidationChecklist
+                    title={tAuth("passwordRequirements.title")}
+                    requirements={passwordRequirements}
+                    show={!!newPassword}
+                  />
+                </div>
+
+                <FormField
+                  label={t("changePassword.confirmPassword")}
+                  type="password"
+                  autoComplete="new-password"
+                  error={passwordForm.formState.errors.confirmPassword}
+                  {...passwordForm.register("confirmPassword")}
+                />
+
+                <SubmitButton
+                  className="w-full"
+                  isLoading={isChangingPassword}
+                  loadingText={t("changePassword.updating")}
+                  disabled={!passwordForm.formState.isValid}
+                >
+                  {t("changePassword.update")}
+                </SubmitButton>
+              </form>
             </CardContent>
           </Card>
 

--- a/frontend/src/pages/ProjectDetail.tsx
+++ b/frontend/src/pages/ProjectDetail.tsx
@@ -4,7 +4,6 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import {
   ArrowLeft,
-  Loader2,
   Users,
   UserPlus,
   Trash2,
@@ -19,6 +18,8 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import { NotFoundState } from "@/components/NotFoundState";
+import { PageSpinner } from "@/components/PageSpinner";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { PageShell } from "@/components/layout/PageShell";
 import { InviteExpertModal } from "@/components/modals/InviteExpertModal";
@@ -237,16 +238,16 @@ const ProjectDetail = () => {
   if (isLoading) {
     return (
       <PageShell variant="centered">
-        <output aria-label={tCommon("a11y.loading")}>
-          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-          <span className="sr-only">{tCommon("common.loading")}</span>
-        </output>
+        <PageSpinner />
       </PageShell>
     );
   }
 
+  // Loading is over and there is still no project: the redirect in the
+  // hasLoadError effect above has not landed yet, or the id resolved to
+  // nothing. Either way, show the not-found screen rather than a blank page.
   if (!project) {
-    return null;
+    return <NotFoundState />;
   }
 
   const resultsErrorFallback = (

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -15,6 +15,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { EmptyState } from "@/components/EmptyState";
+import { PageSpinner } from "@/components/PageSpinner";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { PageShell } from "@/components/layout/PageShell";
 import { CreateProjectModal } from "@/components/modals/CreateProjectModal";
@@ -148,10 +150,7 @@ const Projects = () => {
   if (isLoading) {
     return (
       <PageShell variant="centered">
-        <output aria-label={tCommon("a11y.loading")}>
-          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-          <span className="sr-only">{tCommon("common.loading")}</span>
-        </output>
+        <PageSpinner />
       </PageShell>
     );
   }
@@ -201,23 +200,16 @@ const Projects = () => {
 
           <TabsContent value="projects" className="space-y-6">
             {projects.length === 0 ? (
-              <motion.div
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                className="text-center py-16"
+              <EmptyState
+                icon={Inbox}
+                title={t("empty.title")}
+                description={t("empty.description")}
               >
-                <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center mx-auto mb-4">
-                  <Inbox className="h-8 w-8 text-muted-foreground" />
-                </div>
-                <h3 className="font-display font-medium text-lg mb-2">{t("empty.title")}</h3>
-                <p className="text-muted-foreground mb-6">
-                  {t("empty.description")}
-                </p>
                 <Button onClick={() => setCreateModalOpen(true)} className="gap-2">
                   <Plus className="h-4 w-4" />
                   {t("empty.createFirst")}
                 </Button>
-              </motion.div>
+              </EmptyState>
             ) : (
               <>
               <motion.div
@@ -326,19 +318,11 @@ const Projects = () => {
 
           <TabsContent value="invitations" className="space-y-6">
             {invitations.length === 0 ? (
-              <motion.div
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                className="text-center py-16"
-              >
-                <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center mx-auto mb-4">
-                  <Mail className="h-8 w-8 text-muted-foreground" />
-                </div>
-                <h3 className="font-display font-medium text-lg mb-2">{t("invitations.empty.title")}</h3>
-                <p className="text-muted-foreground">
-                  {t("invitations.empty.description")}
-                </p>
-              </motion.div>
+              <EmptyState
+                icon={Mail}
+                title={t("invitations.empty.title")}
+                description={t("invitations.empty.description")}
+              />
             ) : (
               <motion.div
                 className="space-y-4 max-w-2xl"

--- a/frontend/tests/pages/Profile.test.tsx
+++ b/frontend/tests/pages/Profile.test.tsx
@@ -176,8 +176,9 @@ describe('Profile - Edit Profile', () => {
     const firstNameInput = screen.getByLabelText('First Name');
     await user.clear(firstNameInput);
     await user.type(firstNameInput, 'John123');
+    await user.tab();
 
-    expect(screen.getByText(/can only contain letters/i)).toBeInTheDocument();
+    expect(await screen.findByText(/can only contain letters/i)).toBeInTheDocument();
   });
 
   it('disables save button when first name is empty', async () => {
@@ -216,24 +217,19 @@ describe('Profile - Change Password', () => {
     });
   });
 
-  it('shows error toast when passwords do not match', async () => {
+  it('shows an inline error when passwords do not match', async () => {
     const user = userEvent.setup();
     render(<Profile />);
 
     await user.type(screen.getByLabelText('Current Password'), 'oldPassword123!');
     await user.type(screen.getByLabelText('New Password'), 'NewPassword1!@#');
     await user.type(screen.getByLabelText('Confirm New Password'), 'DiffPassword1!@#');
+    await user.tab();
 
-    await user.click(screen.getByRole('button', { name: 'Update Password' }));
-
-    await waitFor(() => {
-      expect(mockToast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          variant: 'destructive',
-          description: 'Passwords do not match',
-        })
-      );
-    });
+    // The mismatch is reported under the field, not as a toast, so it stays
+    // next to the input the user has to correct.
+    expect(await screen.findByText('Passwords must match')).toBeInTheDocument();
+    expect(mockApi.changePassword).not.toHaveBeenCalled();
   });
 
   it('shows password requirements when typing new password', async () => {
@@ -484,14 +480,19 @@ describe('Profile - Name Validation', () => {
     const firstNameInput = screen.getByLabelText('First Name');
     await user.clear(firstNameInput);
     await user.type(firstNameInput, 'John123');
+    // Validation runs onTouched, so the field has to be blurred once before
+    // errors appear; after that it revalidates as the user types.
+    await user.tab();
 
-    expect(screen.getByText(/can only contain letters/i)).toBeInTheDocument();
+    expect(await screen.findByText(/can only contain letters/i)).toBeInTheDocument();
     expect(firstNameInput).toHaveAttribute('aria-invalid', 'true');
 
     await user.clear(firstNameInput);
     await user.type(firstNameInput, 'John');
 
-    expect(screen.queryByText(/can only contain letters/i)).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText(/can only contain letters/i)).not.toBeInTheDocument();
+    });
     expect(firstNameInput).toHaveAttribute('aria-invalid', 'false');
   });
 
@@ -502,14 +503,21 @@ describe('Profile - Name Validation', () => {
     const lastNameInput = screen.getByLabelText('Last Name');
     await user.clear(lastNameInput);
     await user.type(lastNameInput, 'Doe@!');
+    await user.tab();
 
-    const alerts = screen.getAllByRole('alert');
-    expect(alerts.length).toBeGreaterThan(0);
+    // Assert on this field's own message: tabbing lands in the password form
+    // below, which touches its first field and raises an unrelated alert.
+    const error = await screen.findByText(/can only contain letters/i);
+    expect(error).toHaveAttribute('role', 'alert');
+    expect(lastNameInput).toHaveAttribute('aria-invalid', 'true');
 
     await user.clear(lastNameInput);
     await user.type(lastNameInput, 'Doe');
 
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText(/can only contain letters/i)).not.toBeInTheDocument();
+    });
+    expect(lastNameInput).toHaveAttribute('aria-invalid', 'false');
   });
 
   it('disables save button when name has validation errors', async () => {
@@ -614,25 +622,20 @@ describe('Profile - Password Change Success/Error', () => {
     expect(screen.getByRole('button', { name: 'Update Password' })).toBeDisabled();
   });
 
-  it('shows error toast when passwords do not match but requirements met', async () => {
+  it('blocks submission when passwords do not match but requirements are met', async () => {
     const user = userEvent.setup();
     render(<Profile />);
 
     await user.type(screen.getByLabelText('Current Password'), 'OldPassword1!@#');
     await user.type(screen.getByLabelText('New Password'), 'NewPassword1!@#');
     await user.type(screen.getByLabelText('Confirm New Password'), 'DiffPassword1!@#');
+    await user.tab();
 
-    // Both meet requirements so button should be clickable
-    await user.click(screen.getByRole('button', { name: 'Update Password' }));
-
-    await waitFor(() => {
-      expect(mockToast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          description: 'Passwords do not match',
-          variant: 'destructive',
-        })
-      );
-    });
+    // The mismatch is a schema error now, so the form never submits and the
+    // message sits under the field rather than in a toast.
+    expect(await screen.findByText('Passwords must match')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Update Password' })).toBeDisabled();
+    expect(mockApi.changePassword).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Last of three PRs on UI consistency. **Branched off `refactor/page-shell-and-type-scale` (#320), which in turn sits on #318 — merge those first.**

## Profile was the last page validating by hand

Five forms in the app run on react-hook-form + zod through the shared `FormField` / `PasswordInput` / `SubmitButton`. Profile's two ran on `useState` with their own regex, which meant:

- **Change-password errors went only to a toast.** A mismatch produced a destructive toast with no `aria-invalid` on the offending input and nothing under the field — so the message appeared away from the input the user has to correct, and a screen reader got no association at all. It is a schema error now, reported inline like every other form.
- **The save buttons dropped their accessible name while saving.** Both raw `Button`s replaced their text with a bare `Loader2`, so the button lost its label at exactly the moment it mattered. The Download Data button in the same file already kept text and spinner together; `SubmitButton` does the same everywhere else.
- **Four different "is this form valid" strategies** existed across the app. Profile's two hand-rolled boolean expressions are now `formState.isValid`, the same as Register and ResetPassword.

`role="alert"` moves onto the shared field wrapper and `PasswordInput` as part of this. Profile's hand-written markup had it and the shared components did not, so rather than Profile losing the announcement, every form gains it.

## Also in this PR

- **`CreateProjectModal`** was the only RHF form still on the default `onSubmit` timing, so errors appeared only after a submit attempt — now `onTouched` like the rest. Its description textarea was also never passed its `error` prop, so a validation failure there rendered nothing.
- **`PageSpinner`** replaces five separately written copies of the same spinner (`App.tsx`, `ProtectedRoute`, `Projects`, `ProjectDetail`, `Profile`), which had drifted into two idioms — `role="status"` and `<output>` — and disagreed on whether to include the visually hidden label.
- **`EmptyState`** replaces the two hand-copied empty blocks on Projects.
- **`ProjectDetail` rendered a blank page** when loading finished with no project: `return null` produced a white screen with no navbar and no explanation. It now shows the not-found screen.

## Verification

`lint`, `typecheck` clean. `test:coverage`: 994 tests, thresholds met (98.49 / 95.13 / 97.83 / 98.74).

Five tests in `Profile.test.tsx` were updated because the behaviour they asserted changed on purpose — the password mismatch is no longer a toast, and validation now fires on blur rather than on every keystroke. They assert the inline message and that `api.changePassword` is never reached. One of them had to stop querying `getAllByRole('alert')` document-wide: tabbing out of the last-name field lands in the password form below and touches its first field, raising an unrelated alert, so it now asserts on its own field's message.
