### PR TITLE
chore: promote the profile photo streaming fix to staging

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1022,7 +1022,7 @@
         "filename": "tests/unit/api/services/test_storage.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 24
+        "line_number": 25
       }
     ],
     "tests/unit/api/services/test_user.py": [
@@ -1183,5 +1183,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-31T18:46:02Z"
+  "generated_at": "2026-08-01T09:44:09Z"
 }

--- a/api/README.md
+++ b/api/README.md
@@ -153,12 +153,15 @@ sending it. The header is that app's only copy of the value, which is why
 The photo proxy is public, because an `<img>` tag cannot send an auth header. It passes
 the bucket's response straight through to the client instead of downloading the object
 first, so the wait before the first byte is one bucket round trip rather than a full
-download. The URL it is reached by carries a `?v=` token taken from the stored object
-key, and every upload mints a new key, so a given versioned URL always resolves to the same
-bytes and is served with `Cache-Control: public, max-age=31536000, immutable`. The bare path
-without that token is a stable URL whose bytes change when the photo does, so it gets
-`max-age=300` instead: nothing the API emits looks like that, but pinning it in a shared
-cache would serve one person's replaced avatar to everyone who asked.
+download. The URL it is reached by carries a `?v=` token taken from the stored object key,
+and every upload mints a new key.
+
+The route always serves whichever photo the account holds now, so the cache header depends on
+whether the request named that photo. A `v` matching the current key describes bytes that
+cannot change under it and is served with `Cache-Control: public, max-age=31536000, immutable`.
+Anything else -- no token, a stale one, an invented one -- gets `max-age=300`, because those
+URLs already resolve to different bytes than they once did and will again. Pinning one for a
+year would leave a shared cache handing out a replaced avatar to everyone who asked for it.
 
 Deleting the account (`DELETE /api/v1/users/me`) accepts an optional body that says what
 to do with every project the user still admins -- `transfer` it to another member or

--- a/api/README.md
+++ b/api/README.md
@@ -154,8 +154,11 @@ The photo proxy is public, because an `<img>` tag cannot send an auth header. It
 the bucket's response straight through to the client instead of downloading the object
 first, so the wait before the first byte is one bucket round trip rather than a full
 download. The URL it is reached by carries a `?v=` token taken from the stored object
-key, and every upload mints a new key, so a given URL always resolves to the same bytes
-and is served with `Cache-Control: public, max-age=31536000, immutable`.
+key, and every upload mints a new key, so a given versioned URL always resolves to the same
+bytes and is served with `Cache-Control: public, max-age=31536000, immutable`. The bare path
+without that token is a stable URL whose bytes change when the photo does, so it gets
+`max-age=300` instead: nothing the API emits looks like that, but pinning it in a shared
+cache would serve one person's replaced avatar to everyone who asked.
 
 Deleting the account (`DELETE /api/v1/users/me`) accepts an optional body that says what
 to do with every project the user still admins -- `transfer` it to another member or

--- a/api/README.md
+++ b/api/README.md
@@ -147,7 +147,15 @@ sending it. The header is that app's only copy of the value, which is why
 | PUT | `/api/v1/users/me/password` | Change password |
 | POST | `/api/v1/users/me/photo` | Upload photo (JPEG/PNG/GIF/WebP, max 5 MB and 4096x4096 px) |
 | DELETE | `/api/v1/users/me/photo` | Delete photo |
+| GET | `/api/v1/users/{id}/photo` | Serve a profile photo from the private bucket (public) |
 | DELETE | `/api/v1/users/me` | Delete account, handling each owned project (GDPR Art. 17) |
+
+The photo proxy is public, because an `<img>` tag cannot send an auth header. It passes
+the bucket's response straight through to the client instead of downloading the object
+first, so the wait before the first byte is one bucket round trip rather than a full
+download. The URL it is reached by carries a `?v=` token taken from the stored object
+key, and every upload mints a new key, so a given URL always resolves to the same bytes
+and is served with `Cache-Control: public, max-age=31536000, immutable`.
 
 Deleting the account (`DELETE /api/v1/users/me`) accepts an optional body that says what
 to do with every project the user still admins -- `transfer` it to another member or

--- a/api/routes/users.py
+++ b/api/routes/users.py
@@ -44,6 +44,7 @@ from api.services.storage.exceptions import (
     StorageUploadError,
 )
 from api.services.user_service import UserService
+from api.utils.photo_links import photo_version
 from api.utils.streaming import StoredObjectResponse
 from api.utils.upload import UploadTooLarge, read_within_limit
 
