### PR TITLE
fix: deliver the csrf token to a spa on a different host

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -266,14 +266,14 @@
         "filename": "frontend/tests/lib/api.test.ts",
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_verified": false,
-        "line_number": 469
+        "line_number": 580
       },
       {
         "type": "Secret Keyword",
         "filename": "frontend/tests/lib/api.test.ts",
         "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
         "is_verified": false,
-        "line_number": 663
+        "line_number": 787
       }
     ],
     "frontend/tests/lib/validation.test.ts": [
@@ -421,112 +421,112 @@
         "filename": "tests/integration/api/auth/test_auth.py",
         "hashed_secret": "72559b51f94a7a3ad058c5740cbe2f7cb0d4080b",
         "is_verified": false,
-        "line_number": 14
+        "line_number": 20
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/api/auth/test_auth.py",
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_verified": false,
-        "line_number": 100
+        "line_number": 106
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/api/auth/test_auth.py",
         "hashed_secret": "4ac8e380d51f3acc0e5fb586bb209b592f837e10",
         "is_verified": false,
-        "line_number": 116
+        "line_number": 122
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/api/auth/test_auth.py",
         "hashed_secret": "9d2621ef1cd618ef8e896aa14b97113254f44f55",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 139
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/api/auth/test_auth.py",
         "hashed_secret": "dd45ccd44c543b225b36e3314ceef8759a9c6b88",
         "is_verified": false,
-        "line_number": 150
+        "line_number": 156
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/api/auth/test_auth.py",
         "hashed_secret": "e82f75c25f6288f9fd4a02281ec687709986e55b",
         "is_verified": false,
-        "line_number": 167
+        "line_number": 173
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/api/auth/test_auth.py",
         "hashed_secret": "2b8f0e2da3babfc4530da58570ef4850718380d7",
         "is_verified": false,
-        "line_number": 219
+        "line_number": 225
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/api/auth/test_auth.py",
         "hashed_secret": "b0426f3cce577fc98d6485a08cdf36f6ead2997c",
         "is_verified": false,
-        "line_number": 224
+        "line_number": 230
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/api/auth/test_auth.py",
         "hashed_secret": "d8bba58683e577cdd462e2cd1207808e1b01b3cb",
         "is_verified": false,
-        "line_number": 236
+        "line_number": 242
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/api/auth/test_auth.py",
         "hashed_secret": "0a43574105b7b0b34105cc521cbb984689b687dd",
         "is_verified": false,
-        "line_number": 580
+        "line_number": 586
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/api/auth/test_auth.py",
         "hashed_secret": "f479c4a4cce57a73cc7b21c7f6121578c7b6721b",
         "is_verified": false,
-        "line_number": 599
+        "line_number": 605
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/api/auth/test_auth.py",
         "hashed_secret": "b64ca15ef136afeb98bc611387381b2f79b7a6b2",
         "is_verified": false,
-        "line_number": 615
+        "line_number": 621
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/api/auth/test_auth.py",
         "hashed_secret": "cc66a9094e133f44da4b43c2e3549ce57eec77fe",
         "is_verified": false,
-        "line_number": 631
+        "line_number": 637
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/api/auth/test_auth.py",
         "hashed_secret": "a55a3986a699ba4d2b29b2057811322bf076abd0",
         "is_verified": false,
-        "line_number": 647
+        "line_number": 653
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/api/auth/test_auth.py",
         "hashed_secret": "6b76447d5b887021a79e2d4d46448970d15addaf",
         "is_verified": false,
-        "line_number": 663
+        "line_number": 669
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/api/auth/test_auth.py",
         "hashed_secret": "d5187d62eb205e7330677263f98292f2c2c4e60c",
         "is_verified": false,
-        "line_number": 767
+        "line_number": 773
       }
     ],
     "tests/integration/api/auth/test_current_user_cache.py": [
@@ -1183,5 +1183,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-31T15:55:52Z"
+  "generated_at": "2026-07-31T18:46:02Z"
 }

--- a/api/README.md
+++ b/api/README.md
@@ -92,7 +92,7 @@ api/
 | POST | `/api/v1/auth/refresh` | Refresh access token |
 | POST | `/api/v1/auth/forgot-password` | Request a password reset email |
 | POST | `/api/v1/auth/reset-password` | Reset password using a token |
-| GET | `/api/v1/auth/me` | Get current user profile |
+| GET | `/api/v1/auth/me` | Get current user profile, plus the session's CSRF token as a header |
 
 **Registration and activation.** `POST /auth/register` always answers `202` with the same
 body, whether the address is free, already registered but unverified, or already registered
@@ -124,9 +124,18 @@ does.
 `/api/v1/auth`) plus a readable `csrf_token` cookie; the tokens are also returned in the
 response body so programmatic clients can keep using the `Authorization: Bearer` header.
 A cookie-authenticated mutating request (POST/PUT/PATCH/DELETE) must echo the
-`csrf_token` cookie back in an `X-CSRF-Token` header (double-submit CSRF); Bearer-header
+`csrf_token` value back in an `X-CSRF-Token` header (double-submit CSRF); Bearer-header
 requests are exempt. `/auth/refresh` reads the refresh token from the cookie or the body,
 and logout revokes the session and clears the cookies.
+
+Login and refresh also return that value in an `X-CSRF-Token` **response** header, and
+`GET /auth/me` returns whatever the request's own `csrf_token` cookie holds -- nothing is
+minted there, and a request without the cookie gets no header. This is not redundancy: the
+cookie has no `Domain` attribute, so it belongs to the API host, and a browser app served
+from any other host cannot read it out of `document.cookie` even though the browser keeps
+sending it. The header is that app's only copy of the value, which is why
+`CORSMiddleware` lists it under `expose_headers` as well as `allow_headers`. See
+`docs/security.md` for why the cookie is not widened with a `Domain` instead.
 
 ### Users
 

--- a/api/auth/cookies.py
+++ b/api/auth/cookies.py
@@ -3,9 +3,11 @@
 Access and refresh tokens are delivered as ``Secure; HttpOnly; SameSite=Strict``
 cookies so JavaScript cannot read them (blunts token theft via XSS). A separate,
 readable ``csrf_token`` cookie backs the double-submit CSRF check: the SPA echoes it
