### PR TITLE
fix: allow the api origin as an image source in the spa policy

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -308,11 +308,15 @@ out, since the SPA reads the CSRF token off the response.
 
 Both tiers send security response headers: the API from middleware
 (`api/middleware/security_headers.py`), the SPA from nginx (`frontend/nginx.conf`). Their
-Content-Security-Policies match except where the SPA genuinely needs more -- its
-`connect-src` also names the API origin, which is cross-origin on the deploys, and the
-Sentry ingest hosts the browser SDK reports to. That origin is baked into the policy when
-the image is built, from the same `VITE_API_URL` build argument the bundle uses, so the
-served policy cannot drift from the URL the app actually calls. `X-XSS-Protection` is set
+Content-Security-Policies match except where the SPA genuinely needs more. Its
+`connect-src` names the API origin, which is cross-origin on the deploys, plus the Sentry
+ingest hosts the browser SDK reports to. Its `img-src` names that same API origin, because
+profile photos are served by the API and rendered in `<img>` tags -- an image load, which
+`connect-src` does not cover. That origin is baked into the policy when the image is built,
+from the same `VITE_API_URL` build argument the bundle uses, so the served policy cannot
+drift from the URL the app actually calls. Both directives are asserted against the config
+in `tests/integration/test_frontend_csp.py`: a CSP that under-permits fails silently, since
+the browser drops the request before it reaches the origin and nothing appears in the logs. `X-XSS-Protection` is set
 to `0` on both tiers on purpose: the legacy auditor it enables is unreliable, browsers have
 dropped it, and its blocking mode has itself leaked cross-origin information. The CSP is
 what constrains injection.

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -26,21 +26,25 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "0" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'__API_ORIGIN__ https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://*.ingest.us.sentry.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests" always;
+        add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:__API_ORIGIN__; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'__API_ORIGIN__ https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://*.ingest.us.sentry.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests" always;
     }
 
     # Security headers. The CSP mirrors the API's own policy
-    # (api/middleware/security_headers.py) with two deliberate differences:
+    # (api/middleware/security_headers.py) with three deliberate differences:
     #   - connect-src also names the API origin, which is cross-origin on the deploys
     #     (VITE_API_URL is a build arg, substituted into __API_ORIGIN__ at image build),
     #     plus the Sentry ingest hosts the browser SDK reports to;
+    #   - img-src names the same API origin, because profile photos are served by the
+    #     API (GET /users/{id}/photo) and rendered in <img> tags. That is an image load,
+    #     not a fetch, so connect-src does not cover it and the browser drops the
+    #     request before it leaves the tab -- avatars silently never appear;
     #   - style-src allows inline styles, which Tailwind and the chart config need.
     # X-XSS-Protection is 0 on purpose: the legacy auditor it enables is unreliable and
     # has itself been a source of leaks. CSP is what actually blocks injection here.
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "0" always;
-    add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'__API_ORIGIN__ https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://*.ingest.us.sentry.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests" always;
+    add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:__API_ORIGIN__; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'__API_ORIGIN__ https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://*.ingest.us.sentry.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests" always;
     # nginx serves the internal http hop, so add HSTS unconditionally (the client
     # reaches us over https via Cloudflare/Railway). No "preload" until the domain
     # is actually submitted to the HSTS preload list.

