### PR TITLE
ci: analyse main in sonarcloud, not only pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,11 +409,16 @@ jobs:
           path: /tmp/become-e2e-api.log
           retention-days: 7
 
+  # Runs on pushes to the long-lived branches as well as on pull requests. Analysing only
+  # pull requests left SonarCloud with no picture of the branches themselves: `main` was last
+  # analysed on 2026-02-21 and reported 76.7% coverage against a real 99%, while `develop` and
+  # `staging` had never been analysed at all. A pull request's "new code" is measured against
+  # its base, so a stale base also made unrelated old code count as new -- that is what failed
+  # the gate on the promotion in #326 over CSS introduced by a different pull request.
   sonarcloud:
     name: SonarCloud Analysis
     runs-on: ubuntu-24.04
     needs: [python-tests, frontend-tests]
-    if: github.event_name == 'pull_request'
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
@@ -434,6 +439,23 @@ jobs:
           name: frontend-coverage-report
           path: frontend/coverage/
 
+      # SonarCloud's new-code period for this project is "previous version", but no version was
+      # ever reported, so every analysis looked like the same one and the period degenerated.
+      # The release tags are the meaningful boundary here, so the latest one becomes the version
+      # and "new code" reads as "changed since the last release".
+      #
+      # The latest tag in the repository, not `git describe`. Releases are tagged on `main`,
+      # which is downstream of `develop`, so a release tag is never reachable from `develop` --
+      # `git describe` there answers with the release before last, and every branch would end up
+      # comparing against a different baseline. Falls back to the commit only when no tag exists.
+      - name: Derive the analysed version from the latest release tag
+        id: sonar_version
+        run: |
+          version="$(git tag --sort=-v:refname | head -1)"
+          echo "version=${version:-$(git rev-parse --short HEAD)}" >> "$GITHUB_OUTPUT"
+
       - name: SonarQube Cloud Scan
         if: env.SONAR_TOKEN != ''
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8
+        with:
+          args: -Dsonar.projectVersion=${{ steps.sonar_version.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,16 +409,21 @@ jobs:
           path: /tmp/become-e2e-api.log
           retention-days: 7
 
-  # Runs on pushes to the long-lived branches as well as on pull requests. Analysing only
-  # pull requests left SonarCloud with no picture of the branches themselves: `main` was last
-  # analysed on 2026-02-21 and reported 76.7% coverage against a real 99%, while `develop` and
-  # `staging` had never been analysed at all. A pull request's "new code" is measured against
-  # its base, so a stale base also made unrelated old code count as new -- that is what failed
-  # the gate on the promotion in #326 over CSS introduced by a different pull request.
+  # Runs on pull requests and on pushes to `main`. Analysing only pull requests left the main
+  # branch itself unanalysed since 2026-02-21, reporting 76.7% coverage against a real 99%, and
+  # a pull request's "new code" is measured against its base -- so a stale base made unrelated
+  # old code count as new, which is what failed the gate on the promotion in #326 over CSS
+  # introduced by a different pull request. Keeping `main` current fixes that at the root.
+  #
+  # `develop` and `staging` are deliberately not analysed: branch analysis for anything but the
+  # main branch is a paid SonarCloud feature, and this organization is on the free plan (its API
+  # answers "Organization is not allowed to access data from non main branches"). Pushing an
+  # analysis for them would burn a CI job on a result nothing can read.
   sonarcloud:
     name: SonarCloud Analysis
     runs-on: ubuntu-24.04
     needs: [python-tests, frontend-tests]
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
@@ -446,8 +451,9 @@ jobs:
       #
       # The latest tag in the repository, not `git describe`. Releases are tagged on `main`,
       # which is downstream of `develop`, so a release tag is never reachable from `develop` --
-      # `git describe` there answers with the release before last, and every branch would end up
-      # comparing against a different baseline. Falls back to the commit only when no tag exists.
+      # `git describe` there answers with the release before last, and a pull request opened from
+      # `develop` would compare against a different baseline than one opened from `main`. Falls
+      # back to the commit only when no tag exists.
       - name: Derive the analysed version from the latest release tag
         id: sonar_version
         run: |

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,10 +8,14 @@ sonar.sources=src,api,frontend/src
 sonar.exclusions=**/node_modules/**,**/*.test.*,**/*.spec.*,**/migrations/**,**/__pycache__/**,**/dist/**,**/build/**,frontend/src/components/ui/**
 
 # Tailwind v4 uses custom at-rules (@custom-variant, @utility, @theme) that SonarCloud CSS parser does not recognize
+# S4662 is the unknown at-rule itself; S8767 is what the parser reports for the declarations
+# nested inside one, since it cannot tell that @utility opens a block that may contain them
 # Rate limit constant LIMIT_PWD_RESET contains "pwd" which triggers false positive S2068
-sonar.issue.ignore.multicriteria=tailwindAtRules,rateLimitFalsePositive
+sonar.issue.ignore.multicriteria=tailwindAtRules,tailwindNestedDeclarations,rateLimitFalsePositive
 sonar.issue.ignore.multicriteria.tailwindAtRules.ruleKey=css:S4662
 sonar.issue.ignore.multicriteria.tailwindAtRules.resourceKey=frontend/src/index.css
+sonar.issue.ignore.multicriteria.tailwindNestedDeclarations.ruleKey=css:S8767
+sonar.issue.ignore.multicriteria.tailwindNestedDeclarations.resourceKey=frontend/src/index.css
 sonar.issue.ignore.multicriteria.rateLimitFalsePositive.ruleKey=python:S2068
 sonar.issue.ignore.multicriteria.rateLimitFalsePositive.resourceKey=api/middleware/rate_limit.py
 


### PR DESCRIPTION
SonarCloud has been analysing pull requests only. The `sonarcloud` job carried `if: github.event_name == 'pull_request'`, so `main` itself was never scanned: it was last seen on 2026-02-21, reporting 76.7% coverage against a real 99%.

That is not just a stale dashboard. A pull request's "new code" is measured against its base, so when the base is months out of date, unrelated old code counts as new. That is what failed the gate on promotion #326 -- over CSS that arrived in a different pull request. Keeping `main` current is the fix at the root, so the job now also runs on pushes to `main`.

## Why only `main`

The organization is on SonarCloud's free plan, which analyses the main branch and pull requests and nothing else. Asking it about any other branch answers `Organization is not allowed to access data from non main branches`, and `develop` is on record as a short-lived branch with no stored analysis. Running the scan on pushes to `develop` and `staging` would spend a CI job producing a result nothing can read, so the condition is `pull_request || refs/heads/main` rather than an unconditional run.

## Reporting a version

The new-code period is "previous version", inherited from the instance default. It only means anything if a version is actually reported, and none ever was, so every analysis looked like the same version and the period degenerated into nothing. The scan now passes `-Dsonar.projectVersion=<latest tag>`, making "new code" read as "changed since the last release".

The version comes from `git tag --sort=-v:refname | head -1`, not `git describe`. Releases are tagged on `main`, which is downstream of `develop`, so a release tag is never reachable from `develop` -- `git describe` there answers with the release before last, and a pull request opened from `develop` would compare against a different baseline than one opened from `main`. The job already checks out with `fetch-depth: 0`, so the tags are present.

## Suppressing a false positive properly

`css:S8767` fires 20 times on `frontend/src/index.css`. The CSS parser does not understand Tailwind v4's `@utility`, so it cannot tell that the at-rule opens a block, and reports every declaration inside it as misplaced. It is the same misunderstanding that already required suppressing `css:S4662` on the same file, so it is registered next to it in `sonar-project.properties` rather than resolved by hand in the UI -- that way the reason lives in the repository and survives a re-analysis.

## Related, outside this diff

Automatic Analysis was switched on briefly while this was being prepared and has been switched back off. It is mutually exclusive with a CI-based scan and cannot read coverage reports, and while it was on it posted its own check -- `SonarCloud Code Analysis`, from the SonarCloud app, separate from this workflow's `SonarCloud Analysis` -- failing `develop` on security and reliability ratings with no coverage behind the numbers. That red check on `develop` is its work, not this job's.