-in the ``X-CSRF-Token`` header on mutating requests. The token also stays in the login
-response body so programmatic clients and the test suite can keep using the
-``Authorization: Bearer`` header.
+in the ``X-CSRF-Token`` header on mutating requests. The same value goes out in an
+``X-CSRF-Token`` *response* header, which is the only copy a cross-host SPA can reach
+(see :func:`set_csrf_header`). The token also stays in the login response body so
+programmatic clients and the test suite can keep using the ``Authorization: Bearer``
+header.
 """
 
 import secrets
@@ -91,6 +93,38 @@ def set_auth_cookies(
         secure=secure,
         samesite="strict",
     )
+
+
+def set_csrf_header(response: Response, csrf_token: str | None) -> None:
+    """Repeat the CSRF token in a response header so a cross-host SPA can read it.
+
+    The ``csrf_token`` cookie carries no ``Domain`` attribute, so it belongs to the API
+    host alone. In every deployed environment the SPA is served from a different host and
+    ``document.cookie`` shows it nothing, which leaves it unable to fill in the
+    ``X-CSRF-Token`` request header the double-submit check demands. The header is the
+    copy it can reach; ``CORSMiddleware`` must name it in ``expose_headers`` for the
+    browser to hand it over.
+
+    This gives away nothing. The value was always meant to be readable by the client that
+    owns the cookie -- that is what makes double-submit work -- and CORS answers against an
+    explicit origin allow-list, so a hostile origin can no more read the header than the
+    cookie. Setting ``Domain=becomify.app`` on the cookie instead would look simpler and
+    break the deploys: dev, staging, and production all live under that parent and would
+    overwrite each other's token.
+
+    Only printable ASCII is echoed, because on the ``/auth/me`` path the value is a
+    cookie the client chose. Starlette unescapes cookies the RFC 2109 way, so
+    ``csrf_token="\\012X-Injected: 1"`` -- every character of it legal in a ``Cookie``
+    header -- parses into a value carrying a real newline, and uvicorn's httptools writer
+    concatenates response headers without validating them. Echoing that unchecked would
+    hand the client a response-splitting primitive. A minted token is 43 URL-safe
+    characters and always passes.
+
+    :param response: The response to set the header on.
+    :param csrf_token: Token to echo, or None when the request carried no CSRF cookie.
+    """
+    if csrf_token and csrf_token.isascii() and csrf_token.isprintable():
+        response.headers[CSRF_HEADER] = csrf_token
 
 
 def clear_auth_cookies(response: Response) -> None:

--- a/api/main.py
+++ b/api/main.py
@@ -122,6 +122,11 @@ def create_app() -> FastAPI:
             "X-Request-ID",
             "X-CSRF-Token",
         ],
+        # allow_headers covers the request direction only. The SPA runs on a different
+        # host than the API, so the CSRF token reaches it as a response header, and a
+        # cross-origin response header stays invisible to JavaScript unless it is named
+        # here (see api/auth/cookies.py::set_csrf_header).
+        expose_headers=["X-CSRF-Token"],
         max_age=600,  # Cache preflight requests for 10 minutes
     )
 

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -14,11 +14,13 @@ from fastapi.security import OAuth2PasswordRequestForm
 from starlette.concurrency import run_in_threadpool
 
 from api.auth.cookies import (
+    CSRF_COOKIE,
     REFRESH_COOKIE,
     clear_auth_cookies,
     cookies_secure,
     new_csrf_token,
     set_auth_cookies,
+    set_csrf_header,
 )
 from api.auth.dependencies import CurrentUser, get_current_token_payload
 from api.auth.email_throttle import (
@@ -104,19 +106,25 @@ _VERIFICATION_COMPLETE = "Your email address is confirmed. You can sign in now."
 def _set_session_cookies(response: Response, token_pair: TokenPair, request: Request) -> None:
     """Attach the access, refresh, and CSRF cookies for a freshly issued token pair.
 
+    The CSRF token goes out in a response header as well. A refresh rotates it, so a
+    cross-host SPA reading only the header would otherwise keep sending a superseded
+    value; see :func:`~api.auth.cookies.set_csrf_header` for why the header exists.
+
     :param response: The response to set cookies on.
     :param token_pair: The newly minted access/refresh pair.
     :param request: The incoming request, used to decide the cookie Secure flag.
     """
+    csrf_token = new_csrf_token()
     set_auth_cookies(
         response,
         access_token=token_pair.access_token,
         refresh_token=token_pair.refresh_token,
-        csrf_token=new_csrf_token(),
+        csrf_token=csrf_token,
         access_ttl=token_pair.expires_in,
         refresh_ttl=refresh_token_ttl_seconds(),
         secure=cookies_secure(request),
     )
+    set_csrf_header(response, csrf_token)
 
 
 def _may_mail(throttle: EmailSendThrottle, email: str, *, created: bool) -> bool:
@@ -656,10 +664,23 @@ def reset_password(
 
 
 @router.get("/me", summary="Get current user profile")
-def get_me(current_user: CurrentUser) -> UserResponse:
-    """Return the authenticated user's profile.
+def get_me(
+    response: Response,
+    current_user: CurrentUser,
+    csrf_cookie: Annotated[str | None, Cookie(alias=CSRF_COOKIE)] = None,
+) -> UserResponse:
+    """Return the authenticated user's profile, and the session's CSRF token with it.
 
+    The SPA probes this route on mount, which makes it the one place a page reload can
+    pick the CSRF token back up: the token lives in a cookie belonging to the API host,
+    and the SPA cannot read that cookie when the two run on different hosts. Nothing is
+    minted here -- the request's own cookie is handed straight back -- so a Bearer client,
+    which sends no such cookie, gets no header.
+
+    :param response: Response used to echo the CSRF token header.
     :param current_user: User from JWT token
+    :param csrf_cookie: The session's CSRF cookie; absent for Bearer clients
     :return: User profile data
     """
+    set_csrf_header(response, csrf_cookie)
     return UserResponse.from_user(current_user)

--- a/docs/quality-report.md
+++ b/docs/quality-report.md
@@ -7,8 +7,8 @@
 | mypy (strict) | Pass | No errors (28 files in `src/`+`examples/`, 87 in `api/`) |
 | ruff check | Pass | No issues |
 | ruff format | Pass | All files formatted |
-| pytest | Pass | 1459 tests passed |
-| coverage | Pass | 100% on `src/` (197 statements), 99% on `src/`+`api/` (3956 statements, 49 uncovered) |
+| pytest | Pass | 1474 tests passed |
+| coverage | Pass | 100% on `src/` (197 statements), 99% on `src/`+`api/` (3962 statements, 49 uncovered) |
 
 ## Running Checks
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -205,8 +205,30 @@ carries the `csrf_token` cookie, so Bearer-token clients and the pre-session aut
 (`login`, `register`, `refresh`, password reset) are unaffected -- a stale cookie left by a
 revoked session can never block a fresh login. Logout stays CSRF-protected.
 