@@ -393,12 +394,13 @@ def get_user_photo(
     if stored is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Photo not found")
 
-    # Presence of the version parameter is the whole test. Comparing it against the stored
-    # key would tie this route to how build_photo_url derives the token, and buy nothing:
-    # a caller who invented a version is already asking for a URL nobody handed out.
+    # The version has to match the key being served, not merely be present. This route
+    # always serves whatever photo the account holds now, so a stale or invented `v`
+    # names bytes that already changed once and can change again -- pinning it for a
+    # year would leave a shared cache handing out a replaced avatar under that URL.
     cache_control = (
         _VERSIONED_PHOTO_CACHE_CONTROL
-        if "v" in request.query_params
+        if request.query_params.get("v") == photo_version(user.photo_url)
         else _UNVERSIONED_PHOTO_CACHE_CONTROL
     )
     return StoredObjectResponse(stored, headers={"Cache-Control": cache_control})

--- a/api/routes/users.py
+++ b/api/routes/users.py
@@ -44,9 +44,15 @@ from api.services.storage.exceptions import (
     StorageUploadError,
 )
 from api.services.user_service import UserService
+from api.utils.streaming import StoredObjectResponse
 from api.utils.upload import UploadTooLarge, read_within_limit
 
 router = APIRouter(prefix="/api/v1/users", tags=["users"])
+
+# Profile photo URLs are versioned: build_photo_url appends ?v=<token> taken from the
+# stored object key, and every upload mints a fresh key. A given URL therefore always
+# resolves to the same bytes, so it can be cached for as long as a cache will hold it.
+_PHOTO_CACHE_CONTROL = "public, max-age=31536000, immutable"
 
 
 @router.get("/me", summary="Get current user profile")
@@ -361,7 +367,7 @@ def get_user_photo(
     :param user_id: User whose photo to serve
     :param user_service: User service for the photo key lookup
     :param storage_service: Storage service (None when not configured)
-    :return: The image bytes with public caching headers
+    :return: The image streamed from the bucket, with public caching headers
     """
     if storage_service is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Photo not found")
@@ -373,18 +379,13 @@ def get_user_photo(
     # A storage fault must not surface here: this endpoint is public, and the raw
     # exception text carries the bucket host and object key.
     try:
-        result = storage_service.open(user.photo_url)
+        stored = storage_service.open(user.photo_url)
     except StorageError as err:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Photo not found"
         ) from err
 
-    if result is None:
+    if stored is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Photo not found")
 
-    content, content_type = result
-    return Response(
-        content=content,
-        media_type=content_type,
-        headers={"Cache-Control": "public, max-age=86400"},
-    )
+    return StoredObjectResponse(stored, headers={"Cache-Control": _PHOTO_CACHE_CONTROL})

--- a/api/routes/users.py
+++ b/api/routes/users.py
@@ -50,9 +50,14 @@ from api.utils.upload import UploadTooLarge, read_within_limit
 router = APIRouter(prefix="/api/v1/users", tags=["users"])
 
 # Profile photo URLs are versioned: build_photo_url appends ?v=<token> taken from the
-# stored object key, and every upload mints a fresh key. A given URL therefore always
-# resolves to the same bytes, so it can be cached for as long as a cache will hold it.
-_PHOTO_CACHE_CONTROL = "public, max-age=31536000, immutable"
+# stored object key, and every upload mints a fresh key. A versioned URL therefore always
+# resolves to the same bytes and can be cached for as long as a cache will hold it.
+_VERSIONED_PHOTO_CACHE_CONTROL = "public, max-age=31536000, immutable"
+
+# The bare path carries no version, so its bytes change when the photo does. Nothing the
+# API emits looks like that, but a hand-written or truncated URL would, and pinning it for
+# a year in a shared cache would serve one person's old avatar to everyone who asked.
+_UNVERSIONED_PHOTO_CACHE_CONTROL = "public, max-age=300"
 
 
 @router.get("/me", summary="Get current user profile")
@@ -388,4 +393,12 @@ def get_user_photo(
     if stored is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Photo not found")
 
-    return StoredObjectResponse(stored, headers={"Cache-Control": _PHOTO_CACHE_CONTROL})
+    # Presence of the version parameter is the whole test. Comparing it against the stored
+    # key would tie this route to how build_photo_url derives the token, and buy nothing:
+    # a caller who invented a version is already asking for a URL nobody handed out.
+    cache_control = (
+        _VERSIONED_PHOTO_CACHE_CONTROL
+        if "v" in request.query_params
+        else _UNVERSIONED_PHOTO_CACHE_CONTROL
+    )
+    return StoredObjectResponse(stored, headers={"Cache-Control": cache_control})

--- a/api/services/storage/base.py
+++ b/api/services/storage/base.py
@@ -2,6 +2,8 @@
 
 from abc import ABC, abstractmethod
 
+from api.services.storage.stored_object import StoredObject
+
 
 class StorageService(ABC):
     """File storage backend for profile photos, addressed by object key.
@@ -23,11 +25,14 @@ class StorageService(ABC):
         """
 
     @abstractmethod
-    def open(self, key: str) -> tuple[bytes, str] | None:
-        """Fetch a stored object by key.
+    def open(self, key: str) -> StoredObject | None:
+        """Open a stored object for reading, without downloading it.
+
+        The returned handle owns a live connection to the backend, so the caller
+        must either read it to the end or close it.
 
         :param key: Object key.
-        :return: ``(bytes, content_type)`` or None when the object is absent.
+        :return: An open :class:`StoredObject`, or None when the object is absent.
         :raises StorageError: If the fetch fails for a reason other than absence.
         """
 

--- a/api/services/storage/railway_bucket_storage_service.py
+++ b/api/services/storage/railway_bucket_storage_service.py
@@ -14,6 +14,7 @@ from api.services.storage.exceptions import (
     StorageError,
     StorageUploadError,
 )
+from api.services.storage.stored_object import StoredObject
 from api.services.storage.validation import extension_for
 
 if TYPE_CHECKING:
@@ -124,11 +125,14 @@ class RailwayBucketStorageService(StorageService):
         )
         return key
 
-    def open(self, key: str) -> tuple[bytes, str] | None:
-        """Fetch a stored object by key.
+    def open(self, key: str) -> StoredObject | None:
+        """Open a stored object for reading, leaving its body on the wire.
+
+        ``get_object`` returns once the bucket has answered with headers; the
+        body is pulled later, chunk by chunk, by whoever consumes the handle.
 
         :param key: Object key.
-        :return: ``(bytes, content_type)`` or None when the object is absent.
+        :return: An open :class:`StoredObject`, or None when the object is absent.
         :raises StorageError: If the fetch fails for a reason other than absence.
         """
         start = perf_counter()
@@ -155,18 +159,21 @@ class RailwayBucketStorageService(StorageService):
                 },
             )
             raise StorageError(f"Failed to read file: {exc}") from exc
-        body: bytes = response["Body"].read()
         content_type: str = response.get("ContentType") or "application/octet-stream"
+        content_length: int | None = response.get("ContentLength")
+        # duration_ms is the time to the bucket's response headers, not to the last
+        # byte: the body has not been read yet. That is the number the client waits
+        # on before the image starts arriving, so it is the one worth watching.
         logger.info(
             "S3 open",
             extra={
                 "event": "s3_open",
                 "key": key,
-                "size_bytes": len(body),
+                "size_bytes": content_length,
                 "duration_ms": _elapsed_ms(start),
             },
         )
-        return body, content_type
+        return StoredObject(response["Body"], content_type, content_length)
 
     def delete(self, key: str) -> bool:
         """Delete a stored object by key.

--- a/api/services/storage/stored_object.py
+++ b/api/services/storage/stored_object.py
@@ -1,0 +1,96 @@
+"""Open handle over a stored object, read in chunks instead of all at once."""
+
+from collections.abc import Iterator
+from typing import Protocol
+
+#: Bytes pulled from the backend per iteration. Matches Starlette's own file
+#: streaming, which is tuned for the same trade-off between syscalls and memory.
+DEFAULT_CHUNK_SIZE = 64 * 1024
+
+
+class ByteStream(Protocol):
+    """Readable, closable byte source backing a stored object.
+
+    Narrow on purpose: an S3 ``StreamingBody``, a local file, and a ``BytesIO``
+    all satisfy it, so the storage layer never has to name a vendor type.
+    """
+
+    def read(self, size: int, /) -> bytes:
+        """Return up to ``size`` bytes from the current position.
+
+        :param size: Maximum number of bytes to return.
+        :return: The bytes read; empty once the stream is exhausted.
+        """
+
+    def close(self) -> None:
+        """Release the underlying connection or file handle."""
+
+
+class StoredObject:
+    """An object opened for reading, whose body is still on the wire.
+
+    Holding the stream rather than its bytes is the point: the storage backend
+    answers with headers first, so a response can start immediately and the body
+    is pulled only as it is written out. Nothing is buffered in the process.
+
+    The handle owns a live connection and therefore has a lifecycle -- open until
+    :meth:`chunks` runs to the end or :meth:`close` is called. Leaving it open
+    leaks a connection from the backend pool.
+
+    :param stream: Open byte stream positioned at the start of the object.
+    :param content_type: MIME type reported by the backend.
+    :param content_length: Object size in bytes, when the backend reports one.
+    :param chunk_size: Bytes to pull from the stream per iteration.
+    """
+
+    def __init__(
+        self,
+        stream: ByteStream,
+        content_type: str,
+        content_length: int | None = None,
+        *,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
+    ) -> None:
+        """Wrap an open stream together with the metadata needed to serve it."""
+        self._stream = stream
+        self._content_type = content_type
+        self._content_length = content_length
+        self._chunk_size = chunk_size
+        self._closed = False
+
+    @property
+    def content_type(self) -> str:
+        """MIME type reported by the storage backend."""
+        return self._content_type
+
+    @property
+    def content_length(self) -> int | None:
+        """Object size in bytes, or None when the backend did not report one."""
+        return self._content_length
+
+    @property
+    def closed(self) -> bool:
+        """Whether the underlying stream has been released."""
+        return self._closed
+
+    def chunks(self) -> Iterator[bytes]:
+        """Yield the body in chunks, releasing the stream when iteration ends.
+
+        The ``finally`` covers abandonment as well as exhaustion: a consumer that
+        stops part way leaves the generator unfinished, and closing it still frees
+        the connection instead of stranding it.
+
+        :return: Iterator over the object bytes.
+        """
+        try:
+            while chunk := self._stream.read(self._chunk_size):
+                yield chunk
+        finally:
+            self.close()
+
+    def close(self) -> None:
+        """Release the underlying stream. Calling it again does nothing."""
+        if self._closed:
+            return
+        self._closed = True
+        self._stream.close()

--- a/api/utils/photo_links.py
+++ b/api/utils/photo_links.py
@@ -20,11 +20,15 @@ def build_photo_url(user_id: str | UUID, photo_key: str | None) -> str | None:
     if not photo_key:
         return None
     base = get_settings().api_public_url.rstrip("/")
-    return f"{base}/api/v1/users/{user_id}/photo?v={_cache_buster(photo_key)}"
+    return f"{base}/api/v1/users/{user_id}/photo?v={photo_version(photo_key)}"
 
 
-def _cache_buster(photo_key: str) -> str:
-    """Derive a short, stable cache-buster token from the object key.
+def photo_version(photo_key: str) -> str:
+    """Derive the version token that identifies one stored photo.
+
+    The photo route compares the ``v`` it was asked for against this, so the two
+    must agree on what a version is: only a request naming the key currently on
+    the account describes bytes that cannot change under it.
 
     :param photo_key: Stored object key like ``profiles/<id>/<random>.<ext>``.
     :return: The random key segment without its extension.

--- a/api/utils/streaming.py
+++ b/api/utils/streaming.py
@@ -1,0 +1,47 @@
+"""HTTP response that streams a stored object and always releases it."""
+
+from collections.abc import Mapping
+
+from starlette.responses import StreamingResponse
+from starlette.types import Receive, Scope, Send
+
+from api.services.storage.stored_object import StoredObject
+
+
+class StoredObjectResponse(StreamingResponse):
+    """Stream a stored object's body, releasing its connection on every exit path.
+
+    Plain ``StreamingResponse`` is not enough on its own. Starlette has two ways of
+    handling a client that goes away, and only one of them runs the response's own
+    cleanup hook: the older branch watches for a disconnect message and finishes
+    normally, while the newer one turns a failed write into an exception and simply
+    abandons the body iterator. On that branch the generator's ``finally`` waits on
+    garbage collection of a suspended async generator, which is not prompt and may
+    not happen at all, so the bucket connection is never given back. Wrapping the
+    whole ASGI call in a ``finally`` covers both branches.
+
+    :param stored: Open handle whose body becomes the response body.
+    :param headers: Extra response headers, such as caching directives.
+    """
+
+    def __init__(self, stored: StoredObject, headers: Mapping[str, str] | None = None) -> None:
+        """Build the response from an open handle and its reported metadata."""
+        merged = dict(headers or {})
+        # A declared size lets the browser show real progress instead of falling back
+        # to chunked transfer. Absent only when the backend omits the length.
+        if stored.content_length is not None:
+            merged["Content-Length"] = str(stored.content_length)
+        super().__init__(stored.chunks(), media_type=stored.content_type, headers=merged)
+        self._stored = stored
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Write the response, then release the handle whatever happened.
+
+        :param scope: ASGI connection scope.
+        :param receive: ASGI receive channel.
+        :param send: ASGI send channel.
+        """
+        try:
+            await super().__call__(scope, receive, send)
+        finally:
+            self._stored.close()

--- a/docs/quality-report.md
+++ b/docs/quality-report.md
@@ -4,11 +4,11 @@
 
 | Check | Status | Result |
 |-------|--------|--------|
-| mypy (strict) | Pass | No errors (28 files in `src/`+`examples/`, 87 in `api/`) |
+| mypy (strict) | Pass | No errors (28 files in `src/`+`examples/`, 89 in `api/`) |
 | ruff check | Pass | No issues |
 | ruff format | Pass | All files formatted |
-| pytest | Pass | 1474 tests passed |
-| coverage | Pass | 100% on `src/` (197 statements), 99% on `src/`+`api/` (3962 statements, 49 uncovered) |
+| pytest | Pass | 1499 tests passed |
+| coverage | Pass | 100% on `src/` (197 statements), 99% on `src/`+`api/` (4014 statements, 49 uncovered) |
 
 ## Running Checks
 

--- a/tests/integration/api/routes/test_photo.py
+++ b/tests/integration/api/routes/test_photo.py
@@ -45,6 +45,9 @@ UPLOADED_KEY = "profiles/test/deadbeef0001.jpg"
 # A versioned photo URL always maps to the same bytes, so it is cacheable forever.
 IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable"
 
+# The bare path has no version, so its bytes change with the photo and it gets a short TTL.
+SHORT_CACHE_CONTROL = "public, max-age=300"
+
 
 def _photo_stream(data: bytes = VALID_JPEG_BYTES) -> MagicMock:
     """Wrap a photo body in a mock, so its read and close calls are observable."""
@@ -409,10 +412,31 @@ class TestPhotoProxy:
         user_id = self._user_with_photo(client, "cached@example.com")
 
         # WHEN
-        response = client.get(f"/api/v1/users/{user_id}/photo")
+        response = client.get(f"/api/v1/users/{user_id}/photo?v=deadbeef0001")
 
         # THEN
         assert response.headers["cache-control"] == IMMUTABLE_CACHE_CONTROL
+
+    def test_an_unversioned_url_is_not_pinned_for_a_year(self, client_with_mock_storage):
+        """
+        GIVEN a photo requested through the bare path, with no version parameter
+        WHEN the response is served
+        THEN it carries the short cache header instead of the immutable one
+
+        The bare path is a stable URL whose bytes change when the photo does. Nothing
+        the API emits looks like that, but pinning it in a shared cache would serve one
+        person's replaced avatar to everyone who asked for a year.
+        """
+        # GIVEN
+        client, _ = client_with_mock_storage
+        user_id = self._user_with_photo(client, "unversioned@example.com")
+
+        # WHEN
+        response = client.get(f"/api/v1/users/{user_id}/photo")
+
+        # THEN
+        assert response.headers["cache-control"] == SHORT_CACHE_CONTROL
+        assert response.headers["cache-control"] != IMMUTABLE_CACHE_CONTROL
 
     def test_closes_the_stream_once_the_response_is_written(self, client_with_mock_storage):
         """The bucket connection is released, not left in the pool."""

--- a/tests/integration/api/routes/test_photo.py
+++ b/tests/integration/api/routes/test_photo.py
@@ -438,6 +438,27 @@ class TestPhotoProxy:
         assert response.headers["cache-control"] == SHORT_CACHE_CONTROL
         assert response.headers["cache-control"] != IMMUTABLE_CACHE_CONTROL
 
+    def test_a_version_that_is_not_the_current_one_is_not_pinned(self, client_with_mock_storage):
+        """
+        GIVEN a photo requested with a version token that is stale or invented
+        WHEN the response is served
+        THEN it carries the short cache header, not the immutable one
+
+        The route always serves whatever photo the account holds now, so a `v` that
+        names some other key describes bytes that already changed once and can change
+        again. Treating presence alone as proof of immutability would let anyone pin a
+        replaceable avatar in a shared cache for a year under a URL of their choosing.
+        """
+        # GIVEN
+        client, _ = client_with_mock_storage
+        user_id = self._user_with_photo(client, "stale-version@example.com")
+
+        # WHEN
+        response = client.get(f"/api/v1/users/{user_id}/photo?v=notthecurrentkey")
+
+        # THEN
+        assert response.headers["cache-control"] == SHORT_CACHE_CONTROL
+
     def test_closes_the_stream_once_the_response_is_written(self, client_with_mock_storage):
         """The bucket connection is released, not left in the pool."""
         # GIVEN

--- a/tests/integration/api/routes/test_photo.py
+++ b/tests/integration/api/routes/test_photo.py
@@ -17,6 +17,7 @@ from api.services.storage.exceptions import (
     StorageError,
     StorageUploadError,
 )
+from api.services.storage.stored_object import DEFAULT_CHUNK_SIZE, StoredObject
 from tests.integration.api.conftest import auth_header, create_test_app, register_and_login
 
 
@@ -41,6 +42,30 @@ INVALID_FILE_BYTES = b"This is not an image file"
 # Object key the mocked storage returns for an upload.
 UPLOADED_KEY = "profiles/test/deadbeef0001.jpg"
 
+# A versioned photo URL always maps to the same bytes, so it is cacheable forever.
+IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable"
+
+
+def _photo_stream(data: bytes = VALID_JPEG_BYTES) -> MagicMock:
+    """Wrap a photo body in a mock, so its read and close calls are observable."""
+    return MagicMock(wraps=BytesIO(data))
+
+
+def _stored_photo(
+    stream: MagicMock | None = None, chunk_size: int = DEFAULT_CHUNK_SIZE
+) -> StoredObject:
+    """Build an open handle over an in-memory photo body.
+
+    ``open`` hands back a single-use handle, so every call needs a fresh one --
+    a shared instance would arrive already closed on the second request.
+    """
+    return StoredObject(
+        stream if stream is not None else _photo_stream(),
+        "image/jpeg",
+        len(VALID_JPEG_BYTES),
+        chunk_size=chunk_size,
+    )
+
 
 @pytest.fixture
 def client_with_mock_storage(test_engine):
@@ -53,7 +78,7 @@ def client_with_mock_storage(test_engine):
 
     mock_storage = MagicMock(spec=StorageService)
     mock_storage.upload.return_value = UPLOADED_KEY
-    mock_storage.open.return_value = (VALID_JPEG_BYTES, "image/jpeg")
+    mock_storage.open.side_effect = lambda _key: _stored_photo()
 
     test_app.dependency_overrides[get_session] = override_get_session
     test_app.dependency_overrides[get_storage_service] = lambda: mock_storage
@@ -328,17 +353,23 @@ class TestPhotoDelete:
 class TestPhotoProxy:
     """Tests for GET /api/v1/users/{user_id}/photo."""
 
-    def test_streams_photo_bytes(self, client_with_mock_storage):
-        """The proxy streams the stored object with its content type."""
-        # GIVEN
-        client, mock_storage = client_with_mock_storage
-        token = register_and_login(client, "proxy@example.com")
+    @staticmethod
+    def _user_with_photo(client, email: str) -> str:
+        """Register a user, upload a photo, and return the user id."""
+        token = register_and_login(client, email)
         user_id = client.get("/api/v1/users/me", headers=auth_header(token)).json()["id"]
         client.post(
             "/api/v1/users/me/photo",
             headers=auth_header(token),
             files={"file": ("photo.jpg", VALID_JPEG_BYTES, "image/jpeg")},
         )
+        return str(user_id)
+
+    def test_streams_photo_bytes(self, client_with_mock_storage):
+        """The proxy streams the stored object with its content type and size."""
+        # GIVEN
+        client, mock_storage = client_with_mock_storage
+        user_id = self._user_with_photo(client, "proxy@example.com")
 
         # WHEN - public endpoint, no auth header
         response = client.get(f"/api/v1/users/{user_id}/photo")
@@ -346,13 +377,77 @@ class TestPhotoProxy:
         # THEN
         assert response.status_code == 200
         assert response.headers["content-type"].startswith("image/jpeg")
+        assert response.headers["content-length"] == str(len(VALID_JPEG_BYTES))
         assert response.content == VALID_JPEG_BYTES
         mock_storage.open.assert_called_with(UPLOADED_KEY)
+
+    def test_pulls_the_body_in_chunks_instead_of_buffering_it(self, client_with_mock_storage):
+        """The route hands the open stream to the response, chunk by chunk.
+
+        With a chunk size below the payload, a buffering route would show a single
+        read; a streaming one shows one read per chunk plus the closing empty read.
+        """
+        # GIVEN a handle that yields the photo four bytes at a time
+        client, mock_storage = client_with_mock_storage
+        user_id = self._user_with_photo(client, "chunked@example.com")
+        stream = _photo_stream()
+        mock_storage.open.side_effect = None
+        mock_storage.open.return_value = _stored_photo(stream, chunk_size=4)
+
+        # WHEN
+        response = client.get(f"/api/v1/users/{user_id}/photo")
+
+        # THEN one read per chunk, plus the empty read that ends the stream
+        assert response.content == VALID_JPEG_BYTES
+        expected_reads = -(-len(VALID_JPEG_BYTES) // 4) + 1
+        assert stream.read.call_count == expected_reads
+
+    def test_sets_an_immutable_year_long_cache_header(self, client_with_mock_storage):
+        """A versioned photo URL is cacheable indefinitely."""
+        # GIVEN
+        client, _ = client_with_mock_storage
+        user_id = self._user_with_photo(client, "cached@example.com")
+
+        # WHEN
+        response = client.get(f"/api/v1/users/{user_id}/photo")
+
+        # THEN
+        assert response.headers["cache-control"] == IMMUTABLE_CACHE_CONTROL
+
+    def test_closes_the_stream_once_the_response_is_written(self, client_with_mock_storage):
+        """The bucket connection is released, not left in the pool."""
+        # GIVEN
+        client, mock_storage = client_with_mock_storage
+        user_id = self._user_with_photo(client, "closed@example.com")
+        stream = _photo_stream()
+        stored = _stored_photo(stream)
+        mock_storage.open.side_effect = None
+        mock_storage.open.return_value = stored
+
+        # WHEN
+        response = client.get(f"/api/v1/users/{user_id}/photo")
+
+        # THEN the handle is released once, though two paths try to release it
+        assert response.status_code == 200
+        assert stored.closed is True
+        stream.close.assert_called_once()
+
+    def test_returns_404_when_the_user_does_not_exist(self, client_with_mock_storage):
+        """An unknown user id returns 404 without reaching storage."""
+        # GIVEN
+        client, mock_storage = client_with_mock_storage
+
+        # WHEN
+        response = client.get(f"/api/v1/users/{uuid.uuid4()}/photo")
+
+        # THEN
+        assert response.status_code == 404
+        mock_storage.open.assert_not_called()
 
     def test_returns_404_when_user_has_no_photo(self, client_with_mock_storage):
         """The proxy returns 404 when the user has no photo set."""
         # GIVEN
-        client, _ = client_with_mock_storage
+        client, mock_storage = client_with_mock_storage
         token = register_and_login(client, "nophoto@example.com")
         user_id = client.get("/api/v1/users/me", headers=auth_header(token)).json()["id"]
 
@@ -361,6 +456,7 @@ class TestPhotoProxy:
 
         # THEN
         assert response.status_code == 404
+        mock_storage.open.assert_not_called()
 
     def test_returns_404_when_storage_unavailable(self, client_without_storage):
         """The proxy returns 404 when storage is not configured."""
@@ -377,13 +473,8 @@ class TestPhotoProxy:
         """The proxy returns 404 when the key is set but the object is gone from storage."""
         # GIVEN - a user with a photo whose backing object has since disappeared
         client, mock_storage = client_with_mock_storage
-        token = register_and_login(client, "gone@example.com")
-        user_id = client.get("/api/v1/users/me", headers=auth_header(token)).json()["id"]
-        client.post(
-            "/api/v1/users/me/photo",
-            headers=auth_header(token),
-            files={"file": ("photo.jpg", VALID_JPEG_BYTES, "image/jpeg")},
-        )
+        user_id = self._user_with_photo(client, "gone@example.com")
+        mock_storage.open.side_effect = None
         mock_storage.open.return_value = None
 
         # WHEN
@@ -400,13 +491,7 @@ class TestPhotoProxy:
         """
         # GIVEN - a user with a photo, and storage that fails on read
         client, mock_storage = client_with_mock_storage
-        token = register_and_login(client, "fault@example.com")
-        user_id = client.get("/api/v1/users/me", headers=auth_header(token)).json()["id"]
-        client.post(
-            "/api/v1/users/me/photo",
-            headers=auth_header(token),
-            files={"file": ("photo.jpg", VALID_JPEG_BYTES, "image/jpeg")},
-        )
+        user_id = self._user_with_photo(client, "fault@example.com")
         mock_storage.open.side_effect = StorageError(
             "Failed to read file: Could not connect to the endpoint URL: "
             f"https://private-bucket.example/{UPLOADED_KEY}"

--- a/tests/unit/api/services/test_storage.py
+++ b/tests/unit/api/services/test_storage.py
@@ -1,5 +1,6 @@
 """Unit tests for RailwayBucketStorageService."""
 
+from io import BytesIO
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -160,21 +161,60 @@ class TestUpload:
 class TestOpen:
     """Tests for fetching an object."""
 
-    def test_returns_bytes_and_content_type(self):
-        """Returns the object bytes together with its content type."""
+    def test_returns_an_open_handle_with_metadata(self):
+        """Returns a handle carrying the content type and the reported size."""
         # GIVEN
-        body = MagicMock()
-        body.read.return_value = b"image bytes"
+        body = MagicMock(wraps=BytesIO(b"image bytes"))
         client = MagicMock()
-        client.get_object.return_value = {"Body": body, "ContentType": "image/png"}
+        client.get_object.return_value = {
+            "Body": body,
+            "ContentType": "image/png",
+            "ContentLength": 11,
+        }
         service = RailwayBucketStorageService(_settings(), client=client)
 
         # WHEN
         result = service.open("profiles/user/abc.png")
 
         # THEN
-        assert result == (b"image bytes", "image/png")
+        assert result is not None
+        assert result.content_type == "image/png"
+        assert result.content_length == 11
+        assert b"".join(result.chunks()) == b"image bytes"
         client.get_object.assert_called_once_with(Bucket="test-bucket", Key="profiles/user/abc.png")
+
+    def test_does_not_read_the_body_while_opening(self):
+        """Opening only fetches headers -- the body stays on the wire.
+
+        This is the whole point of the change: time to first byte must not include
+        the full object download.
+        """
+        # GIVEN
+        body = MagicMock(wraps=BytesIO(b"image bytes"))
+        client = MagicMock()
+        client.get_object.return_value = {"Body": body, "ContentLength": 11}
+        service = RailwayBucketStorageService(_settings(), client=client)
+
+        # WHEN
+        service.open("profiles/user/abc.png")
+
+        # THEN
+        body.read.assert_not_called()
+
+    def test_falls_back_to_octet_stream_without_a_content_type(self):
+        """A bucket response with no ContentType yields a generic media type."""
+        # GIVEN
+        client = MagicMock()
+        client.get_object.return_value = {"Body": MagicMock(wraps=BytesIO(b"x"))}
+        service = RailwayBucketStorageService(_settings(), client=client)
+
+        # WHEN
+        result = service.open("profiles/user/abc.png")
+
+        # THEN
+        assert result is not None
+        assert result.content_type == "application/octet-stream"
+        assert result.content_length is None
 
     def test_returns_none_when_object_absent(self):
         """Returns None when the object does not exist."""
@@ -225,6 +265,34 @@ class TestOpen:
         # THEN
         assert mock_logger.info.call_args[1]["extra"]["event"] == "s3_open_miss"
         mock_logger.error.assert_not_called()
+
+    def test_logs_the_reported_size_and_the_time_to_headers(self):
+        """The open event reports ContentLength and how long the headers took.
+
+        duration_ms no longer covers the download, because the body has not been
+        read at that point -- it measures what the client waits for before the
+        first byte arrives.
+        """
+        # GIVEN
+        body = MagicMock(wraps=BytesIO(b"image bytes"))
+        client = MagicMock()
+        client.get_object.return_value = {
+            "Body": body,
+            "ContentType": "image/png",
+            "ContentLength": 11,
+        }
+        service = RailwayBucketStorageService(_settings(), client=client)
+
+        # WHEN
+        with patch("api.services.storage.railway_bucket_storage_service.logger") as mock_logger:
+            service.open("profiles/user/abc.png")
+
+        # THEN
+        extra = mock_logger.info.call_args[1]["extra"]
+        assert extra["event"] == "s3_open"
+        assert extra["size_bytes"] == 11
+        assert "duration_ms" in extra
+        body.read.assert_not_called()
 
     def test_logs_failure_with_exc_info(self):
         """A non-absence failure logs an error carrying exc_info."""

--- a/tests/unit/api/services/test_stored_object.py
+++ b/tests/unit/api/services/test_stored_object.py
@@ -1,0 +1,169 @@
+"""Unit tests for the StoredObject streaming handle."""
+
+from io import BytesIO
+from unittest.mock import MagicMock
+
+from api.services.storage.stored_object import DEFAULT_CHUNK_SIZE, StoredObject
+
+PAYLOAD = b"0123456789abcdef"
+
+
+def _stream(data: bytes = PAYLOAD) -> MagicMock:
+    """Wrap an in-memory stream in a mock so read/close calls are observable."""
+    return MagicMock(wraps=BytesIO(data))
+
+
+class TestMetadata:
+    """Tests for the metadata the handle carries alongside the stream."""
+
+    def test_exposes_content_type_and_length(self):
+        """Content type and length are readable without touching the stream."""
+        # GIVEN
+        stream = _stream()
+
+        # WHEN
+        stored = StoredObject(stream, "image/png", len(PAYLOAD))
+
+        # THEN
+        assert stored.content_type == "image/png"
+        assert stored.content_length == len(PAYLOAD)
+        stream.read.assert_not_called()
+
+    def test_content_length_is_none_when_not_reported(self):
+        """A backend that omits the size leaves content_length unset."""
+        # GIVEN / WHEN
+        stored = StoredObject(_stream(), "image/jpeg")
+
+        # THEN
+        assert stored.content_length is None
+
+    def test_default_chunk_size_matches_starlette_file_streaming(self):
+        """The default chunk is 64 KiB, the same size Starlette uses for files."""
+        # THEN
+        assert DEFAULT_CHUNK_SIZE == 64 * 1024
+
+
+class TestChunks:
+    """Tests for reading the body in pieces."""
+
+    def test_yields_the_whole_body(self):
+        """Concatenated chunks reproduce the stored bytes exactly."""
+        # GIVEN
+        stored = StoredObject(_stream(), "image/jpeg", len(PAYLOAD))
+
+        # WHEN
+        body = b"".join(stored.chunks())
+
+        # THEN
+        assert body == PAYLOAD
+
+    def test_reads_in_pieces_rather_than_all_at_once(self):
+        """The stream is pulled chunk by chunk, never buffered in one read."""
+        # GIVEN a chunk size well below the payload
+        stream = _stream()
+        stored = StoredObject(stream, "image/jpeg", len(PAYLOAD), chunk_size=4)
+
+        # WHEN
+        chunks = list(stored.chunks())
+
+        # THEN four data chunks plus the empty read that ends the loop
+        assert chunks == [b"0123", b"4567", b"89ab", b"cdef"]
+        assert stream.read.call_count == 5
+        assert stream.read.call_args_list[0].args == (4,)
+
+    def test_is_lazy_until_iterated(self):
+        """Calling chunks() does not read anything on its own."""
+        # GIVEN
+        stream = _stream()
+        stored = StoredObject(stream, "image/jpeg")
+
+        # WHEN
+        stored.chunks()
+
+        # THEN
+        stream.read.assert_not_called()
+
+    def test_closes_the_stream_when_exhausted(self):
+        """Reading to the end releases the underlying stream."""
+        # GIVEN
+        stream = _stream()
+        stored = StoredObject(stream, "image/jpeg")
+
+        # WHEN
+        list(stored.chunks())
+
+        # THEN
+        stream.close.assert_called_once()
+        assert stored.closed is True
+
+    def test_closes_the_stream_when_abandoned_part_way(self):
+        """A partly consumed iterator still releases the stream when dropped.
+
+        This is the client-disconnect case: the response stops mid-download, the
+        generator never reaches its end, and the connection must not be stranded.
+        """
+        # GIVEN
+        stream = _stream()
+        stored = StoredObject(stream, "image/jpeg", chunk_size=4)
+        iterator = stored.chunks()
+        next(iterator)
+        assert stream.close.call_count == 0
+
+        # WHEN the consumer walks away
+        iterator.close()
+
+        # THEN
+        stream.close.assert_called_once()
+        assert stored.closed is True
+
+
+class TestClose:
+    """Tests for releasing the handle."""
+
+    def test_closes_the_stream_without_reading(self):
+        """close() releases an untouched handle."""
+        # GIVEN
+        stream = _stream()
+        stored = StoredObject(stream, "image/jpeg")
+
+        # WHEN
+        stored.close()
+
+        # THEN
+        stream.close.assert_called_once()
+        stream.read.assert_not_called()
+
+    def test_is_idempotent(self):
+        """Closing twice touches the stream once.
+
+        The route arms two independent release paths (the generator's finally and a
+        background task), so the second one must be harmless.
+        """
+        # GIVEN
+        stream = _stream()
+        stored = StoredObject(stream, "image/jpeg")
+
+        # WHEN
+        stored.close()
+        stored.close()
+
+        # THEN
+        stream.close.assert_called_once()
+
+    def test_closes_a_handle_that_was_never_iterated(self):
+        """A generator that never started runs no finally, so close() must cover it.
+
+        This is the disconnect-before-the-first-chunk case: nothing else would ever
+        release the connection, since abandoning an unstarted generator does not run
+        its cleanup.
+        """
+        # GIVEN
+        stream = _stream()
+        stored = StoredObject(stream, "image/jpeg")
+        stored.chunks()
+
+        # WHEN
+        stored.close()
+
+        # THEN
+        stream.close.assert_called_once()

--- a/tests/unit/api/utils/test_streaming.py
+++ b/tests/unit/api/utils/test_streaming.py
@@ -1,0 +1,170 @@
+"""Unit tests for StoredObjectResponse."""
+
+from io import BytesIO
+from unittest.mock import MagicMock
+
+import anyio
+import pytest
+from starlette.requests import ClientDisconnect
+
+from api.services.storage.stored_object import StoredObject
+from api.utils.streaming import StoredObjectResponse
+
+PAYLOAD = b"0123456789abcdef"
+CHUNK_SIZE = 4
+TOTAL_CHUNKS = len(PAYLOAD) // CHUNK_SIZE
+
+
+def _stored(content_length: int | None = len(PAYLOAD)) -> tuple[StoredObject, MagicMock]:
+    """Build a chunked handle plus the mock stream behind it."""
+    stream = MagicMock(wraps=BytesIO(PAYLOAD))
+    return StoredObject(stream, "image/png", content_length, chunk_size=CHUNK_SIZE), stream
+
+
+def _scope(spec_version: str) -> dict[str, object]:
+    """Build a minimal HTTP scope pinned to one ASGI spec version.
+
+    The version decides how Starlette reacts to a client that goes away, and the
+    two branches behave differently enough that both are worth exercising.
+    """
+    return {"type": "http", "asgi": {"version": "3.0", "spec_version": spec_version}}
+
+
+class _Recorder:
+    """Collect the ASGI messages a response sends."""
+
+    def __init__(self, disconnect: bool = False, fail_after: int | None = None) -> None:
+        self._disconnect = disconnect
+        self._fail_after = fail_after
+        self._client_left = anyio.Event()
+        self.headers: dict[bytes, bytes] = {}
+        self.body = b""
+        self.chunks = 0
+
+    async def receive(self) -> dict[str, str]:
+        """Report a disconnect once the first chunk is out, or block forever."""
+        if not self._disconnect:
+            await anyio.sleep(3600)
+        await self._client_left.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(self, message: dict) -> None:
+        """Record one outgoing message, simulating a dropped client if asked."""
+        if message["type"] == "http.response.start":
+            self.headers = dict(message["headers"])
+        if message["type"] == "http.response.body" and message.get("body"):
+            self.chunks += 1
+            self.body += message["body"]
+            if self._disconnect:
+                self._client_left.set()
+                await anyio.sleep(0.05)
+            if self._fail_after is not None and self.chunks >= self._fail_after:
+                raise OSError("client went away")
+
+
+class TestHeaders:
+    """Tests for the headers the response declares."""
+
+    @pytest.mark.asyncio
+    async def test_declares_content_length_and_type(self):
+        """The reported size and media type reach the wire."""
+        # GIVEN
+        stored, _ = _stored()
+        recorder = _Recorder()
+
+        # WHEN
+        await StoredObjectResponse(stored)(_scope("2.3"), recorder.receive, recorder.send)
+
+        # THEN
+        assert recorder.headers[b"content-length"] == str(len(PAYLOAD)).encode()
+        assert recorder.headers[b"content-type"] == b"image/png"
+        assert recorder.body == PAYLOAD
+
+    @pytest.mark.asyncio
+    async def test_omits_content_length_when_the_backend_did_not_report_one(self):
+        """Without a known size the response falls back to chunked transfer."""
+        # GIVEN
+        stored, _ = _stored(content_length=None)
+        recorder = _Recorder()
+
+        # WHEN
+        await StoredObjectResponse(stored)(_scope("2.3"), recorder.receive, recorder.send)
+
+        # THEN
+        assert b"content-length" not in recorder.headers
+        assert recorder.body == PAYLOAD
+
+    @pytest.mark.asyncio
+    async def test_keeps_the_caller_supplied_headers(self):
+        """Caching directives passed by the route survive."""
+        # GIVEN
+        stored, _ = _stored()
+        recorder = _Recorder()
+        response = StoredObjectResponse(stored, headers={"Cache-Control": "public, immutable"})
+
+        # WHEN
+        await response(_scope("2.3"), recorder.receive, recorder.send)
+
+        # THEN
+        assert recorder.headers[b"cache-control"] == b"public, immutable"
+
+
+class TestRelease:
+    """Tests that the bucket connection is never left open.
+
+    Starlette handles a vanished client in two ways depending on the ASGI spec
+    version the server advertises: the older branch delivers an ``http.disconnect``
+    message and returns normally, the newer one lets the failed write surface as an
+    exception. Both must end with the handle released.
+    """
+
+    @pytest.mark.asyncio
+    async def test_closes_after_a_complete_response(self):
+        """A fully written response releases the handle exactly once."""
+        # GIVEN
+        stored, stream = _stored()
+        recorder = _Recorder()
+
+        # WHEN
+        await StoredObjectResponse(stored)(_scope("2.3"), recorder.receive, recorder.send)
+
+        # THEN
+        assert recorder.chunks == TOTAL_CHUNKS
+        assert stored.closed is True
+        stream.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_closes_when_the_client_sends_a_disconnect(self):
+        """A disconnect message part way through still releases the handle."""
+        # GIVEN
+        stored, stream = _stored()
+        recorder = _Recorder(disconnect=True)
+
+        # WHEN
+        await StoredObjectResponse(stored)(_scope("2.3"), recorder.receive, recorder.send)
+
+        # THEN the transfer stopped early and nothing stayed open
+        assert recorder.chunks < TOTAL_CHUNKS
+        assert stored.closed is True
+        stream.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_closes_when_writing_to_the_client_fails(self):
+        """A write that fails mid-stream releases the handle before propagating.
+
+        On this branch Starlette abandons the body iterator instead of running any
+        cleanup hook, so without the wrapper the connection would sit in limbo until
+        an async generator that may never be collected finally is.
+        """
+        # GIVEN
+        stored, stream = _stored()
+        recorder = _Recorder(fail_after=2)
+
+        # WHEN
+        with pytest.raises(ClientDisconnect):
+            await StoredObjectResponse(stored)(_scope("2.4"), recorder.receive, recorder.send)
+
+        # THEN
+        assert recorder.chunks == 2
+        assert stored.closed is True
+        stream.close.assert_called_once()


### PR DESCRIPTION
Promotes `develop` to `staging`. Four commits, all from #327.

Profile photos are streamed from the bucket instead of being downloaded into memory first, so the wait before the first byte is one bucket round trip rather than a full download. `StorageService.open()` returns a `StoredObject` handle whose stream is closed when the response finishes, including when the client disconnects part way, which `BackgroundTask` alone does not guarantee on every ASGI branch.

Cache headers now depend on whether the request named the photo being served. A `v` matching the current object key gets `max-age=31536000, immutable`; anything else, including a stale or invented token, gets `max-age=300`, because the route always serves whatever the account holds now and pinning a mutable URL in a shared cache would hand a replaced avatar to everyone who asked.

Edge caching for that endpoint is configured in Cloudflare and is not part of this promotion.

**Merge with a merge commit, not a rebase.** A rebased promotion writes copies under new SHAs, freezes the merge base, and makes every later promotion replay both lineages and conflict.

CI is green on `develop` at 5941417.