--- a/tests/integration/test_frontend_csp.py
+++ b/tests/integration/test_frontend_csp.py
@@ -1,0 +1,88 @@
+"""Regression tests for the SPA's Content-Security-Policy.
+
+frontend/nginx.conf serves the React SPA and carries its CSP. The API is a
+separate origin on every deploy (https://api.<domain>), so any directive that
+has to reach the API names the placeholder __API_ORIGIN__, which
+frontend/Dockerfile substitutes with the real origin at image build time.
+
+Two directives need it, for different reasons: connect-src covers fetch/XHR,
+and img-src covers profile photos, which the API serves as image bytes
+(GET /users/{id}/photo) rendered in <img> tags. Missing img-src is a silent
+failure -- the browser drops the request before it leaves the tab, so nothing
+appears in the API logs and the avatar simply never renders. That shipped to
+production once; these tests exist so it cannot ship again.
+
+The config is plain text with no runtime the test suite can exercise, so this
+module parses it, the same way test_frontend_case_studies.py parses
+caseStudies.ts.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_NGINX_CONF = _PROJECT_ROOT / "frontend" / "nginx.conf"
+_DOCKERFILE = _PROJECT_ROOT / "frontend" / "Dockerfile"
+
+_CSP_HEADER = re.compile(r'add_header\s+Content-Security-Policy\s+"([^"]*)"')
+
+# Directives that must reach the API origin. nginx repeats the whole header in
+# every location block that sets one of its own, so each copy is checked.
+_API_ORIGIN_DIRECTIVES = ("connect-src", "img-src")
+
+
+def _csp_headers() -> list[str]:
+    """Return every Content-Security-Policy value declared in nginx.conf."""
+    return _CSP_HEADER.findall(_NGINX_CONF.read_text(encoding="utf-8"))
+
+
+def _directive(csp: str, name: str) -> str:
+    """Return a single directive out of a CSP header value."""
+    for part in csp.split(";"):
+        stripped = part.strip()
+        if stripped.split(" ")[0] == name:
+            return stripped
+    raise AssertionError(f"CSP has no {name!r} directive: {csp}")
+
+
+class TestNginxContentSecurityPolicy:
+    """Tests for the CSP baked into the frontend image."""
+
+    def test_declares_a_policy(self):
+        """
+        GIVEN the nginx config that serves the SPA
+        WHEN its Content-Security-Policy headers are collected
+        THEN at least one is declared
+        """
+        assert _csp_headers()
+
+    @pytest.mark.parametrize("directive", _API_ORIGIN_DIRECTIVES)
+    def test_directive_reaches_the_api_origin(self, directive: str):
+        """
+        GIVEN every Content-Security-Policy declared in nginx.conf
+        WHEN the directives that must reach the API are read
+        THEN each one carries the __API_ORIGIN__ placeholder
+
+        A location block that sets any add_header of its own stops inheriting
+        the server-level ones, so a copy that omits the placeholder would block
+        API traffic for exactly the asset types that block serves.
+        """
+        for csp in _csp_headers():
+            assert "__API_ORIGIN__" in _directive(csp, directive)
+
+    def test_placeholder_substitution_is_global(self):
+        """
+        GIVEN the Dockerfile that resolves __API_ORIGIN__ at build time
+        WHEN its sed invocation is read
+        THEN the substitution is global
+
+        The placeholder now appears several times over. Without the /g flag sed
+        would rewrite only the first, leaving a literal __API_ORIGIN__ in the
+        served policy -- which is why the build also greps for leftovers.
+        """
+        dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
+
+        assert "s#__API_ORIGIN__#${REPLACEMENT}#g" in dockerfile
+        assert "! grep -q '__API_ORIGIN__' nginx.conf" in dockerfile


### PR DESCRIPTION
Profile photos never render in production. The upload succeeds, the object lands in the bucket, and fetching the photo URL directly returns `200 image/jpeg` with the right cache headers -- but no `GET /users/{id}/photo` ever reaches the API, because the browser drops the request before sending it.

The SPA's Content-Security-Policy is the reason. `connect-src` names the API origin, which is cross-origin on every deploy, but `img-src` stays at `'self' data:`. Photos are served by the API and rendered in `<img>` tags, and an image load is governed by `img-src`, not `connect-src`. So every avatar -- the user's own and everyone else's, on every page -- is blocked at the origin boundary with nothing to show for it in the API logs.

`img-src` now carries the same `__API_ORIGIN__` placeholder `connect-src` does, substituted from `VITE_API_URL` when the image is built. Nothing else is loosened: the origin allowed for images is exactly the one already allowed for fetches. Locally, where the API is a relative path, the placeholder still collapses to nothing and the policy is unchanged.

## Why a test for a config file

This failure mode is silent by construction -- an under-permissive CSP produces no request, no error response, and no log line, so it survives a deploy and a manual smoke test alike. `tests/integration/test_frontend_csp.py` parses `nginx.conf` and asserts that every declared policy names the API origin in both directives, following the precedent of `test_frontend_case_studies.py`. It checks each copy of the header, since a `location` block that sets any header of its own stops inheriting the server-level ones, and it pins the `sed` substitution to `/g`, which became load-bearing the moment the placeholder appeared more than once.

`docs/security.md` records the second directive and the reason it is there.

## Scope

Frontend image only. No API change, no migration, no contract change -- the fix ships when the frontend service redeploys.