+The SPA gets that value from a response header rather than from the cookie. Login and
+refresh return the token they just issued in an `X-CSRF-Token` **response** header, and
+`GET /auth/me` -- the app's session probe on mount -- hands back whatever the request's own
+cookie holds, so a page reload recovers it (`api/auth/cookies.py::set_csrf_header`). The
+header is what makes the check workable at all on the deploys: the cookie carries no
+`Domain` attribute, so it belongs to the API host, and the app is served from a different
+one, where `document.cookie` shows it nothing while the browser keeps sending it. Reading
+the cookie still works when the two share an origin, which is how local development runs
+behind the Vite proxy, and stays the fallback. `CORSMiddleware` names the header in
+`expose_headers`; without that the browser withholds it from cross-origin JavaScript.
+
+Handing the value back changes nothing about the guarantee. It was always meant to be
+readable by the client that owns the cookie -- that is what double-submit is -- and CORS
+answers against an explicit origin allow-list, so a hostile origin can no more read the
+header than the cookie. Widening the cookie with `Domain=becomify.app` would look like the
+smaller fix and is the one to avoid: dev, staging, and production all sit under that parent
+and would overwrite each other's token, breaking whichever was visited last. The echo on
+`/auth/me` repeats a client-supplied value, so it is dropped unless it is printable ASCII;
+Starlette's RFC 2109 cookie unescape turns `csrf_token="\012..."` into a real newline, and
+uvicorn writes response headers without validating them.
+
 The `Authorization: Bearer` path is kept alongside the cookie path for programmatic clients
 and the test suite; it authenticates the same tokens without the cookie or CSRF machinery.
+Such a client sends no `csrf_token` cookie, so it gets no header back either.
 
 ## Authorization and tenant isolation
 
