### PR TITLE
chore: promote the avatar csp fix and sonarcloud analysis scope to production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,11 +409,16 @@ jobs:
           path: /tmp/become-e2e-api.log
           retention-days: 7
 
+  # Runs on pushes to the long-lived branches as well as on pull requests. Analysing only
+  # pull requests left SonarCloud with no picture of the branches themselves: `main` was last
+  # analysed on 2026-02-21 and reported 76.7% coverage against a real 99%, while `develop` and
+  # `staging` had never been analysed at all. A pull request's "new code" is measured against
+  # its base, so a stale base also made unrelated old code count as new -- that is what failed
+  # the gate on the promotion in #326 over CSS introduced by a different pull request.
   sonarcloud:
     name: SonarCloud Analysis
     runs-on: ubuntu-24.04
     needs: [python-tests, frontend-tests]
-    if: github.event_name == 'pull_request'
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
@@ -434,6 +439,23 @@ jobs:
           name: frontend-coverage-report
           path: frontend/coverage/
 
+      # SonarCloud's new-code period for this project is "previous version", but no version was
+      # ever reported, so every analysis looked like the same one and the period degenerated.
+      # The release tags are the meaningful boundary here, so the latest one becomes the version
+      # and "new code" reads as "changed since the last release".
+      #
+      # The latest tag in the repository, not `git describe`. Releases are tagged on `main`,
+      # which is downstream of `develop`, so a release tag is never reachable from `develop` --
+      # `git describe` there answers with the release before last, and every branch would end up
+      # comparing against a different baseline. Falls back to the commit only when no tag exists.
+      - name: Derive the analysed version from the latest release tag
+        id: sonar_version
+        run: |
+          version="$(git tag --sort=-v:refname | head -1)"
+          echo "version=${version:-$(git rev-parse --short HEAD)}" >> "$GITHUB_OUTPUT"
+
       - name: SonarQube Cloud Scan
         if: env.SONAR_TOKEN != ''
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8
+        with:
+          args: -Dsonar.projectVersion=${{ steps.sonar_version.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,16 +409,21 @@ jobs:
           path: /tmp/become-e2e-api.log
           retention-days: 7
 
-  # Runs on pushes to the long-lived branches as well as on pull requests. Analysing only
-  # pull requests left SonarCloud with no picture of the branches themselves: `main` was last
-  # analysed on 2026-02-21 and reported 76.7% coverage against a real 99%, while `develop` and
-  # `staging` had never been analysed at all. A pull request's "new code" is measured against
-  # its base, so a stale base also made unrelated old code count as new -- that is what failed
-  # the gate on the promotion in #326 over CSS introduced by a different pull request.
+  # Runs on pull requests and on pushes to `main`. Analysing only pull requests left the main
+  # branch itself unanalysed since 2026-02-21, reporting 76.7% coverage against a real 99%, and
+  # a pull request's "new code" is measured against its base -- so a stale base made unrelated
+  # old code count as new, which is what failed the gate on the promotion in #326 over CSS
+  # introduced by a different pull request. Keeping `main` current fixes that at the root.
+  #
+  # `develop` and `staging` are deliberately not analysed: branch analysis for anything but the
+  # main branch is a paid SonarCloud feature, and this organization is on the free plan (its API
+  # answers "Organization is not allowed to access data from non main branches"). Pushing an
+  # analysis for them would burn a CI job on a result nothing can read.
   sonarcloud:
     name: SonarCloud Analysis
     runs-on: ubuntu-24.04
     needs: [python-tests, frontend-tests]
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
@@ -446,8 +451,9 @@ jobs:
       #
       # The latest tag in the repository, not `git describe`. Releases are tagged on `main`,
       # which is downstream of `develop`, so a release tag is never reachable from `develop` --
-      # `git describe` there answers with the release before last, and every branch would end up
-      # comparing against a different baseline. Falls back to the commit only when no tag exists.
+      # `git describe` there answers with the release before last, and a pull request opened from
+      # `develop` would compare against a different baseline than one opened from `main`. Falls
+      # back to the commit only when no tag exists.
       - name: Derive the analysed version from the latest release tag
         id: sonar_version
         run: |

--- a/docs/security.md
+++ b/docs/security.md
@@ -308,11 +308,15 @@ out, since the SPA reads the CSRF token off the response.
 
 Both tiers send security response headers: the API from middleware
 (`api/middleware/security_headers.py`), the SPA from nginx (`frontend/nginx.conf`). Their
-Content-Security-Policies match except where the SPA genuinely needs more -- its
-`connect-src` also names the API origin, which is cross-origin on the deploys, and the
-Sentry ingest hosts the browser SDK reports to. That origin is baked into the policy when
-the image is built, from the same `VITE_API_URL` build argument the bundle uses, so the
-served policy cannot drift from the URL the app actually calls. `X-XSS-Protection` is set
+Content-Security-Policies match except where the SPA genuinely needs more. Its
+`connect-src` names the API origin, which is cross-origin on the deploys, plus the Sentry
+ingest hosts the browser SDK reports to. Its `img-src` names that same API origin, because
+profile photos are served by the API and rendered in `<img>` tags -- an image load, which
+`connect-src` does not cover. That origin is baked into the policy when the image is built,
+from the same `VITE_API_URL` build argument the bundle uses, so the served policy cannot
+drift from the URL the app actually calls. Both directives are asserted against the config
+in `tests/integration/test_frontend_csp.py`: a CSP that under-permits fails silently, since
+the browser drops the request before it reaches the origin and nothing appears in the logs. `X-XSS-Protection` is set
 to `0` on both tiers on purpose: the legacy auditor it enables is unreliable, browsers have
 dropped it, and its blocking mode has itself leaked cross-origin information. The CSP is
 what constrains injection.

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -26,21 +26,25 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "0" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'__API_ORIGIN__ https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://*.ingest.us.sentry.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests" always;
+        add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:__API_ORIGIN__; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'__API_ORIGIN__ https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://*.ingest.us.sentry.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests" always;
     }
 
     # Security headers. The CSP mirrors the API's own policy
-    # (api/middleware/security_headers.py) with two deliberate differences:
+    # (api/middleware/security_headers.py) with three deliberate differences:
     #   - connect-src also names the API origin, which is cross-origin on the deploys
     #     (VITE_API_URL is a build arg, substituted into __API_ORIGIN__ at image build),
     #     plus the Sentry ingest hosts the browser SDK reports to;
+    #   - img-src names the same API origin, because profile photos are served by the
+    #     API (GET /users/{id}/photo) and rendered in <img> tags. That is an image load,
+    #     not a fetch, so connect-src does not cover it and the browser drops the
+    #     request before it leaves the tab -- avatars silently never appear;
     #   - style-src allows inline styles, which Tailwind and the chart config need.
     # X-XSS-Protection is 0 on purpose: the legacy auditor it enables is unreliable and
     # has itself been a source of leaks. CSP is what actually blocks injection here.
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "0" always;
-    add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'__API_ORIGIN__ https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://*.ingest.us.sentry.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests" always;
+    add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:__API_ORIGIN__; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'__API_ORIGIN__ https://*.ingest.sentry.io https://*.ingest.de.sentry.io https://*.ingest.us.sentry.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests" always;
     # nginx serves the internal http hop, so add HSTS unconditionally (the client
     # reaches us over https via Cloudflare/Railway). No "preload" until the domain
     # is actually submitted to the HSTS preload list.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,10 +8,14 @@ sonar.sources=src,api,frontend/src
 sonar.exclusions=**/node_modules/**,**/*.test.*,**/*.spec.*,**/migrations/**,**/__pycache__/**,**/dist/**,**/build/**,frontend/src/components/ui/**
 
 # Tailwind v4 uses custom at-rules (@custom-variant, @utility, @theme) that SonarCloud CSS parser does not recognize
+# S4662 is the unknown at-rule itself; S8767 is what the parser reports for the declarations
+# nested inside one, since it cannot tell that @utility opens a block that may contain them
 # Rate limit constant LIMIT_PWD_RESET contains "pwd" which triggers false positive S2068
-sonar.issue.ignore.multicriteria=tailwindAtRules,rateLimitFalsePositive
+sonar.issue.ignore.multicriteria=tailwindAtRules,tailwindNestedDeclarations,rateLimitFalsePositive
 sonar.issue.ignore.multicriteria.tailwindAtRules.ruleKey=css:S4662
 sonar.issue.ignore.multicriteria.tailwindAtRules.resourceKey=frontend/src/index.css
+sonar.issue.ignore.multicriteria.tailwindNestedDeclarations.ruleKey=css:S8767
+sonar.issue.ignore.multicriteria.tailwindNestedDeclarations.resourceKey=frontend/src/index.css
 sonar.issue.ignore.multicriteria.rateLimitFalsePositive.ruleKey=python:S2068
 sonar.issue.ignore.multicriteria.rateLimitFalsePositive.resourceKey=api/middleware/rate_limit.py
 

--- a/tests/integration/test_frontend_csp.py
+++ b/tests/integration/test_frontend_csp.py
@@ -1,0 +1,88 @@
+"""Regression tests for the SPA's Content-Security-Policy.
+
+frontend/nginx.conf serves the React SPA and carries its CSP. The API is a
+separate origin on every deploy (https://api.<domain>), so any directive that
+has to reach the API names the placeholder __API_ORIGIN__, which
+frontend/Dockerfile substitutes with the real origin at image build time.
+
+Two directives need it, for different reasons: connect-src covers fetch/XHR,
+and img-src covers profile photos, which the API serves as image bytes
+(GET /users/{id}/photo) rendered in <img> tags. Missing img-src is a silent
+failure -- the browser drops the request before it leaves the tab, so nothing
+appears in the API logs and the avatar simply never renders. That shipped to
+production once; these tests exist so it cannot ship again.
+
+The config is plain text with no runtime the test suite can exercise, so this
+module parses it, the same way test_frontend_case_studies.py parses
+caseStudies.ts.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_NGINX_CONF = _PROJECT_ROOT / "frontend" / "nginx.conf"
+_DOCKERFILE = _PROJECT_ROOT / "frontend" / "Dockerfile"
+
+_CSP_HEADER = re.compile(r'add_header\s+Content-Security-Policy\s+"([^"]*)"')
+
+# Directives that must reach the API origin. nginx repeats the whole header in
+# every location block that sets one of its own, so each copy is checked.
+_API_ORIGIN_DIRECTIVES = ("connect-src", "img-src")
+
+
+def _csp_headers() -> list[str]:
+    """Return every Content-Security-Policy value declared in nginx.conf."""
+    return _CSP_HEADER.findall(_NGINX_CONF.read_text(encoding="utf-8"))
+
+
+def _directive(csp: str, name: str) -> str:
+    """Return a single directive out of a CSP header value."""
+    for part in csp.split(";"):
+        stripped = part.strip()
+        if stripped.split(" ")[0] == name:
+            return stripped
+    raise AssertionError(f"CSP has no {name!r} directive: {csp}")
+
+
+class TestNginxContentSecurityPolicy:
+    """Tests for the CSP baked into the frontend image."""
+
+    def test_declares_a_policy(self):
+        """
+        GIVEN the nginx config that serves the SPA
+        WHEN its Content-Security-Policy headers are collected
+        THEN at least one is declared
+        """
+        assert _csp_headers()
+
+    @pytest.mark.parametrize("directive", _API_ORIGIN_DIRECTIVES)
+    def test_directive_reaches_the_api_origin(self, directive: str):
+        """
+        GIVEN every Content-Security-Policy declared in nginx.conf
+        WHEN the directives that must reach the API are read
+        THEN each one carries the __API_ORIGIN__ placeholder
+
+        A location block that sets any add_header of its own stops inheriting
+        the server-level ones, so a copy that omits the placeholder would block
+        API traffic for exactly the asset types that block serves.
+        """
+        for csp in _csp_headers():
+            assert "__API_ORIGIN__" in _directive(csp, directive)
+
+    def test_placeholder_substitution_is_global(self):
+        """
+        GIVEN the Dockerfile that resolves __API_ORIGIN__ at build time
+        WHEN its sed invocation is read
+        THEN the substitution is global
+
+        The placeholder now appears several times over. Without the /g flag sed
+        would rewrite only the first, leaving a literal __API_ORIGIN__ in the
+        served policy -- which is why the build also greps for leftovers.
+        """
+        dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
+
+        assert "s#__API_ORIGIN__#${REPLACEMENT}#g" in dockerfile
+        assert "! grep -q '__API_ORIGIN__' nginx.conf" in dockerfile


### PR DESCRIPTION
Promotes `staging` to `main`, releasing the profile photo fix from #330 and the SonarCloud analysis scope from #331.

## Avatars will render again

Profile photos have never appeared in production. Everything behind them worked -- upload succeeded, the object was in the bucket, and fetching the photo URL directly returned `200 image/jpeg` with correct cache headers -- but no `GET /users/{id}/photo` ever reached the API, because the browser dropped the request before sending it.

The SPA's own Content-Security-Policy was the reason: `connect-src` named the API origin, `img-src` did not. Photos are served by the API and rendered in `<img>` tags, and an image load is governed by `img-src`. Every avatar, the user's own and everyone else's, failed silently at the origin boundary. `img-src` now carries the same `__API_ORIGIN__` placeholder, substituted from `VITE_API_URL` when the frontend image is built, so images may load from exactly the origin fetches already could and from nowhere new.

`tests/integration/test_frontend_csp.py` guards it, because this failure mode produces no request, no error response and no log line -- it survives a deploy and a manual smoke test alike.

## SonarCloud sees `main` again

`main` had not been analysed since 2026-02-21 and reported 76.7% coverage against a real 99%. Since a pull request's "new code" is measured against its base, that stale base made unrelated old code count as new, which is what failed the gate on promotion #326. Pushes to `main` are analysed from now on, reporting `-Dsonar.projectVersion=<latest tag>` so the "previous version" new-code period has a boundary. This promotion is the first push that will exercise it.

## Merge notes

**Merge with a merge commit, not a rebase.** A rebased promotion writes copies under new SHAs, freezes the merge base, and makes every later promotion replay both lineages and conflict -- exactly what happened on #311.

No migrations and no API contract change. The fix ships when the frontend service rebuilds; nothing on the backend changes behaviour.