@@ -281,7 +303,8 @@ The public origin is `becomify.app`, served through Cloudflare. A Cloudflare Tra
 injects a shared secret header that the origin then requires (`cloudflare_origin_secret`),
 so the Railway origin cannot be reached directly, bypassing the edge. CORS is configured
 with explicit allowed origins and `allow_credentials=True` (required for the cookie
-session), and permits the `X-CSRF-Token` header.
+session). It permits the `X-CSRF-Token` header on the way in and exposes it on the way
+out, since the SPA reads the CSRF token off the response.
 
 Both tiers send security response headers: the API from middleware
 (`api/middleware/security_headers.py`), the SPA from nginx (`frontend/nginx.conf`). Their

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -16,11 +16,13 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useToast } from "@/hooks/use-toast";
 
 export function Navbar() {
   const { t } = useTranslation();
   const { t: tOnboarding } = useTranslation("onboarding");
   const { isAuthenticated, user, logout } = useAuth();
+  const { toast } = useToast();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
   const location = useLocation();
@@ -35,7 +37,20 @@ export function Navbar() {
   }, []);
 
   const handleLogout = async () => {
-    await logout();
+    try {
+      await logout();
+    } catch {
+      // The local session is already cleared at this point (AuthContext's job) --
+      // only the server-side revoke failed. Stay on the page instead of
+      // navigating home, so the user knows to try again rather than seeing what
+      // looks like a normal sign-out while the session may still be alive.
+      toast({
+        title: t("errors.logoutFailedTitle"),
+        description: t("errors.logoutFailed"),
+        variant: "destructive",
+      });
+      return;
+    }
     globalThis.location.href = '/';
   };
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -80,18 +80,28 @@ export function AuthProvider({ children }: { readonly children: React.ReactNode 
   }, [refreshUser]);
 
   const logout = useCallback(async () => {
+    let logoutFailed = false;
+    let logoutError: unknown;
     try {
       await api.logout();
     } catch (err) {
       // A server that refuses the sign-out is no reason to leave the user holding a
       // session they believe they closed -- on a shared machine that is the worse
-      // outcome of the two, and the session expires on its own regardless.
+      // outcome of the two. Clear the local session below regardless, but keep the
+      // failure and re-throw once it is clean: swallowing it entirely would make a
+      // failed sign-out look identical to a real one, and the caller is what can
+      // tell the user the server session may still be alive.
+      logoutFailed = true;
+      logoutError = err;
       logger.debug('Logout request failed; clearing the local session anyway', { error: err });
     }
     setUser(null);
     setStatus('unauthenticated');
     // Drop cached queries so the next account on this tab cannot see them.
     queryClient.clear();
+    if (logoutFailed) {
+      throw logoutError;
+    }
   }, [queryClient]);
 
   const value = useMemo(() => ({

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -80,7 +80,14 @@ export function AuthProvider({ children }: { readonly children: React.ReactNode 
   }, [refreshUser]);
 
   const logout = useCallback(async () => {
-    await api.logout();
+    try {
+      await api.logout();
+    } catch (err) {
+      // A server that refuses the sign-out is no reason to leave the user holding a
+      // session they believe they closed -- on a shared machine that is the worse
+      // outcome of the two, and the session expires on its own regardless.
+      logger.debug('Logout request failed; clearing the local session anyway', { error: err });
+    }
     setUser(null);
     setStatus('unauthenticated');
     // Drop cached queries so the next account on this tab cannot see them.

--- a/frontend/src/i18n/locales/cs/common.json
+++ b/frontend/src/i18n/locales/cs/common.json
@@ -166,6 +166,8 @@
     "sessionExpiredTitle": "Relace vypršela",
     "tooManyAttempts": "Příliš mnoho pokusů. Chvíli počkejte a zkuste to znovu.",
     "tooManyAttemptsRetry": "Příliš mnoho pokusů. Zkuste to znovu za {{seconds}} s.",
-    "retry": "Zkusit znovu"
+    "retry": "Zkusit znovu",
+    "logoutFailedTitle": "Odhlášení selhalo",
+    "logoutFailed": "Odhlášení neproběhlo. Relace může být stále aktivní. Zkuste to prosím znovu."
   }
 }

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -166,6 +166,8 @@
     "sessionExpiredTitle": "Session expired",
     "tooManyAttempts": "Too many attempts. Please wait a moment and try again.",
     "tooManyAttemptsRetry": "Too many attempts. Please try again in {{seconds}}s.",
-    "retry": "Try again"
+    "retry": "Try again",
+    "logoutFailedTitle": "Sign-out failed",
+    "logoutFailed": "Sign-out did not go through. Your session may still be active. Please try again."
   }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -35,7 +35,15 @@ const API_BASE_URL = import.meta.env.VITE_API_URL || '/api/v1';
 
 const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 
-function readCsrfToken(): string | null {
+const CSRF_HEADER = 'X-CSRF-Token';
+
+/**
+ * Reads the csrf_token cookie, which only works when the API answers on this
+ * app's own origin -- local development, where Vite proxies /api/v1. On the
+ * deploys the cookie belongs to the API host and document.cookie shows nothing,
+ * which is why the token also arrives as a response header.
+ */
+function readCsrfCookie(): string | null {
   const match = document.cookie.match(/(?:^|; )csrf_token=([^;]*)/);
   return match ? decodeURIComponent(match[1]) : null;
 }
@@ -102,11 +110,31 @@ class ApiClient {
   private refreshInFlight: Promise<void> | null = null;
   private sessionExpiredNotified = false;
   private onSessionExpired: (() => void) | null = null;
+  /**
+   * The CSRF token as last handed back by the API, in an X-CSRF-Token response
+   * header on login, refresh, and the session probe. On every deployed
+   * environment this is the only copy the app can reach: the cookie holding the
+   * same value belongs to the API host, not to this one.
+   */
+  private csrfToken: string | null = null;
 
   /** Registers the callback fired when a session cannot be recovered by a silent refresh. */
   setOnSessionExpired(fn: (() => void) | null): void {
     this.sessionExpiredNotified = false;
     this.onSessionExpired = fn;
+  }
+
+  /** Picks up the CSRF token from a response that carries one, ignoring the rest. */
+  private captureCsrfToken(response: Response): void {
+    const token = response.headers.get(CSRF_HEADER);
+    if (token) {
+      this.csrfToken = token;
+    }
+  }
+
+  /** The token to echo on a mutation: the API's own copy, or the cookie same-origin. */
+  private currentCsrfToken(): string | null {
+    return this.csrfToken ?? readCsrfCookie();
   }
 
   /**
@@ -124,6 +152,9 @@ class ApiClient {
         credentials: 'include',
         headers: { 'X-Request-ID': crypto.randomUUID() },
       });
+      // A refresh rotates the CSRF token, so the retry that follows must send the
+      // new one; the value this replaces is already dead on the server.
+      this.captureCsrfToken(res);
       if (!res.ok) {
         throw await toHttpError(res);
       }
@@ -167,11 +198,11 @@ class ApiClient {
       ...(options.headers as Record<string, string>),
     };
 
-    // Cookie-based session: echo the readable csrf_token cookie on mutating requests.
+    // Cookie-based session: echo the current CSRF token on mutating requests.
     if (MUTATING_METHODS.has(method.toUpperCase())) {
-      const csrf = readCsrfToken();
+      const csrf = this.currentCsrfToken();
       if (csrf) {
-        headers['X-CSRF-Token'] = csrf;
+        headers[CSRF_HEADER] = csrf;
       }
     }
 
@@ -182,6 +213,8 @@ class ApiClient {
       credentials: 'include',
       headers,
     });
+
+    this.captureCsrfToken(response);
 
     if (!response.ok) {
       // A 401 gets one silent-refresh-and-retry attempt before it is treated as
@@ -299,6 +332,10 @@ class ApiClient {
       body: formData,
     });
 
+    // Sign-in is where the CSRF token starts; without picking it up here the first
+    // mutation of the session would have to wait for a refresh or a reload.
+    this.captureCsrfToken(response);
+
     if (!response.ok) {
       logger.error('Login failed', { status: response.status });
       throw await toHttpError(response);
@@ -309,12 +346,20 @@ class ApiClient {
     return response.json();
   }
 
+  /**
+   * Revokes the session server-side and clears the HttpOnly cookies.
+   *
+   * Failure is reported, not swallowed: whether a sign-out that the server
+   * refused should still empty the local session is AuthContext's call, and it
+   * cannot make it if this reports success either way.
+   */
   async logout(): Promise<void> {
-    // Hit the server so it revokes the session and clears the HttpOnly cookies.
     try {
       await this.request<void>('/auth/logout', { method: 'POST' }, { isAuthProbe: true });
-    } catch {
-      // Ignore: the user is logging out regardless of a network hiccup.
+    } finally {
+      // The token dies with the session, and holding it would only feed a stale
+      // value to whatever the next account on this tab does.
+      this.csrfToken = null;
     }
   }
 
@@ -347,8 +392,11 @@ class ApiClient {
   }
 
   // Users
+  // Probes the session against /auth/me rather than the identical /users/me: it
+  // returns the CSRF token alongside the profile, which is how a page reload gets
+  // the token back before the user reaches for anything that mutates.
   async getCurrentUser(isAuthProbe = false): Promise<User> {
-    return this.request<User>('/users/me', {}, { isAuthProbe });
+    return this.request<User>('/auth/me', {}, { isAuthProbe });
   }
 
   // Returns the user's full GDPR data export. The payload is only downloaded as
@@ -385,9 +433,9 @@ class ApiClient {
 
     const response = await this.fetchWithRefresh(`${API_BASE_URL}/users/me/photo`, () => {
       const headers: Record<string, string> = { 'X-Request-ID': crypto.randomUUID() };
-      const csrf = readCsrfToken();
+      const csrf = this.currentCsrfToken();
       if (csrf) {
-        headers['X-CSRF-Token'] = csrf;
+        headers[CSRF_HEADER] = csrf;
       }
       return { method: 'POST', credentials: 'include', headers, body: formData };
     });

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -237,7 +237,14 @@ const Profile = () => {
   };
 
   const handleAccountDeleted = async () => {
-    await logout();
+    try {
+      await logout();
+    } catch {
+      // The account no longer exists once we reach here, so there is nothing
+      // left to retry sign-out for. Continue to the success flow regardless --
+      // letting this reject would surface as "Account deletion failed" to a
+      // user whose account was, in fact, already deleted.
+    }
     navigate("/");
     toast({ title: t("toast.accountDeleted") });
   };

--- a/frontend/tests/components/layout/Navbar.test.tsx
+++ b/frontend/tests/components/layout/Navbar.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, within, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen, within, act, waitFor, renderHook } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render, framerMotionMock } from '@tests/utils';
 import { Navbar } from '@/components/layout/Navbar';
+import { useToast } from '@/hooks/use-toast';
 
 // Use vi.hoisted for mock variables
 const { mockUser, mockLogout, mockPathname } = vi.hoisted(() => ({
@@ -260,5 +261,58 @@ describe('Navbar - Mobile Menu (authenticated)', () => {
     await user.click(logoutButton);
 
     expect(mockLogout).toHaveBeenCalled();
+  });
+});
+
+describe('Navbar - Logout Outcome', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // A plain object stand-in avoids happy-dom's real navigation handling, so the
+    // assertions below can tell "navigated" and "stayed put" apart reliably.
+    Object.defineProperty(window, 'location', {
+      value: { href: '' },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    });
+  });
+
+  it('navigates home after a successful sign-out', async () => {
+    mockLogout.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    render(<Navbar />);
+
+    await user.click(screen.getByText('John Doe'));
+    await user.click(screen.getByRole('menuitem', { name: /log out|sign out/i }));
+
+    await waitFor(() => {
+      expect(window.location.href).toBe('/');
+    });
+  });
+
+  it('stays put and shows a destructive toast when sign-out fails', async () => {
+    mockLogout.mockRejectedValueOnce(new Error('Network error'));
+    const user = userEvent.setup();
+    const { result } = renderHook(() => useToast());
+
+    render(<Navbar />);
+    await user.click(screen.getByText('John Doe'));
+    await user.click(screen.getByRole('menuitem', { name: /log out|sign out/i }));
+
+    await waitFor(() => {
+      expect(result.current.toasts[0]).toMatchObject({
+        title: 'Sign-out failed',
+        description: 'Sign-out did not go through. Your session may still be active. Please try again.',
+        variant: 'destructive',
+      });
+    });
+    expect(window.location.href).toBe('');
   });
 });

--- a/frontend/tests/contexts/AuthContext.test.tsx
+++ b/frontend/tests/contexts/AuthContext.test.tsx
@@ -202,10 +202,13 @@ describe('AuthContext', () => {
     expect(result.current.status).toBe('unauthenticated')
   })
 
-  it('clears the local session even when the logout request fails', async () => {
+  it('clears the local session and propagates the failure when the logout request fails', async () => {
     // A server that refuses the sign-out must not leave the user signed in. This is
     // what a cookie-authenticated logout looked like on every deploy: the SPA could
-    // not read the csrf_token cookie, so the request came back 403.
+    // not read the csrf_token cookie, so the request came back 403. Clearing the
+    // local session is not enough on its own though -- a caller that never learns
+    // the server-side session survived would show the exact same success state as
+    // a real sign-out, which is worse than an error on a shared machine.
     const mockUser = createUser({ id: '1', email: 'test@example.com', first_name: 'Test' })
     vi.mocked(api.getCurrentUser).mockResolvedValue(mockUser)
     // Once, not for the rest of the file: clearAllMocks resets recorded calls but
@@ -221,10 +224,21 @@ describe('AuthContext', () => {
       expect(result.current.isAuthenticated).toBe(true)
     })
 
+    // Catch inside act() rather than asserting on the rejected act() promise itself:
+    // act() only flushes the state updates queued before the throw when its own
+    // callback settles without rejecting, so the throw is captured here and
+    // checked on the side, letting the surrounding act() see a normal resolution.
+    let caughtError: unknown
     await act(async () => {
-      await result.current.logout()
+      try {
+        await result.current.logout()
+      } catch (err) {
+        caughtError = err
+      }
     })
 
+    expect(caughtError).toBeInstanceOf(Error)
+    expect((caughtError as Error).message).toBe('CSRF token missing or invalid')
     expect(result.current.user).toBeNull()
     expect(result.current.isAuthenticated).toBe(false)
     expect(result.current.status).toBe('unauthenticated')

--- a/frontend/tests/contexts/AuthContext.test.tsx
+++ b/frontend/tests/contexts/AuthContext.test.tsx
@@ -202,6 +202,34 @@ describe('AuthContext', () => {
     expect(result.current.status).toBe('unauthenticated')
   })
 
+  it('clears the local session even when the logout request fails', async () => {
+    // A server that refuses the sign-out must not leave the user signed in. This is
+    // what a cookie-authenticated logout looked like on every deploy: the SPA could
+    // not read the csrf_token cookie, so the request came back 403.
+    const mockUser = createUser({ id: '1', email: 'test@example.com', first_name: 'Test' })
+    vi.mocked(api.getCurrentUser).mockResolvedValue(mockUser)
+    // Once, not for the rest of the file: clearAllMocks resets recorded calls but
+    // leaves an implementation in place, and the cases after this one expect a
+    // logout that succeeds.
+    vi.mocked(api.logout).mockRejectedValueOnce(new ForbiddenError('CSRF token missing or invalid'))
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: AuthTestProviders,
+    })
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(true)
+    })
+
+    await act(async () => {
+      await result.current.logout()
+    })
+
+    expect(result.current.user).toBeNull()
+    expect(result.current.isAuthenticated).toBe(false)
+    expect(result.current.status).toBe('unauthenticated')
+  })
+
   it('drops cached queries on logout so the next account cannot see them', async () => {
     const mockUser = createUser({ id: '1', email: 'test@example.com', first_name: 'Test' })
     vi.mocked(api.getCurrentUser).mockResolvedValue(mockUser)

--- a/frontend/tests/lib/api.test.ts
+++ b/frontend/tests/lib/api.test.ts
@@ -22,9 +22,21 @@ const localStorageMock = (() => {
 
 Object.defineProperty(window, 'localStorage', { value: localStorageMock });
 
-// Mock fetch
+// Mock fetch. The cases below describe responses as plain objects and mostly leave
+// `headers` out, while a real Response always has one and the client reads the CSRF
+// token off it -- so fill an empty Headers in where a case did not supply its own.
 const mockFetch = vi.fn();
-globalThis.fetch = mockFetch;
+globalThis.fetch = ((...args: Parameters<typeof fetch>) =>
+  Promise.resolve(mockFetch(...args)).then((response) =>
+    response && typeof response === 'object' && !('headers' in response)
+      ? Object.assign(response, { headers: new Headers() })
+      : response
+  )) as typeof fetch;
+
+/** Builds the response headers for a case that needs the API to hand back a CSRF token. */
+function csrfHeaders(token: string): Headers {
+  return new Headers({ 'X-CSRF-Token': token });
+}
 
 // Import api after mocks are set up
 // We need to re-import to get a fresh instance each test
@@ -39,6 +51,9 @@ describe('ApiClient', () => {
     vi.resetModules();
     localStorageMock.clear();
     mockFetch.mockReset();
+    // The DOM environment keeps document.cookie for the whole file, so a case that
+    // plants one would otherwise decide what the next case reads.
+    document.cookie = 'csrf_token=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
 
     // Mock window.location
     Object.defineProperty(window, 'location', {
@@ -78,7 +93,9 @@ describe('ApiClient', () => {
       expect(options.headers.Authorization).toBeUndefined();
     });
 
-    it('echoes the csrf_token cookie as X-CSRF-Token on mutating requests', async () => {
+    it('falls back to the csrf_token cookie when the API has returned no token yet', async () => {
+      // Only reachable same-origin, which is how local development runs: Vite
+      // proxies /api/v1, so the cookie belongs to this origin and is readable.
       document.cookie = 'csrf_token=csrf-abc';
       mockFetch.mockResolvedValueOnce({ ok: true, status: 204 });
 
@@ -86,9 +103,103 @@ describe('ApiClient', () => {
 
       const [, options] = mockFetch.mock.calls[0];
       expect((options.headers as Record<string, string>)['X-CSRF-Token']).toBe('csrf-abc');
-      document.cookie = 'csrf_token=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+    });
+  });
+
+  // On every deployed environment the SPA and the API answer on different hosts, so
+  // the csrf_token cookie belongs to the API and document.cookie shows the app
+  // nothing. The API repeats the value in an X-CSRF-Token response header, and
+  // without picking that up the client cannot produce the header the double-submit
+  // check demands -- which is a 403 on logout and on every other mutation.
+  describe('CSRF token from the response header', () => {
+    it('picks the token up from the login response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: csrfHeaders('from-login'),
+        json: () => Promise.resolve({ access_token: 'tok', token_type: 'bearer' }),
+      });
+      await api.login('user@example.com', 'pass');
+
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 204 });
+      await api.deleteProject('1');
+
+      const [, options] = mockFetch.mock.calls[1];
+      expect((options.headers as Record<string, string>)['X-CSRF-Token']).toBe('from-login');
     });
 
+    it('recovers the token from the session probe, which is what survives a reload', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: csrfHeaders('from-probe'),
+        json: () => Promise.resolve({ id: '1' }),
+      });
+      await api.getCurrentUser(true);
+
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 204 });
+      await api.deleteProject('1');
+
+      const [, options] = mockFetch.mock.calls[1];
+      expect((options.headers as Record<string, string>)['X-CSRF-Token']).toBe('from-probe');
+    });
+
+    it('prefers the token the API returned over the cookie', async () => {
+      document.cookie = 'csrf_token=cookie-value';
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: csrfHeaders('header-value'),
+        json: () => Promise.resolve({ id: '1' }),
+      });
+      await api.getCurrentUser(true);
+
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 204 });
+      await api.deleteProject('1');
+
+      const [, options] = mockFetch.mock.calls[1];
+      expect((options.headers as Record<string, string>)['X-CSRF-Token']).toBe('header-value');
+    });
+
+    it('sends the rotated token on the retry after a silent refresh', async () => {
+      // A refresh mints a new CSRF cookie, so the retry has to carry the new value
+      // or it trades a 401 for a 403.
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 401,
+          json: () => Promise.resolve({ detail: 'Expired' }),
+        })
+        .mockResolvedValueOnce({ ok: true, status: 200, headers: csrfHeaders('rotated') })
+        .mockResolvedValueOnce({ ok: true, status: 204 });
+
+      await api.deleteProject('1');
+
+      const [, retryOptions] = mockFetch.mock.calls[2];
+      expect((retryOptions.headers as Record<string, string>)['X-CSRF-Token']).toBe('rotated');
+    });
+
+    it('forgets the token on logout so the next account starts clean', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: csrfHeaders('first-session'),
+        json: () => Promise.resolve({ access_token: 'tok', token_type: 'bearer' }),
+      });
+      await api.login('user@example.com', 'pass');
+
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 204 });
+      await api.logout();
+
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 204 });
+      await api.deleteProject('1');
+
+      const [, options] = mockFetch.mock.calls[2];
+      expect((options.headers as Record<string, string>)['X-CSRF-Token']).toBeUndefined();
+    });
+  });
+
+  describe('Response Handling', () => {
     it('handles successful JSON response', async () => {
       const userData = { id: '1', email: 'test@example.com' };
       mockFetch.mockResolvedValueOnce({
@@ -609,16 +720,29 @@ describe('ApiClient', () => {
           json: () => Promise.resolve({ detail: 'Refresh failed' }),
         });
 
-      await expect(api.logout()).resolves.toBeUndefined();
+      await expect(api.logout()).rejects.toBeInstanceOf(UnauthorizedError);
 
       expect(onSessionExpired).not.toHaveBeenCalled();
 
       api.setOnSessionExpired(null);
     });
+
+    it('reports a refused logout instead of pretending it worked', async () => {
+      // A 403 here used to be swallowed, so the caller could not tell a revoked
+      // session from one still very much alive. AuthContext decides what to do
+      // about it; the client's job is to say what happened.
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ detail: 'CSRF token missing or invalid' }),
+      });
+
+      await expect(api.logout()).rejects.toThrow('CSRF token missing or invalid');
+    });
   });
 
   describe('User Endpoints', () => {
-    it('getCurrentUser fetches /users/me', async () => {
+    it('getCurrentUser probes /auth/me, which also returns the CSRF token', async () => {
       const user = { id: '1', email: 'me@example.com' };
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -629,7 +753,7 @@ describe('ApiClient', () => {
       const result = await api.getCurrentUser();
 
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining('/users/me'),
+        expect.stringContaining('/auth/me'),
         expect.objectContaining({ headers: expect.any(Object) })
       );
       expect(result).toEqual(user);
@@ -705,6 +829,28 @@ describe('ApiClient', () => {
       );
       const [, options] = mockFetch.mock.calls[0];
       expect(options.body).toBeInstanceOf(FormData);
+    });
+
+    it('uploadPhoto carries the CSRF token too, though it builds its own request', async () => {
+      // The FormData body does not fit the JSON request() contract, so this path
+      // assembles its own headers and would otherwise miss the token entirely.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: csrfHeaders('for-upload'),
+        json: () => Promise.resolve({ id: '1' }),
+      });
+      await api.getCurrentUser(true);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: '1', photo_url: 'https://example.com/p.jpg' }),
+      });
+      await api.uploadPhoto(new File(['test'], 'photo.jpg', { type: 'image/jpeg' }));
+
+      const [, options] = mockFetch.mock.calls[1];
+      expect((options.headers as Record<string, string>)['X-CSRF-Token']).toBe('for-upload');
     });
 
     it('deletePhoto sends DELETE to /users/me/photo', async () => {

--- a/frontend/tests/pages/Profile.test.tsx
+++ b/frontend/tests/pages/Profile.test.tsx
@@ -310,6 +310,31 @@ describe('Profile - Delete Account', () => {
       expect(mockNavigate).toHaveBeenCalledWith('/');
     });
   });
+
+  it('still navigates home and confirms deletion when the post-deletion sign-out fails', async () => {
+    // The account is already gone by the time this runs, so a failed sign-out
+    // request here has nothing left to protect -- it must not be mistaken for a
+    // failed deletion or leave the dialog stuck open.
+    const user = userEvent.setup();
+    mockApi.deleteAccount.mockResolvedValueOnce(undefined);
+    mockLogout.mockRejectedValueOnce(new Error('Network error'));
+
+    render(<Profile />);
+
+    await user.click(screen.getByRole('button', { name: 'Delete Account' }));
+
+    const confirm = await screen.findByRole('button', { name: 'Delete My Account' });
+    await waitFor(() => expect(confirm).toBeEnabled());
+    await user.click(confirm);
+
+    await waitFor(() => {
+      expect(mockApi.deleteAccount).toHaveBeenCalledWith([]);
+      expect(mockLogout).toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+      expect(mockToast).toHaveBeenCalledWith({ title: 'Account deleted' });
+    });
+    expect(screen.queryByText('Account deletion failed. Please try again.')).not.toBeInTheDocument();
+  });
 });
 
 describe('Profile - Photo Upload', () => {

--- a/tests/integration/api/auth/test_auth.py
+++ b/tests/integration/api/auth/test_auth.py
@@ -9,7 +9,13 @@ test_email_verification.py.
 from sqlmodel import select
 
 from api.db.models import User
-from tests.integration.api.conftest import register, register_verified, stored_accounts
+from tests.integration.api.conftest import (
+    auth_header,
+    register,
+    register_and_login,
+    register_verified,
+    stored_accounts,
+)
 
 PASSWORD = "SecurePass123!"
 
@@ -964,3 +970,93 @@ class TestCookieAuth:
         )
 
         assert resp.status_code == 200
+
+
+class TestCsrfTokenHeader:
+    """The CSRF token also travels as a response header, for an SPA on another host.
+
+    Every deployed environment serves the SPA and the API from separate hosts, and the
+    csrf_token cookie carries no Domain attribute, so it belongs to the API host alone:
+    the browser keeps sending it, while document.cookie hides it from the app. Reading
+    the cookie is therefore not something the SPA can do, and without another copy of the
+    value it cannot produce the X-CSRF-Token header logout requires. These tests pin the
+    header path end to end, never touching the cookie jar for the value.
+    """
+
+    PASSWORD = "SecurePass123!"
+
+    def _login(self, cookie_client, email):
+        """Register an activated user and log in, leaving the cookies in the client jar."""
+        register_verified(cookie_client, email, password=self.PASSWORD)
+        return cookie_client.post(
+            "/api/v1/auth/login",
+            data={"username": email, "password": self.PASSWORD},
+        )
+
+    def test_login_returns_the_token_it_just_set(self, cookie_client):
+        """The login response header carries the same value as the cookie it sets."""
+        resp = self._login(cookie_client, "csrflogin@example.com")
+
+        assert resp.status_code == 200
+        assert resp.headers["X-CSRF-Token"] == cookie_client.cookies.get("csrf_token")
+
+    def test_refresh_returns_the_rotated_token(self, cookie_client):
+        """A refresh mints a fresh CSRF cookie, so the header must carry the new value.
+
+        A client left holding the token from login would send a superseded one on the
+        next mutation and be refused.
+        """
+        issued = self._login(cookie_client, "csrfrefresh@example.com").headers["X-CSRF-Token"]
+
+        resp = cookie_client.post("/api/v1/auth/refresh")
+
+        assert resp.status_code == 200
+        rotated = resp.headers["X-CSRF-Token"]
+        assert rotated != issued
+        assert rotated == cookie_client.cookies.get("csrf_token")
+
+    def test_profile_echoes_the_token_from_the_request_cookie(self, cookie_client):
+        """The session probe is how the SPA picks the token back up after a page reload."""
+        self._login(cookie_client, "csrfme@example.com")
+
+        resp = cookie_client.get("/api/v1/auth/me")
+
+        assert resp.status_code == 200
+        assert resp.headers["X-CSRF-Token"] == cookie_client.cookies.get("csrf_token")
+
+    def test_profile_omits_the_header_for_a_bearer_client(self, client):
+        """No CSRF cookie on the request, no header on the response."""
+        token = register_and_login(client, "csrfbearer@example.com")
+
+        resp = client.get("/api/v1/auth/me", headers=auth_header(token))
+
+        assert resp.status_code == 200
+        assert "X-CSRF-Token" not in resp.headers
+
+    def test_logout_succeeds_on_the_header_value_alone(self, cookie_client):
+        """The deployed shape: the token comes from the response, never from the cookie.
+
+        The browser still sends the cookie, which is what arms the double-submit check;
+        the client only ever sees the value the API handed back.
+        """
+        issued = self._login(cookie_client, "csrfsplit@example.com").headers["X-CSRF-Token"]
+
+        resp = cookie_client.post("/api/v1/auth/logout", headers={"X-CSRF-Token": issued})
+
+        assert resp.status_code == 204
+
+    def test_profile_refuses_to_echo_a_cookie_that_would_split_the_response(self, cookie_client):
+        """A cookie value carrying a newline is dropped instead of written to a header.
+
+        Every character sent below is legal in a Cookie header, and Starlette's RFC 2109
+        unescape turns it into a real newline. uvicorn writes response headers without
+        validating them, so echoing the value unchecked would let the client inject one.
+        """
+        self._login(cookie_client, "csrfjunk@example.com")
+        cookie_client.cookies.set("csrf_token", '"\\012X-Injected: 1"')
+
+        resp = cookie_client.get("/api/v1/auth/me")
+
+        assert resp.status_code == 200
+        assert "X-CSRF-Token" not in resp.headers
+        assert "X-Injected" not in resp.headers

--- a/tests/unit/api/auth/test_cookies.py
+++ b/tests/unit/api/auth/test_cookies.py
@@ -1,7 +1,11 @@
-"""Tests for the auth-cookie Secure-flag policy."""
+"""Tests for the auth-cookie Secure-flag policy and the CSRF response header."""
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import Response
+from starlette.requests import cookie_parser
 
 from api.auth import cookies
 from api.config import Environment
@@ -32,3 +36,53 @@ class TestCookiesSecure:
             cookies, "get_settings", return_value=SimpleNamespace(environment=Environment.DEV)
         ):
             assert cookies.cookies_secure(_request("https")) is True
+
+
+class TestSetCsrfHeader:
+    """The CSRF token is repeated in a response header, and only when it is safe to."""
+
+    def test_echoes_a_minted_token(self):
+        """A freshly minted token goes back out unchanged."""
+        response = Response()
+        token = cookies.new_csrf_token()
+
+        cookies.set_csrf_header(response, token)
+
+        assert response.headers[cookies.CSRF_HEADER] == token
+
+    def test_omits_the_header_when_there_is_no_token(self):
+        """A request without the CSRF cookie gets a response without the header."""
+        response = Response()
+
+        cookies.set_csrf_header(response, None)
+
+        assert cookies.CSRF_HEADER not in response.headers
+
+    @pytest.mark.parametrize(
+        "value",
+        ["", "\nX-Injected: 1", "token\r\nX-Injected: 1", "caf\xe9", "tok\x00en"],
+        ids=["empty", "newline", "crlf", "non-ascii", "null"],
+    )
+    def test_refuses_a_value_outside_printable_ascii(self, value):
+        """A cookie the client chose never decides what goes into a response header.
+
+        On the ``/auth/me`` path the echoed value comes straight from the request, and
+        uvicorn's httptools writer does not validate header values, so a newline in one
+        would split the response.
+        """
+        response = Response()
+
+        cookies.set_csrf_header(response, value)
+
+        assert cookies.CSRF_HEADER not in response.headers
+
+    def test_the_vector_it_guards_against_is_reachable_from_a_real_cookie(self):
+        """Starlette's cookie unescaping really does yield a newline-bearing value.
+
+        Pins the premise of the check above, which would otherwise be theatre. Every
+        character of the header below is legal in a ``Cookie`` header; Starlette applies
+        the RFC 2109 octal unescape and hands back an actual newline.
+        """
+        parsed = cookie_parser('csrf_token="\\012X-Injected: 1"')
+
+        assert parsed["csrf_token"] == "\nX-Injected: 1"

--- a/tests/unit/api/test_main.py
+++ b/tests/unit/api/test_main.py
@@ -48,6 +48,39 @@ class TestDocsExposure:
             get_settings.cache_clear()
 
 
+class TestCorsExposedHeaders:
+    """The browser is allowed to read the CSRF token header off a cross-origin reply."""
+
+    def test_csrf_token_header_is_readable_cross_origin(self, monkeypatch, tmp_path):
+        """A cross-origin response names X-CSRF-Token in Access-Control-Expose-Headers.
+
+        The SPA and the API sit on separate hosts in every deployed environment, and a
+        response header stays invisible to cross-origin JavaScript unless CORS says
+        otherwise. Listing the header under allow_headers covers only the request
+        direction, so without this the SPA gets the token handed to it and cannot see it.
+        """
+        from fastapi.testclient import TestClient
+
+        from api.config import get_settings
+        from api.main import create_app
+
+        # chdir out of the repository first: the real .env would otherwise decide which
+        # origins are allowed, and this test picks its own.
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("APP_ENV", "dev")
+        monkeypatch.setenv("SECRET_KEY", "a-sufficiently-strong-secret-value")
+        monkeypatch.setenv("CORS_ORIGINS", '["https://app.example.com"]')
+        get_settings.cache_clear()
+        try:
+            client = TestClient(create_app())
+            response = client.get("/api/v1/health", headers={"Origin": "https://app.example.com"})
+        finally:
+            get_settings.cache_clear()
+
+        assert response.status_code == 200
+        assert "X-CSRF-Token" in response.headers["access-control-expose-headers"]
+
+
 class TestSentryInit:
     """Sentry is initialised so no credential can ride along on an event."""
 


### PR DESCRIPTION
Every CSRF-protected mutation currently answers `403` in production, and has since the double-submit check shipped. Creating a project, submitting an opinion, updating a profile and signing out are all affected. Reading works, which is why it went unnoticed.

Verified against production without signing in, by sending `POST /api/v1/auth/logout` three ways:

| Request | Response |
|---|---|
| `csrf_token` cookie, no header | `403` |
| `csrf_token` cookie, matching header | `401` |
| no cookie at all | `401` |

The middleware is live and behaves exactly as designed. The problem is that the browser can satisfy the cookie half and the SPA cannot satisfy the header half.

## Why

`csrf_token` is set with no `Domain` attribute, so it belongs to the API host. The SPA runs on a different host and reads the cookie through `document.cookie`, which only exposes its own host's cookies, so it never sends `X-CSRF-Token`. The browser still sends the cookie to the API, so `api/middleware/csrf.py` sees a cookie-authenticated client, engages, finds no matching header, and rejects.

Local development is same-origin — `vite.config.ts` proxies `/api/v1` to the backend — so the cookie is readable there and everything works. The bug only appears once the SPA and the API sit on different hosts, which is every deployed environment: `www.becomify.app` against `api.becomify.app`, and the same shape on dev and staging.

## The fix

Deliver the token in a response header instead of relying on the SPA reading the cookie.

Responses that set the session cookies (`login`, `refresh`) now return the same value in an `X-CSRF-Token` response header, and `GET /auth/me` returns the current one read from the request's own cookie, so the SPA recovers it after a reload. `expose_headers` was added to the CORS config; the header name was already allowed in the request direction only. The client keeps the token in memory and prefers it, falling back to the cookie so same-origin local development keeps working.

This does not weaken the double-submit defence. The value was always meant to be readable by the page, and `CORSMiddleware` uses an explicit origin allow-list, so a hostile origin can read neither the cookie nor the header.

Setting `Domain=becomify.app` on the cookie would be a one-line alternative and is deliberately not used: every environment now lives under that parent domain, so dev, staging and production would overwrite each other's `csrf_token`.

## Two things found while fixing

The echo on `/auth/me` returns a cookie value the client controls. Starlette unescapes cookies RFC 2109 style, so a value containing an encoded newline arrives carrying a real newline, and the ASGI server concatenates response headers without validating them — a response-splitting primitive. The echo is restricted to printable ASCII.

`ApiClient.logout()` already swallowed its failure, so the local sign-out did run; the session survived because the navbar follows `logout()` with a full page reload, which re-probes cookies the rejected request never cleared. The tolerance now lives in `AuthContext`, so signing out locally happens deliberately rather than as a side effect.

## Verification

1474 backend tests at 99% coverage and 1028 frontend tests above the coverage gate; ruff, mypy, eslint and the secrets baseline clean.

Every new test was run against the pre-fix code first: 12 backend failures and 10 frontend failures, including the logout-tolerance and header-recovery cases. The three backend tests that pass both before and after are the negative ones — no header for a Bearer client, no echo of a cookie carrying a newline.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers CSRF tokens to the cross-host SPA through exposed response headers.
- Echoes newly issued tokens from login and refresh and recovers an existing token through `/auth/me`.
- Stores the token in the frontend client for mutation headers while retaining the same-origin cookie fallback.
- Moves logout-failure tolerance into AuthContext and adds backend and frontend coverage and documentation.

<h3>Confidence Score: 4/5</h3>

The logout failure path should be fixed before merging because a page reload can restore the same server session the user attempted to close.

Suppressing a failed logout lets navigation continue even though the API-host HttpOnly cookies may remain valid, and the application immediately probes those cookies and restores authenticated state after reload.

**Files Needing Attention:** frontend/src/contexts/AuthContext.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/auth/cookies.py | Adds a printable-ASCII-validated helper for exposing the CSRF cookie value in a response header. |
| api/routes/auth.py | Returns issued CSRF tokens on login and refresh and echoes the existing cookie from the authenticated session probe. |
| api/main.py | Exposes X-CSRF-Token to cross-origin browser JavaScript through CORS. |
| frontend/src/lib/api.ts | Captures response-header CSRF tokens, applies them to mutations, handles rotation, and switches the session probe to `/auth/me`. |
| frontend/src/contexts/AuthContext.tsx | Clears local auth state after failed logout requests, but allows the subsequent reload to restore a server session that was never revoked. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant SPA
  participant API
  participant Browser
  SPA->>API: Login or refresh
  API-->>Browser: Set-Cookie csrf_token
  API-->>SPA: X-CSRF-Token response header
  SPA->>SPA: Store token in memory
  SPA->>API: Mutation with X-CSRF-Token
  Browser->>API: csrf_token cookie
  API-->>SPA: Validate matching values
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
frontend/src/contexts/AuthContext.tsx:85-91
**Failed logout restores session**

When the server rejects logout before revoking the session and clearing its HttpOnly cookies, this catch block still clears local state and lets the navbar reload the page. The remounted auth provider then probes `/auth/me` with the surviving cookies and restores the same session the user attempted to close.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: describe how the CSRF token reache..."](https://github.com/caitlon/become/commit/e15f679aad4677f61e65a4d35812cd23a3935718) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49163497)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->