### PR TITLE
feat: promote logging coverage and per-environment levels to staging

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -8,6 +8,8 @@ DATABASE_URL=sqlite:///./become.db
 # Local SQLite uses create_all; Alembic targets PostgreSQL only. To migrate a
 # remote database ad hoc, set ALEMBIC_DATABASE_URL when running alembic.
 DEBUG=true
+# Matches the dev profile's own default; spelled out so the level is obvious here.
+LOG_LEVEL=DEBUG
 CORS_ORIGINS=["http://localhost:3000","http://localhost:8080"]
 API_PUBLIC_URL=http://localhost:8000
 

--- a/.env.example
+++ b/.env.example
@@ -37,11 +37,15 @@ DATABASE_URL=sqlite:///./become.db
 # MX_CHECK_ENABLED=true
 
 # Logging
-# LOG_LEVEL sets verbosity (DEBUG/INFO/WARNING/ERROR/CRITICAL, case-insensitive);
-# default INFO. An unsupported value is rejected when settings load.
-# Dev emits human-readable text; test/prod emit JSON for the Railway log drain.
+# LOG_LEVEL sets verbosity (DEBUG/INFO/WARNING/ERROR/CRITICAL, case-insensitive).
+# Leave it out and the profile decides: DEBUG on dev, INFO on test and prod. A value
+# set here or in .env.<profile> always wins. An unsupported value is rejected when
+# settings load. Set it explicitly on each deployed service anyway, so the level is
+# visible in the service's variables instead of only in api/config.py.
+# A local shell keeps human-readable text; every deployed service emits JSON for the
+# log drain, the Railway dev service included.
 # LOG_FILE, when set, also writes rotating log files to that path.
-# LOG_LEVEL=INFO
+# LOG_LEVEL=
 # LOG_FILE=
 
 # Observability (Sentry error tracking; disabled when unset)

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -12,6 +12,10 @@ DATABASE_URL=postgresql://user:password@host:5432/become
 # the split is never silently lost; set it explicitly even if it matches DATABASE_URL.
 MIGRATION_DATABASE_URL=postgresql://migrator:password@host:5432/become
 DEBUG=false
+# Matches the prod profile's own default. Keep it at INFO: the DEBUG traces exist for
+# a developer reading a local console, and shipping them from production costs drain
+# volume without answering a question production asks.
+LOG_LEVEL=INFO
 CORS_ORIGINS=["https://your-domain.example"]
 API_PUBLIC_URL=https://api.becomify.app
 

--- a/.env.test.example
+++ b/.env.test.example
@@ -11,6 +11,9 @@ DATABASE_URL=postgresql://user:password@host:5432/become_staging
 # the split is never silently lost; set it explicitly even if it matches DATABASE_URL.
 MIGRATION_DATABASE_URL=postgresql://migrator:password@host:5432/become
 DEBUG=false
+# Matches the test profile's own default. DEBUG here would ship every read trace to
+# the log drain for no benefit staging can use.
+LOG_LEVEL=INFO
 CORS_ORIGINS=["https://staging.your-domain.example"]
 API_PUBLIC_URL=https://test-backend-staging.up.railway.app
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1149,28 +1149,28 @@
         "filename": "tests/unit/api/test_logging_config.py",
         "hashed_secret": "8f4494325f12768b8b7230e5adfe9338cc8351c7",
         "is_verified": false,
-        "line_number": 28
+        "line_number": 35
       },
       {
         "type": "Basic Auth Credentials",
         "filename": "tests/unit/api/test_logging_config.py",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 29
+        "line_number": 36
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/api/test_logging_config.py",
         "hashed_secret": "77d52a1258cbac72db430cbce22b157351915e5e",
         "is_verified": false,
-        "line_number": 31
+        "line_number": 38
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/api/test_logging_config.py",
         "hashed_secret": "907c184320b6f5ee0f72365a6b4da6c4c93cdb28",
         "is_verified": false,
-        "line_number": 35
+        "line_number": 42
       }
     ],
     "tests/unit/api/test_main.py": [
@@ -1183,5 +1183,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-01T09:44:09Z"
+  "generated_at": "2026-08-01T17:36:58Z"
 }

--- a/api/README.md
+++ b/api/README.md
@@ -250,7 +250,7 @@ Environment variables (can use `.env` file):
 | `BUCKET_ENDPOINT` | *optional* | S3-compatible bucket endpoint |
 | `BUCKET_ACCESS_KEY_ID` | *optional* | Bucket access key |
 | `BUCKET_SECRET_ACCESS_KEY` | *optional* | Bucket secret key |
-| `LOG_LEVEL` | `INFO` | Log verbosity (`DEBUG`/`INFO`/`WARNING`/`ERROR`); dev emits text, test/prod emit JSON |
+| `LOG_LEVEL` | per profile: `DEBUG` on dev, `INFO` on test and prod | Log verbosity (`DEBUG`/`INFO`/`WARNING`/`ERROR`/`CRITICAL`); an explicit value always wins. A local shell emits text, every deployed service emits JSON |
 | `LOG_FILE` | *optional* | Path for a rotating log file (console logging is always on) |
 | `SENTRY_DSN` | *optional* | Sentry DSN for backend error tracking (disabled when unset) |
 | `BETTERSTACK_SOURCE_TOKEN` | *optional* | Better Stack log source token (ships `api.*` logs when set together with the host below) |
@@ -260,7 +260,13 @@ Environment variables (can use `.env` file):
 
 **Migrations:** The PostgreSQL schema is managed by Alembic (`migrations/`). `alembic upgrade head` runs automatically before each Railway deploy; to apply it manually against a specific database use `ALEMBIC_DATABASE_URL=<url> uv run alembic upgrade head`. SQLite (local development and the test suite) keeps using `create_all`, so no migration step is needed there.
 
-**Observability:** Every request gets an `X-Request-ID` response header (generated, or echoed from the client's header) for log correlation. A `ContextFilter` binds that ID and the acting user through contextvars, so every `api.*` record -- service and security logs included -- carries `request_id` and `user_id`, not just the request line. Requests, unhandled exceptions, and rate-limit violations are logged under the `api.*` loggers; in `test`/`prod` the output is JSON so a log drain can index fields like `request_id` and `status_code`. Unhandled exceptions return an opaque 500 and are reported to Sentry when `SENTRY_DSN` is set. When the `BETTERSTACK_*` variables are set, the `api.*` logs are also shipped to Better Stack (a per-environment source) via `logtail-python`.
+**Observability:** Every request gets an `X-Request-ID` response header (generated, or echoed from the client's header) for log correlation. A `ContextFilter` binds that ID and the acting user through contextvars, so every `api.*` record -- service and security logs included -- carries `request_id` and `user_id`, not just the request line.
+
+What is logged, under the `api.*` loggers: each request and its timing; every mutating domain action (`api.service.*` and `api.route.*`); every refusal, whether it is a CSRF rejection, an over-large body, a rejected token, a denied invitation, or a refused photo upload; and, at `DEBUG`, the reads and the outbound calls to Redis, S3, and the email provider with their timings. Records carry structured `extra` fields under an `event` name rather than free text. Output is JSON on every deployed service -- the Railway `dev` service included, since it is a deploy and not a laptop -- so a drain can index `event`, `request_id`, `status_code`, and `duration_ms`.
+
+Three third-party loggers are wired into the same handlers with pinned levels (`_EXTERNAL_LOG_LEVELS` in `api/logging_config.py`): `uvicorn.error` at INFO, so a boot that never finished is visible in the drain; `httpx` and `botocore` at WARNING, since their successful calls are already covered by `email_sent` and `s3_upload`. `uvicorn.access` is deliberately silenced -- `api.request` logs the same requests with more fields. **`sqlalchemy.engine` is pinned at WARNING and must stay there:** its DEBUG level prints bound query parameters, which on this schema means password hashes, addresses, and reset-token hashes going to the drain in the clear. Query shape and timing are logged by the read services instead. If drain volume from dev's DEBUG stream becomes a problem, the lever is `logtail_handler.setLevel(logging.INFO)` in `setup_logging` -- the console keeps DEBUG, the drain does not.
+
+Unhandled exceptions return an opaque 500 and are reported to Sentry when `SENTRY_DSN` is set. When the `BETTERSTACK_*` variables are set, the logs are also shipped to Better Stack (a per-environment source) via `logtail-python`.
 
 ## Testing
 

--- a/api/auth/cookies.py
+++ b/api/auth/cookies.py
@@ -10,11 +10,14 @@ programmatic clients and the test suite can keep using the ``Authorization: Bear
 header.
 """
 
+import logging
 import secrets
 
 from fastapi import Request, Response
 
 from api.config import Environment, get_settings
+
+logger = logging.getLogger("api.security")
 
 ACCESS_COOKIE = "access_token"
 REFRESH_COOKIE = "refresh_token"
@@ -93,6 +96,15 @@ def set_auth_cookies(
         secure=secure,
         samesite="strict",
     )
+    logger.debug(
+        "Auth cookies set",
+        extra={
+            "event": "auth_cookies_set",
+            "secure": secure,
+            "access_ttl": access_ttl,
+            "refresh_ttl": refresh_ttl,
+        },
+    )
 
 
 def set_csrf_header(response: Response, csrf_token: str | None) -> None:
@@ -125,6 +137,15 @@ def set_csrf_header(response: Response, csrf_token: str | None) -> None:
     """
     if csrf_token and csrf_token.isascii() and csrf_token.isprintable():
         response.headers[CSRF_HEADER] = csrf_token
+    elif csrf_token:
+        # The guard just refused to echo a client-chosen value, i.e. it blocked a
+        # response-splitting attempt. The value itself stays out of the record: it is
+        # attacker-controlled and may carry the very control characters that make
+        # writing it anywhere unsafe.
+        logger.warning(
+            "CSRF header not echoed",
+            extra={"event": "csrf_header_suppressed", "reason": "non_printable"},
+        )
 
 
 def clear_auth_cookies(response: Response) -> None:
@@ -135,3 +156,4 @@ def clear_auth_cookies(response: Response) -> None:
     response.delete_cookie(ACCESS_COOKIE)
     response.delete_cookie(REFRESH_COOKIE, path=REFRESH_COOKIE_PATH)
     response.delete_cookie(CSRF_COOKIE)
+    logger.debug("Auth cookies cleared", extra={"event": "auth_cookies_cleared"})

--- a/api/auth/email_throttle.py
+++ b/api/auth/email_throttle.py
@@ -23,6 +23,7 @@ rebuilding by timing the account-existence oracle the uniform response removes.
 """
 
 import hashlib
+import logging
 import threading
 from datetime import UTC, datetime, timedelta
 from functools import lru_cache
@@ -31,6 +32,8 @@ from typing import Protocol, runtime_checkable
 import redis
 
 from api.config import get_settings
+
+logger = logging.getLogger("api.security")
 
 # At most one email per address per cooldown, plus a small daily total, so a known
 # inbox cannot be flooded even when the per-IP limiter is evaded across many IPs.
@@ -44,8 +47,45 @@ VERIFICATION_KEY_PREFIX = "verify"
 
 
 def _digest(identifier: str) -> str:
-    """Return the SHA-256 hex digest of a normalized email, so no address is stored."""
+    """Return the SHA-256 hex digest of a normalized email, so no address is stored.
+
+    Never log this value. It is an unkeyed digest, so anyone holding the logs could
+    hash a guessed address and confirm it appears -- the account-existence oracle
+    ``api.auth.logging.hash_email`` exists to prevent. Records here name the flow,
+    never the address; the address-scoped event belongs at the call site in
+    ``api/routes/auth.py``, which has the keyed tag.
+    """
     return hashlib.sha256(identifier.strip().lower().encode()).hexdigest()
+
+
+def _log_denied(reason: str, **fields: object) -> None:
+    """Record a refused email send.
+
+    :param reason: Which budget refused it -- ``cooldown`` or ``daily_cap``.
+    :param fields: Extra context; never an address or its digest.
+    """
+    logger.debug(
+        "Email send throttled",
+        extra={"event": "email_throttle_denied", "reason": reason, **fields},
+    )
+
+
+def _log_store_unavailable(op: str, exc: redis.RedisError, key_prefix: str) -> None:
+    """Record a throttle store that could not be reached.
+
+    Worth a record because this throttle fails open: the send proceeds and the caller
+    sees nothing, so an outage silently lifts the per-address cap on every flow behind
+    it. ``docs/security.md`` accepts that risk; this makes it observable.
+
+    :param op: Throttle operation that failed -- ``allow`` or ``record``.
+    :param exc: The Redis error that caused it.
+    :param key_prefix: Key namespace of the flow whose cap was lifted.
+    """
+    logger.warning(
+        "Email throttle store unavailable, cap not enforced",
+        extra={"event": "throttle_store_unavailable", "op": op, "key_prefix": key_prefix},
+        exc_info=exc,
+    )
 
 
 @runtime_checkable
@@ -83,9 +123,11 @@ class InMemoryEmailSendThrottle:
             recent = [t for t in self._sends.get(key, []) if now - t < self._daily_window]
             if recent and now - recent[-1] < self._cooldown:
                 self._sends[key] = recent
+                _log_denied("cooldown", backend="memory")
                 return False
             if len(recent) >= self._daily_cap:
                 self._sends[key] = recent
+                _log_denied("daily_cap", backend="memory")
                 return False
             recent.append(now)
             self._sends[key] = recent
@@ -135,16 +177,19 @@ class RedisEmailSendThrottle:
         try:
             # Cooldown gate: SET NX succeeds only when the cooldown window is clear.
             if not self._client.set(cooldown_key, "1", nx=True, ex=self._cooldown):
+                _log_denied("cooldown", backend="redis", key_prefix=self._key_prefix)
                 return False
             raw = self._client.get(daily_key)
             sent_today = int(raw) if isinstance(raw, bytes | str | int) else 0
             if sent_today >= self._daily_cap:
+                _log_denied("daily_cap", backend="redis", key_prefix=self._key_prefix)
                 return False
             if self._client.incr(daily_key) == 1:
                 self._client.expire(daily_key, self._daily_window)
             return True
-        except redis.RedisError:
+        except redis.RedisError as e:
             # Fail open: a store outage must never suppress a legitimate email.
+            _log_store_unavailable("allow", e, self._key_prefix)
             return True
 
     def record(self, identifier: str) -> None:
@@ -157,9 +202,10 @@ class RedisEmailSendThrottle:
             daily_key = f"{self._key_prefix}:daily:{digest}"
             if self._client.incr(daily_key) == 1:
                 self._client.expire(daily_key, self._daily_window)
-        except redis.RedisError:
+        except redis.RedisError as e:
             # Fail open, as ``allow`` does: a store outage must not turn into an error
             # on a request whose email has already been decided.
+            _log_store_unavailable("record", e, self._key_prefix)
             return
 
 
@@ -170,6 +216,16 @@ def _build_throttle(key_prefix: str) -> EmailSendThrottle:
     :return: The throttle backend for that flow.
     """
     settings = get_settings()
+    backend = "redis" if settings.redis_url else "memory"
+    logger.debug(
+        "Email throttle backend selected",
+        extra={
+            "event": "throttle_backend_selected",
+            "throttle": "email",
+            "key_prefix": key_prefix,
+            "backend": backend,
+        },
+    )
     if settings.redis_url:
         client = redis.from_url(settings.redis_url, socket_connect_timeout=2, socket_timeout=2)
         return RedisEmailSendThrottle(client, key_prefix=key_prefix)

--- a/api/auth/jwt.py
+++ b/api/auth/jwt.py
@@ -1,5 +1,6 @@
 """JWT token creation and decoding with refresh token support."""
 
+import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from uuid import UUID, uuid4
@@ -10,11 +11,39 @@ from jwt import InvalidTokenError
 from api.auth.revocation_store import RevocationStore, RevocationStoreError
 from api.config import get_settings
 
+logger = logging.getLogger("api.security")
+
 ALGORITHM = "HS256"
+
+# Refusals that are ordinary traffic, not a signal: an access token expires every 15
+# minutes, so every active session hits this, and so does every stale browser tab.
+# Logged at DEBUG so the refusals that do mean something -- a revoked token, an
+# unreachable store -- stay visible in a stream filtered to WARNING.
+_ROUTINE_REJECTIONS = frozenset({"invalid_or_expired", "invalid_user_id"})
 
 
 class TokenError(Exception):
     """Raised when token validation fails."""
+
+
+def _reject(reason: str, message: str, **fields: object) -> TokenError:
+    """Log a refused token and build the error to raise.
+
+    The token string never reaches the record -- only why it was refused and the
+    opaque identifiers needed to correlate the refusal with the session it came from.
+
+    :param reason: Machine-readable cause, e.g. ``jti_revoked``.
+    :param message: Message carried by the raised :class:`TokenError`.
+    :param fields: Extra context to attach to the record.
+    :return: The error the caller should raise.
+    """
+    level = logging.DEBUG if reason in _ROUTINE_REJECTIONS else logging.WARNING
+    logger.log(
+        level,
+        "Token rejected",
+        extra={"event": "token_rejected", "reason": reason, **fields},
+    )
+    return TokenError(message)
 
 
 @dataclass(frozen=True)
@@ -101,6 +130,17 @@ def create_token_pair(user_id: UUID, sid: str | None = None) -> TokenPair:
     session_id = sid or uuid4().hex
     refresh_token, jti = create_refresh_token(user_id, session_id)
     access_token = create_access_token(user_id, session_id, jti)
+    logger.debug(
+        "Token pair issued",
+        extra={
+            "event": "token_pair_issued",
+            "user_id": str(user_id),
+            "sid": session_id,
+            "jti": jti,
+            "expires_in": settings.access_token_expire_minutes * 60,
+            "continued": sid is not None,
+        },
+    )
     return TokenPair(
         access_token=access_token,
         refresh_token=refresh_token,
@@ -134,19 +174,25 @@ def decode_token(token: str, expected_type: str, store: RevocationStore) -> Toke
 
         token_type: str | None = payload.get("type")
         if token_type != expected_type:
-            raise TokenError(f"Invalid token type: expected {expected_type}")
+            raise _reject(
+                "type_mismatch",
+                f"Invalid token type: expected {expected_type}",
+                expected_type=expected_type,
+            )
 
         jti: str | None = payload.get("jti")
         if not jti:
-            raise TokenError("Missing token ID")
+            raise _reject("missing_jti", "Missing token ID", expected_type=expected_type)
 
         # Check revocation store (fail-closed: a store error becomes a 401)
         try:
             revoked = store.is_jti_revoked(jti)
         except RevocationStoreError as e:
-            raise TokenError("Revocation store unavailable") from e
+            raise _reject(
+                "store_unavailable", "Revocation store unavailable", op="is_jti_revoked"
+            ) from e
         if revoked:
-            raise TokenError("Token has been revoked")
+            raise _reject("jti_revoked", "Token has been revoked", jti=jti)
 
         # Reject any token whose session (sid) was revoked. Refresh-token reuse
         # revokes the whole family, so a stolen token cannot outlive detection.
@@ -155,13 +201,15 @@ def decode_token(token: str, expected_type: str, store: RevocationStore) -> Toke
             try:
                 session_revoked = store.is_session_revoked(sid)
             except RevocationStoreError as e:
-                raise TokenError("Revocation store unavailable") from e
+                raise _reject(
+                    "store_unavailable", "Revocation store unavailable", op="is_session_revoked"
+                ) from e
             if session_revoked:
-                raise TokenError("Token has been revoked")
+                raise _reject("session_revoked", "Token has been revoked", jti=jti, sid=sid)
 
         user_id_str: str | None = payload.get("sub")
         if not user_id_str:
-            raise TokenError("Missing user ID in token")
+            raise _reject("missing_sub", "Missing user ID in token", expected_type=expected_type)
         user_id = UUID(user_id_str)
 
         # Reject tokens issued before the user's valid_after cutoff (M1): a password
@@ -169,9 +217,16 @@ def decode_token(token: str, expected_type: str, store: RevocationStore) -> Toke
         try:
             valid_after = store.get_user_valid_after(user_id)
         except RevocationStoreError as e:
-            raise TokenError("Revocation store unavailable") from e
+            raise _reject(
+                "store_unavailable", "Revocation store unavailable", op="get_user_valid_after"
+            ) from e
         if valid_after is not None and datetime.fromtimestamp(payload["iat"], tz=UTC) < valid_after:
-            raise TokenError("Token has been revoked")
+            raise _reject(
+                "issued_before_valid_after",
+                "Token has been revoked",
+                jti=jti,
+                user_id=str(user_id),
+            )
 
         # exp is guaranteed by PyJWT with require=["exp"]
         exp_datetime = datetime.fromtimestamp(payload["exp"], tz=UTC)
@@ -184,9 +239,13 @@ def decode_token(token: str, expected_type: str, store: RevocationStore) -> Toke
             sid=sid or "",
         )
     except InvalidTokenError as e:
-        raise TokenError("Invalid or expired token") from e
+        raise _reject(
+            "invalid_or_expired", "Invalid or expired token", expected_type=expected_type
+        ) from e
     except ValueError as e:
-        raise TokenError("Invalid user ID in token") from e
+        raise _reject(
+            "invalid_user_id", "Invalid user ID in token", expected_type=expected_type
+        ) from e
 
 
 def decode_access_token(token: str, store: RevocationStore) -> UUID:
@@ -234,3 +293,4 @@ def revoke_token(jti: str, store: RevocationStore) -> None:
     :param store: Revocation store to record the JTI in
     """
     store.revoke_jti(jti, refresh_token_ttl_seconds())
+    logger.debug("Token revoked", extra={"event": "token_revoked", "jti": jti})

--- a/api/auth/login_throttle.py
+++ b/api/auth/login_throttle.py
@@ -32,6 +32,7 @@ rather than capping the pair.
 """
 
 import hashlib
+import logging
 import threading
 from datetime import UTC, datetime, timedelta
 from functools import lru_cache
@@ -40,6 +41,8 @@ from typing import Protocol, runtime_checkable
 import redis
 
 from api.config import get_settings
+
+logger = logging.getLogger("api.security")
 
 # After this many failures within the window, the account is locked until the window
 # elapses with no further failures. Ten is generous for a mistyped password while still
@@ -54,8 +57,33 @@ ACTIVATION_KEY_PREFIX = "activation"
 
 
 def _digest(identifier: str) -> str:
-    """Return the SHA-256 hex digest of a normalized identifier, so no raw value is stored."""
+    """Return the SHA-256 hex digest of a normalized identifier, so no raw value is stored.
+
+    Never log this value. It is an unkeyed digest, so anyone holding the logs could
+    hash a guessed address and confirm it appears -- exactly the account-existence
+    oracle ``api.auth.logging.hash_email`` is keyed to prevent. Records in this module
+    name the flow, never the account.
+    """
     return hashlib.sha256(identifier.strip().lower().encode()).hexdigest()
+
+
+def _log_store_unavailable(op: str, exc: redis.RedisError, key_prefix: str) -> None:
+    """Record a lockout store that could not be reached.
+
+    Worth a record because this throttle fails open: the attempt proceeds as if no
+    failures had been counted, so an outage silently disables the account lockout with
+    nothing else to show for it. ``docs/security.md`` accepts that risk; this makes it
+    observable.
+
+    :param op: Throttle operation that failed -- ``record_failure``, ``is_locked``, or ``reset``.
+    :param exc: The Redis error that caused it.
+    :param key_prefix: Key namespace of the flow whose lockout stopped being enforced.
+    """
+    logger.warning(
+        "Login throttle store unavailable, lockout not enforced",
+        extra={"event": "throttle_store_unavailable", "op": op, "key_prefix": key_prefix},
+        exc_info=exc,
+    )
 
 
 @runtime_checkable
@@ -144,15 +172,17 @@ class RedisLoginThrottle:
             pipe.incr(key)
             pipe.expire(key, self._window)
             pipe.execute()
-        except redis.RedisError:
+        except redis.RedisError as e:
             # Fail open: never block an attempt because the throttle store hiccupped.
+            _log_store_unavailable("record_failure", e, self._key_prefix)
             return
 
     def is_locked(self, identifier: str) -> bool:
         """Return whether the account has reached the failure threshold."""
         try:
             raw = self._client.get(self._key(identifier))
-        except redis.RedisError:
+        except redis.RedisError as e:
+            _log_store_unavailable("is_locked", e, self._key_prefix)
             return False
         if not isinstance(raw, bytes | str | int):
             return False
@@ -165,7 +195,8 @@ class RedisLoginThrottle:
         """Clear the account's failure counter (called on a successful attempt)."""
         try:
             self._client.delete(self._key(identifier))
-        except redis.RedisError:
+        except redis.RedisError as e:
+            _log_store_unavailable("reset", e, self._key_prefix)
             return
 
 
@@ -176,6 +207,16 @@ def _build_throttle(key_prefix: str) -> LoginThrottle:
     :return: The throttle backend for that flow.
     """
     settings = get_settings()
+    backend = "redis" if settings.redis_url else "memory"
+    logger.debug(
+        "Login throttle backend selected",
+        extra={
+            "event": "throttle_backend_selected",
+            "throttle": "login",
+            "key_prefix": key_prefix,
+            "backend": backend,
+        },
+    )
     if settings.redis_url:
         client = redis.from_url(settings.redis_url, socket_connect_timeout=2, socket_timeout=2)
         return RedisLoginThrottle(client, key_prefix=key_prefix)

--- a/api/auth/revocation_store.py
+++ b/api/auth/revocation_store.py
@@ -1,14 +1,18 @@
 """Shared-state store for token revocation and per-user session invalidation."""
 
+import logging
 import threading
 from datetime import UTC, datetime, timedelta
 from functools import lru_cache
+from time import perf_counter
 from typing import Protocol, runtime_checkable
 from uuid import UUID
 
 import redis
 
 from api.config import get_settings
+
+logger = logging.getLogger("api.security")
 
 
 @runtime_checkable
@@ -114,6 +118,45 @@ class RevocationStoreError(Exception):
     """Raised when the revocation store cannot be reached (fail-closed)."""
 
 
+def _store_error(op: str, exc: redis.RedisError) -> RevocationStoreError:
+    """Log an unreachable revocation store and build the error to raise.
+
+    This record exists because the store is fail-closed and most callers hide the
+    cause: every ``decode_token`` path in :mod:`api.auth.jwt` turns this error into
+    a plain 401, so without a log line a Redis outage is indistinguishable from a
+    wave of bad tokens. Only the 503 path
+    (``revocation_store_unavailable_handler``) was visible before.
+
+    :param op: Store operation that failed, e.g. ``is_jti_revoked``.
+    :param exc: The Redis error that caused it.
+    :return: The error the caller should raise.
+    """
+    logger.warning(
+        "Revocation store unavailable",
+        extra={"event": "revocation_store_unavailable", "op": op},
+        exc_info=exc,
+    )
+    return RevocationStoreError(str(exc))
+
+
+def _log_call(op: str, start: float, **fields: object) -> None:
+    """Trace one revocation-store round trip.
+
+    :param op: Store operation that ran.
+    :param start: ``perf_counter()`` reading taken before the call.
+    :param fields: Extra context to attach to the record.
+    """
+    logger.debug(
+        "Revocation store call",
+        extra={
+            "event": "revocation_store_call",
+            "op": op,
+            "duration_ms": round((perf_counter() - start) * 1000.0, 1),
+            **fields,
+        },
+    )
+
+
 class RedisRevocationStore:
     """Redis-backed RevocationStore shared across replicas and workers."""
 
@@ -124,28 +167,30 @@ class RedisRevocationStore:
         try:
             self._client.set(f"revoked:jti:{jti}", "1", ex=max(ttl_seconds, 1))
         except redis.RedisError as e:
-            raise RevocationStoreError(str(e)) from e
+            raise _store_error("revoke_jti", e) from e
 
     def is_jti_revoked(self, jti: str) -> bool:
         try:
             return bool(self._client.exists(f"revoked:jti:{jti}"))
         except redis.RedisError as e:
-            raise RevocationStoreError(str(e)) from e
+            raise _store_error("is_jti_revoked", e) from e
 
     def set_user_valid_after(self, user_id: UUID, valid_after: datetime) -> None:
         # Expire a bit after the longest-lived token so the cutoff outlives every token
         # it must invalidate, yet the key does not accumulate forever per user.
         ttl = get_settings().refresh_token_expire_days * 86400 + 3600
+        start = perf_counter()
         try:
             self._client.set(f"user:valid_after:{user_id}", valid_after.isoformat(), ex=ttl)
         except redis.RedisError as e:
-            raise RevocationStoreError(str(e)) from e
+            raise _store_error("set_user_valid_after", e) from e
+        _log_call("set_user_valid_after", start, user_id=str(user_id))
 
     def get_user_valid_after(self, user_id: UUID) -> datetime | None:
         try:
             raw = self._client.get(f"user:valid_after:{user_id}")
         except redis.RedisError as e:
-            raise RevocationStoreError(str(e)) from e
+            raise _store_error("get_user_valid_after", e) from e
         if raw is None:
             return None
         text = raw.decode() if isinstance(raw, bytes) else str(raw)
@@ -155,10 +200,11 @@ class RedisRevocationStore:
         try:
             self._client.set(f"session:current:{sid}", jti, ex=max(ttl_seconds, 1))
         except redis.RedisError as e:
-            raise RevocationStoreError(str(e)) from e
+            raise _store_error("start_session", e) from e
 
     def rotate_session(self, sid: str, expected_jti: str, new_jti: str, ttl_seconds: int) -> bool:
         key = f"session:current:{sid}"
+        start = perf_counter()
         try:
             with self._client.pipeline() as pipe:
                 while True:
@@ -168,30 +214,34 @@ class RedisRevocationStore:
                         current = raw.decode() if isinstance(raw, bytes) else raw
                         if current != expected_jti:
                             pipe.unwatch()
+                            _log_call("rotate_session", start, sid=sid, rotated=False)
                             return False
                         pipe.multi()
                         pipe.set(key, new_jti, ex=max(ttl_seconds, 1))
                         pipe.execute()
+                        _log_call("rotate_session", start, sid=sid, rotated=True)
                         return True
                     except redis.WatchError:
                         continue
         except redis.RedisError as e:
-            raise RevocationStoreError(str(e)) from e
+            raise _store_error("rotate_session", e) from e
 
     def revoke_session(self, sid: str, ttl_seconds: int) -> None:
+        start = perf_counter()
         try:
             pipe = self._client.pipeline()
             pipe.set(f"session:revoked:{sid}", "1", ex=max(ttl_seconds, 1))
             pipe.delete(f"session:current:{sid}")
             pipe.execute()
         except redis.RedisError as e:
-            raise RevocationStoreError(str(e)) from e
+            raise _store_error("revoke_session", e) from e
+        _log_call("revoke_session", start, sid=sid)
 
     def is_session_revoked(self, sid: str) -> bool:
         try:
             return bool(self._client.exists(f"session:revoked:{sid}"))
         except redis.RedisError as e:
-            raise RevocationStoreError(str(e)) from e
+            raise _store_error("is_session_revoked", e) from e
 
 
 @lru_cache
@@ -202,6 +252,11 @@ def get_revocation_store() -> RevocationStore:
     (production), otherwise an in-memory store for dev and tests.
     """
     settings = get_settings()
+    backend = "redis" if settings.redis_url else "memory"
+    logger.info(
+        "Revocation store selected",
+        extra={"event": "revocation_store_selected", "backend": backend},
+    )
     if settings.redis_url:
         client = redis.from_url(settings.redis_url, socket_connect_timeout=2, socket_timeout=2)
         return RedisRevocationStore(client)

--- a/api/config.py
+++ b/api/config.py
@@ -50,6 +50,16 @@ class Environment(StrEnum):
     PROD = "prod"
 
 
+# Verbosity used when LOG_LEVEL is not set. Development wants every DEBUG trace;
+# the deployed profiles stay at INFO, where the drain is affordable and the records
+# carry no detail that only helps a developer sitting at a keyboard.
+_DEFAULT_LOG_LEVELS: dict[Environment, LogLevel] = {
+    Environment.DEV: "DEBUG",
+    Environment.TEST: "INFO",
+    Environment.PROD: "INFO",
+}
+
+
 def _resolve_environment() -> Environment:
     """Resolve the active profile from the ``APP_ENV`` variable.
 
@@ -135,7 +145,9 @@ class Settings(BaseSettings):
     debug: bool = False
     api_version: str = _version
 
-    # Logging
+    # Logging. The field default is only a floor: when LOG_LEVEL is absent,
+    # _apply_profile_log_level replaces it with the active profile's level from
+    # _DEFAULT_LOG_LEVELS.
     log_level: LogLevel = "INFO"
     log_file: str | None = None
 
@@ -238,6 +250,24 @@ class Settings(BaseSettings):
         if self.email_provider == "http":
             return bool(self.email_api_key)
         return False
+
+    @model_validator(mode="after")
+    def _apply_profile_log_level(self) -> "Settings":
+        """Fall back to the active profile's log level when ``LOG_LEVEL`` is unset.
+
+        Without this, a service whose variable was never set -- a new deploy, a
+        cleared value, a fresh clone -- runs at the field default, and development
+        silently loses every DEBUG trace it is supposed to emit.
+
+        An explicit value always wins: pydantic-settings records anything sourced
+        from the environment or a dotenv file in ``model_fields_set``, so only a
+        genuinely absent ``LOG_LEVEL`` is replaced here.
+
+        :return: The settings instance with ``log_level`` resolved.
+        """
+        if "log_level" not in self.model_fields_set:
+            self.log_level = _DEFAULT_LOG_LEVELS[self.environment]
+        return self
 
     @model_validator(mode="after")
     def _validate_deploy_invariants(self) -> "Settings":

--- a/api/logging_config.py
+++ b/api/logging_config.py
@@ -31,6 +31,14 @@ _DEBUG_FORMAT = "%(asctime)s %(levelname)-8s [%(name)s] %(message)s (%(filename)
 #                      drain in the clear. The dev deploy runs at DEBUG, so inheriting
 #                      LOG_LEVEL here would leak on a real database. Query shape and
 #                      timing are logged by the read services instead.
+#                      Caveat, so nobody reads this pin as stronger than it is: SQLAlchemy's
+#                      InstanceLogger substitutes its own level from ``echo`` and calls
+#                      ``Logger._log`` directly, so an engine built with ``echo=True``
+#                      emits statements regardless of the level set here. What actually
+#                      keeps that off every deployed service is ``_validate_deploy_invariants``,
+#                      which refuses to boot any deploy with ``debug`` on, and
+#                      ``api/db/engine.py`` ties ``echo`` to ``settings.debug``. The pin
+#                      covers the case echo does not: SQLAlchemy's own INFO/DEBUG records.
 #   httpx / botocore   the Resend and S3 calls, already covered by ``email_sent`` and
 #                      ``s3_upload`` with timings; only transport failures add anything.
 _EXTERNAL_LOG_LEVELS: dict[str, int] = {

--- a/api/logging_config.py
+++ b/api/logging_config.py
@@ -16,6 +16,31 @@ _LOG_FILE_BACKUP_COUNT = 3
 _TEXT_FORMAT = "%(asctime)s %(levelname)-8s [%(name)s] %(message)s"
 _DEBUG_FORMAT = "%(asctime)s %(levelname)-8s [%(name)s] %(message)s (%(filename)s:%(lineno)d)"
 
+# Third-party loggers worth keeping, and the level each is pinned at. They sit outside
+# the ``api`` tree and uvicorn switches its own off propagation, so without this their
+# records reach the container's stdout but never the log drain.
+#
+# The levels are deliberate, not inherited from LOG_LEVEL:
+#   uvicorn.error      startup, shutdown, and protocol failures -- the records that
+#                      explain a boot that never finished. Low volume, high value.
+#   uvicorn.access     silenced: ``api.request`` already logs a richer line per request
+#                      (ip, duration, correlation id). Listed so the choice is visible.
+#   sqlalchemy.engine  MUST stay above DEBUG. Its INFO level prints every statement and
+#                      its DEBUG level adds the bound parameters -- password hashes, raw
+#                      addresses, names, reset-token hashes -- which would ship to the
+#                      drain in the clear. The dev deploy runs at DEBUG, so inheriting
+#                      LOG_LEVEL here would leak on a real database. Query shape and
+#                      timing are logged by the read services instead.
+#   httpx / botocore   the Resend and S3 calls, already covered by ``email_sent`` and
+#                      ``s3_upload`` with timings; only transport failures add anything.
+_EXTERNAL_LOG_LEVELS: dict[str, int] = {
+    "uvicorn.error": logging.INFO,
+    "uvicorn.access": logging.WARNING,
+    "sqlalchemy.engine": logging.WARNING,
+    "httpx": logging.WARNING,
+    "botocore": logging.WARNING,
+}
+
 # Built-in LogRecord attributes; anything else on a record came from ``extra``.
 _RESERVED_ATTRS = frozenset(
     {
@@ -79,13 +104,19 @@ class JsonLogFormatter(logging.Formatter):
 def _build_formatter(settings: Settings) -> logging.Formatter:
     """Choose a log formatter for the active environment profile.
 
-    Development keeps human-readable text; every other profile emits JSON so the
-    Railway log drain can index ``extra`` fields.
+    A developer's console keeps human-readable text. Anything running as a deployed
+    service emits JSON so the log drain can index the ``extra`` fields -- and that
+    includes the Railway ``dev`` service, which is a deploy that happens to run the
+    dev profile rather than a laptop. Keying only on the profile would ship its
+    records as plain text and leave every structured field unqueryable.
 
     :param settings: Application settings.
     :return: Formatter matching the profile.
     """
-    if settings.environment is Environment.DEV:
+    is_local_dev = (
+        settings.environment is Environment.DEV and settings.railway_environment_name is None
+    )
+    if is_local_dev:
         return logging.Formatter(_DEBUG_FORMAT if settings.debug else _TEXT_FORMAT)
     return JsonLogFormatter()
 
@@ -104,32 +135,28 @@ def _betterstack_host(raw: str) -> str:
     return host.rstrip("/")
 
 
-def setup_logging(settings: Settings) -> None:
-    """Configure the parent ``api`` logger from application settings.
+def _build_handlers(settings: Settings) -> list[logging.Handler]:
+    """Build the handler set shared by every logger this module configures.
 
-    Sets the level from ``LOG_LEVEL``, attaches a console handler (and a rotating
-    file handler when ``LOG_FILE`` is set), and disables propagation so uvicorn
-    and SQLAlchemy logs stay separate. Every handler carries a
-    :class:`~api.logging_context.ContextFilter`, so the request-scoped
-    ``request_id`` and ``user_id`` reach records from child loggers such as
-    ``api.security`` too. Safe to call repeatedly: existing ``api`` handlers are
-    cleared first, so reloads and tests do not stack duplicates.
+    Always a console handler, plus a rotating file handler when ``LOG_FILE`` is set
+    and a Better Stack handler when both of its settings are present. Each carries
+    a :class:`~api.logging_context.ContextFilter` so the request-scoped
+    ``request_id`` and ``user_id`` reach every record.
+
+    The handlers are built once and shared, not rebuilt per logger: that keeps the
+    Better Stack handler a single HTTP client with a single buffer instead of one
+    per configured logger.
 
     :param settings: Application settings.
+    :return: Handlers to attach, console first.
     """
-    logger = logging.getLogger("api")
-    logger.setLevel(settings.log_level.upper())
-    logger.propagate = False
-
-    for handler in list(logger.handlers):
-        logger.removeHandler(handler)
-
     context_filter = ContextFilter()
     formatter = _build_formatter(settings)
+    handlers: list[logging.Handler] = []
+
     stream_handler = logging.StreamHandler()
     stream_handler.setFormatter(formatter)
-    stream_handler.addFilter(context_filter)
-    logger.addHandler(stream_handler)
+    handlers.append(stream_handler)
 
     if settings.log_file:
         file_handler = RotatingFileHandler(
@@ -138,13 +165,57 @@ def setup_logging(settings: Settings) -> None:
             backupCount=_LOG_FILE_BACKUP_COUNT,
         )
         file_handler.setFormatter(formatter)
-        file_handler.addFilter(context_filter)
-        logger.addHandler(file_handler)
+        handlers.append(file_handler)
 
     if settings.betterstack_source_token and settings.betterstack_ingesting_host:
         logtail_handler = LogtailHandler(
             source_token=settings.betterstack_source_token,
             host=f"https://{_betterstack_host(settings.betterstack_ingesting_host)}",
         )
-        logtail_handler.addFilter(context_filter)
-        logger.addHandler(logtail_handler)
+        handlers.append(logtail_handler)
+
+    for handler in handlers:
+        handler.addFilter(context_filter)
+    return handlers
+
+
+def _attach(logger: logging.Logger, handlers: list[logging.Handler], level: int | str) -> None:
+    """Point one logger at the shared handlers at a given level.
+
+    Existing handlers are dropped first, so calling this more than once in a
+    process -- a reload, or the tests that configure logging repeatedly -- does not
+    stack duplicates. Propagation is switched off because the logger already carries
+    the full handler set; leaving it on would emit each record a second time through
+    an ancestor.
+
+    :param logger: Logger to configure.
+    :param handlers: Shared handler set from :func:`_build_handlers`.
+    :param level: Level to set on the logger.
+    """
+    logger.setLevel(level)
+    logger.propagate = False
+
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+    for handler in handlers:
+        logger.addHandler(handler)
+
+
+def setup_logging(settings: Settings) -> None:
+    """Configure the ``api`` logger tree and the third-party loggers worth keeping.
+
+    The ``api`` logger takes its level from ``LOG_LEVEL``; every child
+    (``api.request``, ``api.security``, ``api.service.*``, ...) inherits it. The
+    loggers in :data:`_EXTERNAL_LOG_LEVELS` get the same handlers at their own
+    pinned levels, so uvicorn's startup failures and the transport errors from
+    httpx and botocore land in the drain next to the ``api.*`` records that explain
+    them -- see that mapping for why each level is what it is.
+
+    Safe to call repeatedly: every configured logger has its handlers cleared first.
+
+    :param settings: Application settings.
+    """
+    handlers = _build_handlers(settings)
+    _attach(logging.getLogger("api"), handlers, settings.log_level.upper())
+    for name, level in _EXTERNAL_LOG_LEVELS.items():
+        _attach(logging.getLogger(name), handlers, level)

--- a/api/middleware/body_size.py
+++ b/api/middleware/body_size.py
@@ -7,9 +7,13 @@ declared ``Content-Length`` above the limit up front, and counts bytes for chunk
 bodies so no request can buffer more than the limit regardless of the declared size.
 """
 
+import logging
+
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+logger = logging.getLogger("api.request")
 
 # Default cap for buffered request bodies (2 MiB). Comfortably fits the largest
 # legitimate JSON payload -- a 1000-expert /calculate request -- while stopping the
@@ -41,6 +45,21 @@ class BodySizeLimitMiddleware:
 
         declared = self._declared_length(scope)
         if declared is not None and declared > self._max_body_bytes:
+            # This record carries no request_id: the middleware is added last and so
+            # runs first, before RequestLoggingMiddleware binds the correlation id.
+            # That ordering is the whole point -- the body is refused before anything
+            # buffers it -- so the missing id is a consequence, not an oversight.
+            logger.warning(
+                "Request body rejected",
+                extra={
+                    "event": "request_body_rejected",
+                    "reason": "declared_content_length",
+                    "declared_bytes": declared,
+                    "limit_bytes": self._max_body_bytes,
+                    "method": scope.get("method"),
+                    "path": scope.get("path"),
+                },
+            )
             await self._send_too_large(send)
             return
 
@@ -108,4 +127,15 @@ def body_too_large_handler(request: Request, exc: Exception) -> Response:
     :param exc: The raised :class:`RequestBodyTooLarge`.
     :return: A 413 JSON response.
     """
+    # The configured cap belongs to the middleware instance and is not reachable from
+    # this handler, so the record states what happened without guessing the number.
+    logger.warning(
+        "Request body rejected",
+        extra={
+            "event": "request_body_rejected",
+            "reason": "streamed_overflow",
+            "method": request.method,
+            "path": request.url.path,
+        },
+    )
     return JSONResponse(status_code=413, content={"detail": "Request body too large"})

--- a/api/middleware/csrf.py
+++ b/api/middleware/csrf.py
@@ -11,6 +11,7 @@ requests; this double-submit check is defense-in-depth: an attacker who cannot r
 ``csrf_token`` cookie value cannot forge the matching ``X-CSRF-Token`` header.
 """
 
+import logging
 import secrets
 
 from starlette import status
@@ -19,6 +20,9 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
 from api.auth.cookies import CSRF_COOKIE, CSRF_HEADER
+from api.utils.client_ip import get_client_ip
+
+logger = logging.getLogger("api.security")
 
 # Methods that never change state need no CSRF token (OPTIONS also keeps CORS preflight
 # working, since a cross-origin preflight carries no cookies or custom headers).
@@ -52,11 +56,37 @@ class CSRFMiddleware(BaseHTTPMiddleware):
             cookie = request.cookies.get(CSRF_COOKIE)
             if cookie is not None:
                 header = request.headers.get(CSRF_HEADER)
+                if header is None:
+                    return self._reject("missing_header", request)
                 # Compare as bytes: compare_digest raises TypeError on a non-ASCII str,
                 # which would turn a junk header into a 500 instead of this 403.
-                if header is None or not secrets.compare_digest(header.encode(), cookie.encode()):
-                    return JSONResponse(
-                        status_code=status.HTTP_403_FORBIDDEN,
-                        content={"detail": "CSRF token missing or invalid"},
-                    )
+                if not secrets.compare_digest(header.encode(), cookie.encode()):
+                    return self._reject("token_mismatch", request)
         return await call_next(request)
+
+    @staticmethod
+    def _reject(reason: str, request: Request) -> JSONResponse:
+        """Log the refused request and build its 403.
+
+        Neither the cookie nor the header value reaches the record: they are the
+        secret this check compares, so logging either would hand anyone reading the
+        log the token needed to forge the request it just blocked.
+
+        :param reason: Why the check failed -- ``missing_header`` or ``token_mismatch``.
+        :param request: The refused request.
+        :return: The 403 response sent to the caller.
+        """
+        logger.warning(
+            "CSRF check failed",
+            extra={
+                "event": "csrf_rejected",
+                "reason": reason,
+                "method": request.method,
+                "path": request.url.path,
+                "ip": get_client_ip(request),
+            },
+        )
+        return JSONResponse(
+            status_code=status.HTTP_403_FORBIDDEN,
+            content={"detail": "CSRF token missing or invalid"},
+        )

--- a/api/routes/calculate.py
+++ b/api/routes/calculate.py
@@ -4,6 +4,7 @@ This module provides direct calculation endpoint without project context.
 Uses dependency injection for calculator following DIP.
 """
 
+import logging
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -15,6 +16,8 @@ from src.calculators.become_calculator import BeCoMeCalculator
 from src.exceptions import BeCoMeError
 from src.models.expert_opinion import ExpertOpinion
 from src.models.fuzzy_number import FuzzyTriangleNumber
+
+logger = logging.getLogger("api.route.calculate")
 
 router = APIRouter(prefix="/api/v1", tags=["calculation"])
 
@@ -51,8 +54,27 @@ def calculate(
     try:
         result = calculator.calculate_compromise(opinions)
     except BeCoMeError as e:
+        # The HTTPException raised here reaches FastAPI's own handler, not the app's
+        # exception handlers, so this refusal would otherwise leave no trace at all.
+        # Only the expert count is logged: the payload carries up to 1000 opinions.
+        logger.warning(
+            "Calculation rejected",
+            extra={
+                "event": "calculation_rejected",
+                "reason": type(e).__name__,
+                "expert_count": len(opinions),
+            },
+        )
         raise HTTPException(status_code=400, detail=str(e)) from e
 
+    logger.debug(
+        "Calculation completed",
+        extra={
+            "event": "calculation_completed",
+            "expert_count": result.num_experts,
+            "max_error": result.max_error,
+        },
+    )
     return CalculateResponse(
         best_compromise=FuzzyNumberOutput.from_domain(result.best_compromise),
         arithmetic_mean=FuzzyNumberOutput.from_domain(result.arithmetic_mean),

--- a/api/routes/invitations.py
+++ b/api/routes/invitations.py
@@ -1,11 +1,13 @@
 """Invitation management routes for email-based invitations."""
 
+import logging
 from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
 from api.auth.dependencies import CurrentUser
+from api.auth.logging import hash_email
 from api.dependencies import ProjectAdmin, ProjectMember, get_invitation_service
 from api.exceptions import AlreadyInvitedError, UserNotFoundForInvitationError
 from api.middleware.rate_limit import LIMIT_WRITE, limiter
@@ -19,7 +21,37 @@ from api.schemas.invitation import (
 from api.schemas.project import MemberResponse
 from api.services.invitation_service import InvitationService
 
+logger = logging.getLogger("api.route.invitations")
+
 router = APIRouter(prefix="/api/v1", tags=["invitations"])
+
+
+def _log_invitation_rejected(reason: str, project_id: UUID, inviter_id: UUID, email: str) -> None:
+    """Record an invitation the endpoint refused.
+
+    Both refusals translate a :class:`~api.exceptions.BeCoMeAPIError` into an
+    ``HTTPException`` inside the route, so ``become_api_error_handler`` never sees the
+    original and neither refusal is logged anywhere else.
+
+    The address is tagged, never written out: this endpoint is the application's
+    email-enumeration surface, and a log of the addresses people probed for would be
+    the registry the uniform rate limit exists to deny.
+
+    :param reason: ``invitee_not_found`` or ``already_invited``.
+    :param project_id: Project the invitation targeted.
+    :param inviter_id: Admin who sent it.
+    :param email: Address that was invited.
+    """
+    logger.warning(
+        "Invitation rejected",
+        extra={
+            "event": "invitation_rejected",
+            "reason": reason,
+            "project_id": str(project_id),
+            "inviter_id": str(inviter_id),
+            "email_hash": hash_email(email),
+        },
+    )
 
 
 @router.post(
@@ -55,11 +87,13 @@ def invite_by_email(
             invitee_email=data.email,
         )
     except UserNotFoundForInvitationError as err:
+        _log_invitation_rejected("invitee_not_found", project.id, current_user.id, data.email)
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="No user found with this email",
         ) from err
     except AlreadyInvitedError as err:
+        _log_invitation_rejected("already_invited", project.id, current_user.id, data.email)
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="User already has a pending invitation",
@@ -88,6 +122,15 @@ def list_project_invitations(
     invitations = invitation_service.get_project_invitations(
         project.id, limit=pagination.limit, offset=pagination.offset
     )
+    logger.debug(
+        "Project invitations listed",
+        extra={
+            "event": "invitations_listed",
+            "scope": "project",
+            "project_id": str(project.id),
+            "row_count": len(invitations),
+        },
+    )
     return [ProjectInvitationResponse.from_model(inv, invitee) for inv, invitee in invitations]
 
 
@@ -106,6 +149,14 @@ def list_my_invitations(
     """
     invitations = invitation_service.get_user_invitations(
         current_user.id, limit=pagination.limit, offset=pagination.offset
+    )
+    logger.debug(
+        "User invitations listed",
+        extra={
+            "event": "invitations_listed",
+            "scope": "user",
+            "row_count": len(invitations),
+        },
     )
     return [
         InvitationListItemResponse.from_model(

--- a/api/routes/opinions.py
+++ b/api/routes/opinions.py
@@ -4,6 +4,7 @@ Exception handling follows OCP: all exceptions are handled
 by centralized middleware, routes focus on business logic only.
 """
 
+import logging
 from typing import Annotated
 from uuid import UUID
 
@@ -25,6 +26,11 @@ from api.services.export.data import ExportFormat, ReportLang
 from api.services.export.result_export_service import ResultExportService
 from api.services.opinion_service import OpinionService
 
+# Only refusals and reads live here. The upsert, delete, recalculation, and export
+# events already come from opinion_service, calculation_service, and
+# result_export_service.
+logger = logging.getLogger("api.route.opinions")
+
 router = APIRouter(prefix="/api/v1/projects", tags=["opinions"])
 
 
@@ -44,6 +50,14 @@ def list_opinions(
     """
     opinions = opinion_service.get_opinions_for_project(
         project.id, limit=pagination.limit, offset=pagination.offset
+    )
+    logger.debug(
+        "Opinions listed",
+        extra={
+            "event": "opinions_listed",
+            "project_id": str(project.id),
+            "row_count": len(opinions),
+        },
     )
     return [OpinionResponse.from_model(item.opinion, item.user) for item in opinions]
 
@@ -137,6 +151,14 @@ def get_result(
     :return: Calculation result or None
     """
     result = calculation_service.get_result(project.id)
+    logger.debug(
+        "Result read",
+        extra={
+            "event": "result_read",
+            "project_id": str(project.id),
+            "has_result": bool(result),
+        },
+    )
     if not result:
         return None
 
@@ -192,6 +214,15 @@ def export_result(
     """
     exported = service.export(project, export_format, lang)
     if exported is None:
+        logger.warning(
+            "Result export had nothing to export",
+            extra={
+                "event": "result_export_missing",
+                "project_id": str(project.id),
+                "format": export_format.value,
+                "lang": lang.value,
+            },
+        )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="No calculation result to export",

--- a/api/routes/projects.py
+++ b/api/routes/projects.py
@@ -4,6 +4,7 @@ Exception handling follows OCP: all exceptions are handled
 by centralized middleware, routes focus on business logic only.
 """
 
+import logging
 from typing import Annotated
 from uuid import UUID
 
@@ -32,6 +33,11 @@ from api.services.project_membership_service import ProjectMembershipService
 from api.services.project_query_service import ProjectQueryService
 from api.services.project_service import ProjectService
 
+# Refusals raised as HTTPException inside a route reach FastAPI's own handler, not the
+# app's, so they are logged here or nowhere. Successful writes are not: project_service
+# and project_membership_service already emit those events.
+logger = logging.getLogger("api.route.projects")
+
 router = APIRouter(prefix="/api/v1/projects", tags=["projects"])
 
 
@@ -50,6 +56,15 @@ def list_projects(
     """
     projects_with_roles = query_service.get_user_projects_with_roles(
         current_user.id, limit=pagination.limit, offset=pagination.offset
+    )
+    logger.debug(
+        "Projects listed",
+        extra={
+            "event": "projects_listed",
+            "row_count": len(projects_with_roles),
+            "limit": pagination.limit,
+            "offset": pagination.offset,
+        },
     )
     return [
         ProjectWithRoleResponse.from_model_with_role(
@@ -100,6 +115,16 @@ def get_project(
     """
     role = membership_service.get_user_role_in_project(project.id, current_user.id)
     if role is None:
+        # The ProjectMember dependency already accepted this caller, so a missing role
+        # here means the membership went away between the two reads.
+        logger.warning(
+            "Project membership missing after access check",
+            extra={
+                "event": "project_membership_missing",
+                "project_id": str(project.id),
+                "user_id": str(current_user.id),
+            },
+        )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Membership not found for this project.",
@@ -173,6 +198,15 @@ def transfer_ownership(
     :raises HTTPException: 400 if transferring ownership to self
     """
     if request.new_admin_id == current_user.id:
+        logger.warning(
+            "Ownership transfer rejected",
+            extra={
+                "event": "ownership_transfer_rejected",
+                "reason": "self_transfer",
+                "project_id": str(project.id),
+                "user_id": str(current_user.id),
+            },
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="You are already the project admin.",
@@ -199,6 +233,14 @@ def list_members(
     """
     members = membership_service.get_members(
         project.id, limit=pagination.limit, offset=pagination.offset
+    )
+    logger.debug(
+        "Project members listed",
+        extra={
+            "event": "members_listed",
+            "project_id": str(project.id),
+            "row_count": len(members),
+        },
     )
     return [MemberResponse.from_model(member.membership, member.user) for member in members]
 
@@ -232,6 +274,15 @@ def remove_member(
     :raises HTTPException: 400 if removing self
     """
     if user_id == current_user.id:
+        logger.warning(
+            "Member removal rejected",
+            extra={
+                "event": "member_removal_rejected",
+                "reason": "self_removal",
+                "project_id": str(project.id),
+                "user_id": str(current_user.id),
+            },
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Admin cannot remove themselves. Delete the project instead.",
@@ -239,3 +290,14 @@ def remove_member(
 
     if membership_service.remove_member(project.id, user_id):
         calculation_service.recalculate(project.id)
+    else:
+        # A 204 either way, so without this the no-op is indistinguishable from a
+        # removal in the log. project_membership_service logs the removal itself.
+        logger.debug(
+            "Member removal was a no-op",
+            extra={
+                "event": "member_removal_noop",
+                "project_id": str(project.id),
+                "user_id": str(user_id),
+            },
+        )

--- a/api/routes/users.py
+++ b/api/routes/users.py
@@ -1,5 +1,6 @@
 """User management routes: profile, password, photo, account deletion."""
 
+import logging
 from contextlib import suppress
 from datetime import UTC, datetime
 from typing import Annotated
@@ -48,7 +49,47 @@ from api.utils.photo_links import photo_version
 from api.utils.streaming import StoredObjectResponse
 from api.utils.upload import UploadTooLarge, read_within_limit
 
+# Password change, account deletion, and the GDPR export are logged by
+# api/auth/logging.py; the storage layer logs its own s3_* events and the dimension
+# rejection. What is left for this router is the profile write and the photo refusals,
+# which are raised as HTTPException and so never reach the app's exception handlers.
+logger = logging.getLogger("api.route.users")
+
 router = APIRouter(prefix="/api/v1/users", tags=["users"])
+
+
+def _photo_upload_rejected(reason: str, user_id: UUID, **fields: object) -> None:
+    """Record a refused photo upload.
+
+    :param reason: Which check refused it, e.g. ``content_type``.
+    :param user_id: Uploader.
+    :param fields: Extra context, never the file's bytes.
+    """
+    logger.warning(
+        "Photo upload rejected",
+        extra={
+            "event": "photo_upload_rejected",
+            "reason": reason,
+            "user_id": str(user_id),
+            **fields,
+        },
+    )
+
+
+def _photo_not_found(reason: str, user_id: UUID) -> None:
+    """Record a 404 from the public photo proxy.
+
+    DEBUG rather than WARNING: the endpoint is public and fires on every avatar render,
+    so a missing photo is ordinary traffic rather than a signal.
+
+    :param reason: Which branch answered 404.
+    :param user_id: User whose photo was requested.
+    """
+    logger.debug(
+        "Photo not found",
+        extra={"event": "photo_not_found", "reason": reason, "user_id": str(user_id)},
+    )
+
 
 # Profile photo URLs are versioned: build_photo_url appends ?v=<token> taken from the
 # stored object key, and every upload mints a fresh key. A versioned URL therefore always
@@ -114,6 +155,23 @@ def update_current_user(
         user=current_user,
         first_name=request.first_name,
         last_name=request.last_name,
+    )
+    # Field names only. The values are the user's own name, which the record does not
+    # need in order to say that the profile changed.
+    logger.info(
+        "Profile updated",
+        extra={
+            "event": "profile_updated",
+            "user_id": str(current_user.id),
+            "fields": [
+                name
+                for name, value in (
+                    ("first_name", request.first_name),
+                    ("last_name", request.last_name),
+                )
+                if value is not None
+            ],
+        },
     )
     return UserResponse.from_user(updated)
 
@@ -269,6 +327,7 @@ async def upload_photo(
     :return: Updated user profile
     """
     if storage_service is None:
+        _photo_upload_rejected("storage_unavailable", current_user.id)
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Photo upload is not available",
@@ -277,6 +336,7 @@ async def upload_photo(
     # Validate content type
     content_type = file.content_type
     if content_type is None or content_type not in validation.ALLOWED_CONTENT_TYPES:
+        _photo_upload_rejected("content_type", current_user.id, content_type=content_type)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid file type. Allowed: JPEG, PNG, GIF, WebP",
@@ -286,6 +346,9 @@ async def upload_photo(
     try:
         content = await read_within_limit(file, validation.MAX_FILE_SIZE_BYTES)
     except UploadTooLarge:
+        _photo_upload_rejected(
+            "too_large", current_user.id, limit_bytes=validation.MAX_FILE_SIZE_BYTES
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="File too large. Maximum size is 5 MB",
@@ -293,6 +356,7 @@ async def upload_photo(
 
     # Validate actual file content matches claimed type (magic bytes check)
     if not validation.validate_image_content(content, content_type):
+        _photo_upload_rejected("content_mismatch", current_user.id, content_type=content_type)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="File content does not match declared type",
@@ -321,6 +385,15 @@ async def upload_photo(
         ) from err
 
     updated_user = user_service.update_photo_url(current_user, photo_key)
+    logger.info(
+        "Profile photo uploaded",
+        extra={
+            "event": "photo_uploaded",
+            "user_id": str(current_user.id),
+            "size_bytes": len(content),
+            "content_type": content_type,
+        },
+    )
     return UserResponse.from_user(updated_user)
 
 
@@ -341,6 +414,11 @@ def delete_photo(
     :param storage_service: Storage service
     """
     if not current_user.photo_url:
+        # A 204 either way, so without this the no-op looks like a deletion.
+        logger.debug(
+            "Photo delete was a no-op",
+            extra={"event": "photo_delete_noop", "user_id": str(current_user.id)},
+        )
         return
 
     # Try to delete from storage, but always clear the DB record
@@ -349,6 +427,10 @@ def delete_photo(
             storage_service.delete(current_user.photo_url)
 
     user_service.update_photo_url(current_user, None)
+    logger.info(
+        "Profile photo deleted",
+        extra={"event": "photo_deleted", "user_id": str(current_user.id)},
+    )
 
 
 @router.get(
@@ -376,10 +458,12 @@ def get_user_photo(
     :return: The image streamed from the bucket, with public caching headers
     """
     if storage_service is None:
+        _photo_not_found("no_storage", user_id)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Photo not found")
 
     user = user_service.get_by_id(user_id)
     if user is None or not user.photo_url:
+        _photo_not_found("no_user_or_key", user_id)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Photo not found")
 
     # A storage fault must not surface here: this endpoint is public, and the raw
@@ -387,11 +471,15 @@ def get_user_photo(
     try:
         stored = storage_service.open(user.photo_url)
     except StorageError as err:
+        # The bucket layer already logged the fault with its own s3_open_failed event;
+        # this only records that the caller was answered 404 because of it.
+        _photo_not_found("storage_error", user_id)
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Photo not found"
         ) from err
 
     if stored is None:
+        _photo_not_found("object_missing", user_id)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Photo not found")
 
     # The version has to match the key being served, not merely be present. This route

--- a/api/services/email/resend_email_sender.py
+++ b/api/services/email/resend_email_sender.py
@@ -2,15 +2,22 @@
 
 from __future__ import annotations
 
+import logging
+from time import perf_counter
 from typing import TYPE_CHECKING
 
 import httpx
 
+from api.auth.logging import hash_email
 from api.services.email.base import EmailSender
 from api.services.email.exceptions import EmailSendError
 
 if TYPE_CHECKING:
     from api.config import Settings
+
+# Same logger as the console sender: both implement EmailSender, and a reader asking
+# "did the mail go out" wants one logger for email regardless of the backend.
+logger = logging.getLogger("api.service.email")
 
 _TIMEOUT_SECONDS = 10.0
 _MINUTES_PER_HOUR = 60
@@ -26,6 +33,69 @@ def _format_ttl_window(minutes: int) -> str:
         hours = minutes // _MINUTES_PER_HOUR
         return "1 hour" if hours == 1 else f"{hours} hours"
     return f"{minutes} minutes"
+
+
+def _log_send_started(kind: str, email_hash: str, provider_url: str) -> None:
+    """Trace an outbound provider call before it is made.
+
+    :param kind: Which email is going out, e.g. ``password_reset``.
+    :param email_hash: Keyed tag for the recipient.
+    :param provider_url: Provider endpoint being called.
+    """
+    logger.debug(
+        "Email send started",
+        extra={
+            "event": "email_send_started",
+            "kind": kind,
+            "email_hash": email_hash,
+            "provider_url": provider_url,
+        },
+    )
+
+
+def _log_send_result(
+    kind: str,
+    email_hash: str,
+    *,
+    start: float,
+    status_code: int | None = None,
+    exc: httpx.HTTPError | None = None,
+) -> None:
+    """Record how one provider call ended.
+
+    Neither the payload nor the headers reach the record: the payload carries the
+    recipient address and a redeemable link, and the headers carry the API key. Only
+    the keyed address tag, the provider's status, and the timing are logged.
+
+    A failure is WARNING here, not ERROR, and that is deliberate. ``api/routes/auth.py``
+    already logs the swallowed :class:`EmailSendError` at ERROR precisely so Sentry --
+    initialised without a LoggingIntegration, so its default ``event_level`` of ERROR
+    decides -- raises one issue per outage. A second ERROR would double every issue.
+
+    :param kind: Which email it was.
+    :param email_hash: Keyed tag for the recipient.
+    :param start: ``perf_counter()`` reading taken before the request.
+    :param status_code: Provider status when the call completed.
+    :param exc: The transport or status error when it did not.
+    """
+    fields: dict[str, object] = {
+        "kind": kind,
+        "email_hash": email_hash,
+        "duration_ms": round((perf_counter() - start) * 1000.0, 1),
+    }
+    if exc is None:
+        fields["status_code"] = status_code
+        logger.info("Email sent", extra={"event": "email_sent", **fields})
+        return
+
+    response = getattr(exc, "response", None)
+    if response is not None:
+        fields["status_code"] = response.status_code
+    logger.warning(
+        "Email send failed",
+        extra={"event": "email_send_failed", **fields},
+        exc_info=exc,
+    )
 
 
 class ResendEmailSender(EmailSender):
@@ -56,11 +126,18 @@ class ResendEmailSender(EmailSender):
             "html": self._build_html(reset_url),
         }
         headers = {"Authorization": f"Bearer {self._settings.email_api_key}"}
+        email_hash = hash_email(to_email)
+        _log_send_started("password_reset", email_hash, self._settings.email_api_url)
+        start = perf_counter()
         try:
             response = await self._post(payload, headers)
             response.raise_for_status()
         except httpx.HTTPError as exc:
+            _log_send_result("password_reset", email_hash, start=start, exc=exc)
             raise EmailSendError(f"Failed to send password reset email: {exc}") from exc
+        _log_send_result(
+            "password_reset", email_hash, start=start, status_code=response.status_code
+        )
 
     async def send_email_verification(self, *, to_email: str, verify_url: str) -> None:
         """Send an account-verification email via Resend.
@@ -76,11 +153,16 @@ class ResendEmailSender(EmailSender):
             "html": self._build_verification_html(verify_url),
         }
         headers = {"Authorization": f"Bearer {self._settings.email_api_key}"}
+        email_hash = hash_email(to_email)
+        _log_send_started("verification", email_hash, self._settings.email_api_url)
+        start = perf_counter()
         try:
             response = await self._post(payload, headers)
             response.raise_for_status()
         except httpx.HTTPError as exc:
+            _log_send_result("verification", email_hash, start=start, exc=exc)
             raise EmailSendError(f"Failed to send verification email: {exc}") from exc
+        _log_send_result("verification", email_hash, start=start, status_code=response.status_code)
 
     async def send_registration_attempt_notice(
         self, *, to_email: str, login_url: str, reset_url: str
@@ -99,11 +181,18 @@ class ResendEmailSender(EmailSender):
             "html": self._build_registration_attempt_html(login_url=login_url, reset_url=reset_url),
         }
         headers = {"Authorization": f"Bearer {self._settings.email_api_key}"}
+        email_hash = hash_email(to_email)
+        _log_send_started("registration_notice", email_hash, self._settings.email_api_url)
+        start = perf_counter()
         try:
             response = await self._post(payload, headers)
             response.raise_for_status()
         except httpx.HTTPError as exc:
+            _log_send_result("registration_notice", email_hash, start=start, exc=exc)
             raise EmailSendError(f"Failed to send registration attempt notice: {exc}") from exc
+        _log_send_result(
+            "registration_notice", email_hash, start=start, status_code=response.status_code
+        )
 
     def _build_html(self, reset_url: str) -> str:
         """Render the reset-email HTML body.

--- a/api/services/project_query_service.py
+++ b/api/services/project_query_service.py
@@ -1,5 +1,7 @@
 """Project query service for complex UI queries."""
 
+import logging
+from time import perf_counter
 from uuid import UUID
 
 from sqlmodel import col, select
@@ -8,6 +10,37 @@ from api.db.models import MemberRole, Project, ProjectMember
 from api.schemas.internal import ProjectWithMemberCount, ProjectWithMemberCountAndRole
 from api.services.base import BaseService
 from api.services.query_helpers import MemberCountSubquery
+
+logger = logging.getLogger("api.service.project_query")
+
+
+def _log_query(variant: str, user_id: UUID, row_count: int, start: float, **fields: object) -> None:
+    """Trace one project query's shape and cost.
+
+    This is the application-level answer to "trace the reads". Turning
+    ``sqlalchemy.engine`` up instead would print the statement and, at DEBUG, its bound
+    parameters -- password hashes, addresses, names -- into the log drain, so
+    :data:`api.logging_config._EXTERNAL_LOG_LEVELS` pins that logger below DEBUG and
+    the shape and timing are recorded here instead. The statement itself is never
+    logged.
+
+    :param variant: Which query ran -- ``with_counts`` or ``with_roles``.
+    :param user_id: Owner of the result set.
+    :param row_count: Rows returned.
+    :param start: ``perf_counter()`` reading taken before the query.
+    :param fields: Extra context, e.g. the paging window.
+    """
+    logger.debug(
+        "User projects queried",
+        extra={
+            "event": "user_projects_queried",
+            "variant": variant,
+            "user_id": str(user_id),
+            "row_count": row_count,
+            "duration_ms": round((perf_counter() - start) * 1000.0, 1),
+            **fields,
+        },
+    )
 
 
 class ProjectQueryService(BaseService):
@@ -36,7 +69,9 @@ class ProjectQueryService(BaseService):
             .where(ProjectMember.user_id == user_id)
             .order_by(col(Project.created_at).desc())
         )
+        start = perf_counter()
         results = self._session.exec(statement).all()
+        _log_query("with_counts", user_id, len(results), start)
         return [
             ProjectWithMemberCount(project=project, member_count=count)
             for project, count in results
@@ -68,7 +103,9 @@ class ProjectQueryService(BaseService):
         )
         if limit is not None:
             statement = statement.limit(limit).offset(offset)
+        start = perf_counter()
         results = self._session.exec(statement).all()
+        _log_query("with_roles", user_id, len(results), start, limit=limit, offset=offset)
         return [
             ProjectWithMemberCountAndRole(
                 project=project,

--- a/api/services/registration_service.py
+++ b/api/services/registration_service.py
@@ -1,5 +1,6 @@
 """Registration policy for accounts that are activated by email."""
 
+import logging
 from dataclasses import dataclass
 
 from sqlalchemy.exc import IntegrityError
@@ -9,6 +10,27 @@ from api.db.models import User
 from api.exceptions import UserExistsError
 from api.services.email_verification_service import PendingCredentials
 from api.services.user_service import UserService
+
+logger = logging.getLogger("api.service.registration")
+
+
+def _log_branch(branch: str) -> None:
+    """Trace which registration branch ran.
+
+    DEBUG, and deliberately anonymous.
+    :func:`api.auth.logging.log_registration_attempt` already documents that a reader
+    of the full application log can recover which branch ran for a given
+    ``email_hash``, because the account write and the token minting emit their own
+    records under the same request id -- log access is the trust boundary there, not
+    this line. Carrying an ``email_hash`` here would make that join trivial instead of
+    merely possible, so it does not.
+
+    :param branch: ``created``, ``pending_unverified``, or ``already_verified``.
+    """
+    logger.debug(
+        "Registration branch taken",
+        extra={"event": "registration_branch", "branch": branch},
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -93,6 +115,7 @@ class RegistrationService:
         if existing is None:
             created = self._create_account(email, password, first_name, last_name)
             if created is not None:
+                _log_branch("created")
                 return RegistrationResult(
                     user=created,
                     credentials=PendingCredentials(
@@ -115,6 +138,7 @@ class RegistrationService:
             last_name=last_name,
         )
         pending = existing if existing is not None and existing.email_verified_at is None else None
+        _log_branch("pending_unverified" if pending is not None else "already_verified")
         return RegistrationResult(user=pending, credentials=credentials, created=False)
 
     def _create_account(
@@ -146,5 +170,9 @@ class RegistrationService:
             # unique index -- both of them answers this endpoint must never give,
             # since a caller can tell them apart from the uniform 202. Roll the failed
             # insert back so the session is usable and take the taken-address path.
+            logger.warning(
+                "Registration raced for a free address",
+                extra={"event": "registration_race_detected"},
+            )
             self._users.session.rollback()
             return None

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -92,21 +92,28 @@ Each environment has its own isolated Railway Postgres (`*-db`) and its own Rail
 
 The root `railway.toml` carries the API build and deploy settings: it points at `docker/Dockerfile` and the `/api/v1/health` check. Railway reads that file from the repository root for every service in the project, so the frontend cannot share it without trying to build the API image. The frontend service therefore has its own config file, `frontend/railway.json`, chosen per service through the Railway "Railway Config File" setting (the absolute path `/frontend/railway.json`); it pins `frontend/Dockerfile` and a `/` health check. Everything else that differs between environments lives in per-environment service variables.
 
-| Variable | staging (test) | production (prod) |
-|----------|----------------|-------------------|
-| `APP_ENV` | `test` | `prod` |
-| `SECRET_KEY` | strong value (`openssl rand -hex 32`) | strong value |
-| `DATABASE_URL` | staging `become_app` role | production `become_app` role |
-| `MIGRATION_DATABASE_URL` | privileged role, Alembic only | privileged role, Alembic only |
-| `CORS_ORIGINS` | staging origin(s) | production origin(s) |
-| `REDIS_URL` | staging Redis | production Redis |
-| `CLOUDFLARE_ORIGIN_SECRET` | — | shared secret matching the Cloudflare Transform Rule |
-| `DEBUG` | `false` | `false` |
-| `API_PUBLIC_URL` | staging API URL | production API URL |
-| `VITE_API_URL` (frontend build arg) | staging API URL | production API URL |
-| `BUCKET_NAME` / `BUCKET_ENDPOINT` / `BUCKET_ACCESS_KEY_ID` / `BUCKET_SECRET_ACCESS_KEY` | injected from `test-photos` | injected from `prod-photos` |
+| Variable | dev | staging (test) | production (prod) |
+|----------|-----|----------------|-------------------|
+| `APP_ENV` | `dev` | `test` | `prod` |
+| `SECRET_KEY` | strong value (`openssl rand -hex 32`) | strong value | strong value |
+| `DATABASE_URL` | dev `become_app` role | staging `become_app` role | production `become_app` role |
+| `MIGRATION_DATABASE_URL` | privileged role, Alembic only | privileged role, Alembic only | privileged role, Alembic only |
+| `CORS_ORIGINS` | dev origin(s) | staging origin(s) | production origin(s) |
+| `REDIS_URL` | dev Redis | staging Redis | production Redis |
+| `CLOUDFLARE_ORIGIN_SECRET` | — | — | shared secret matching the Cloudflare Transform Rule |
+| `DEBUG` | `false` | `false` | `false` |
+| `LOG_LEVEL` | `DEBUG` | `INFO` | `INFO` |
+| `API_PUBLIC_URL` | dev API URL | staging API URL | production API URL |
+| `VITE_API_URL` / `VITE_SENTRY_DSN` / `VITE_APP_ENV` (frontend build args) | dev values | staging values | production values |
+| `BUCKET_NAME` / `BUCKET_ENDPOINT` / `BUCKET_ACCESS_KEY_ID` / `BUCKET_SECRET_ACCESS_KEY` | injected from `dev-photos` | injected from `test-photos` | injected from `prod-photos` |
 
-If `APP_ENV` is left unset on a deployed service, it falls back to dev, which turns debug on and opens CORS. Every deployed service must set its profile explicitly (`test` or `prod`) so the startup guard runs.
+If `APP_ENV` is left unset on a deployed service, it falls back to dev, which turns debug on and opens CORS. Every deployed service must set its profile explicitly (`dev`, `test`, or `prod`) so the startup guard runs.
+
+`LOG_LEVEL` is listed as a service variable even though `api/config.py` already defaults it per profile (`DEBUG` on dev, `INFO` on test and prod). The default is the safety net for a service whose variable was never set; the variable is what makes the level visible to whoever opens the service without reading the settings module. An explicit value always wins over the profile default.
+
+Log format follows the deploy, not the profile. `api/logging_config.py` emits human-readable text only when the profile is dev *and* `RAILWAY_ENVIRONMENT_NAME` is absent, i.e. on a laptop. The Railway `dev` service is a deploy, so it emits JSON like staging and production and its `extra` fields stay indexable in the drain.
+
+Every `VITE_*` variable the SPA reads must also be declared as an `ARG`/`ENV` pair in `frontend/Dockerfile`. Railway passes service variables to the build as build args, but Docker only exposes the ones the Dockerfile declares, and Vite inlines `undefined` for anything missing at build time -- silently, with no build error. That gap left `VITE_SENTRY_DSN` set on all three frontend services while `Sentry.init` was tree-shaken out of every bundle.
 
 ## Database schema and access
 

--- a/docs/quality-report.md
+++ b/docs/quality-report.md
@@ -4,11 +4,11 @@
 
 | Check | Status | Result |
 |-------|--------|--------|
-| mypy (strict) | Pass | No errors (28 files in `src/`+`examples/`, 89 in `api/`) |
+| mypy (strict) | Pass | No errors (24 files in `src/`+`examples/`, 89 in `api/`) |
 | ruff check | Pass | No issues |
 | ruff format | Pass | All files formatted |
-| pytest | Pass | 1499 tests passed |
-| coverage | Pass | 100% on `src/` (197 statements), 99% on `src/`+`api/` (4014 statements, 49 uncovered) |
+| pytest | Pass | 1639 passed, 59 skipped (the e2e tier needs a live PostgreSQL; it runs in CI) |
+| coverage | Pass | 100% on `src/` (197 statements), 99% on `src/`+`api/` (4190 statements, 49 uncovered) |
 
 ## Running Checks
 
@@ -28,20 +28,22 @@ uv run mypy src/ examples/ && uv run ruff check . && uv run pytest --cov=src
 | Module | Statements | Coverage |
 |--------|------------|----------|
 | calculators/base_calculator.py | 12 | 100% |
-| calculators/become_calculator.py | 31 | 100% |
-| calculators/median_strategies.py | 20 | 100% |
+| calculators/become_calculator.py | 28 | 100% |
+| calculators/median_strategies.py | 14 | 100% |
 | exceptions.py | 8 | 100% |
 | interpreters/likert_interpreter.py | 24 | 100% |
 | models/become_result.py | 24 | 100% |
 | models/expert_opinion.py | 36 | 100% |
-| models/fuzzy_number.py | 49 | 100% |
-| **Total** | **204** | **100%** |
+| models/fuzzy_number.py | 51 | 100% |
+| **Total** | **197** | **100%** |
 
 HTML report: `uv run pytest --cov=src --cov-report=html` generates `htmlcov/index.html`.
 
 ## Test Breakdown
 
-Unit tests (797) cover models, calculators, interpreters, utilities, and API components (auth, schemas, services, middleware, logging). Integration tests (393) validate core calculations against Excel reference data for all three case studies and test API routes with a real database. End-to-end tests (59) exercise full API workflows. The frontend adds 733 Vitest tests and 76 Playwright scenarios run on three browsers. Edge cases include single expert, identical opinions, empty lists, and boundary values.
+Unit tests (1142) cover models, calculators, interpreters, utilities, and API components (auth, schemas, services, middleware, logging). Integration tests (497) validate core calculations against Excel reference data for all three case studies and test API routes with a real database. End-to-end tests (59) exercise full API workflows; they skip on a machine without a live PostgreSQL and run in CI. The frontend adds 1031 Vitest tests and 76 Playwright scenarios run on three browsers. Edge cases include single expert, identical opinions, empty lists, and boundary values.
+
+Logging has its own two-part guard. `tests/unit/api/test_logging_events.py` asserts that each refusal, external call, and read emits the record it promises, at the level it promises -- several of those tests assert on what is *absent*, since a CSRF record must not carry the token it just compared and a throttle record must not carry the account it throttled. `tests/unit/api/test_logging_pii.py` walks the syntax tree of every module under `api/` and fails on an `extra={...}` field whose name denotes a credential or a raw identifier, so the rule in `docs/security.md` does not depend on a reviewer noticing it.
 
 ## Mutation Testing
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -340,6 +340,33 @@ to `SECRET_KEY`), which makes it meaningless outside the application while still
 correlating repeated attempts on one account. Rotating the fallback re-tags every later
 record, so set `LOG_HASH_KEY` explicitly where that correlation has to survive a rotation.
 
+The rule for any new log record: identifiers, keyed tags, and counts, never the values
+themselves. Allowed are `user_id`, `project_id`, `invitation_id`, `jti`, `sid`, `ip`,
+`status_code`, `duration_ms`, `row_count`, and the `reason` a request was refused. Never
+logged, at any level: passwords and password hashes, raw JWTs, the CSRF cookie or header
+value, the email API key or bucket credentials, the `Authorization` header, any request or
+response body, raw email addresses, activation or reset tokens and the URLs carrying them,
+and free-text user content such as a project description.
+
+Two specific traps are worth naming. First, `_digest()` in `api/auth/login_throttle.py` and
+`api/auth/email_throttle.py` is a **plain, unkeyed** SHA-256 of the identifier -- it exists
+to key the store, not to be logged. Writing it out would rebuild exactly the oracle
+`hash_email` is keyed to prevent, so records in those modules name the flow (`key_prefix`,
+`op`) and never the account; the address-scoped event belongs at the call site in
+`api/routes/auth.py`, which has the keyed tag. Second, `sqlalchemy.engine` is pinned at
+WARNING in `api/logging_config.py` and must stay below DEBUG on any deployed service: its
+DEBUG level prints bound query parameters, which on this schema means bcrypt hashes,
+addresses, names, and reset-token hashes shipped to the log drain in the clear. That pin
+matters because the dev deploy now runs at `LOG_LEVEL=DEBUG` against a real database.
+
+Both throttles fail open, and that is now observable rather than silent. A Redis outage
+lifts the per-account login lockout and the per-address email cap while the request still
+succeeds, so each failure path logs a `throttle_store_unavailable` warning naming the
+operation and the flow. The accepted risk is unchanged; what changed is that it leaves a
+trace. The same applies to the revocation store, which fails *closed*: its errors surface to
+the caller as a plain 401, so `revocation_store_unavailable` is the only thing separating a
+Redis outage from a wave of bad tokens.
+
 Unhandled errors hit a catch-all `500` handler and, when `SENTRY_DSN` is configured, Sentry.
 
 Two separate switches keep credentials out of the tracker, and both are needed.
@@ -357,6 +384,14 @@ The browser SDK needs its own guard, since the reset link carries its token in t
 string: `frontend/src/main.tsx` installs `beforeSend` and `beforeBreadcrumb` hooks
 (`frontend/src/lib/sentry.ts`) that redact `token`, `access_token`, and `refresh_token`
 from event URLs and from navigation and fetch breadcrumbs.
+
+Those hooks were inert until this was fixed. `frontend/Dockerfile` declared only
+`ARG VITE_API_URL`, so `VITE_SENTRY_DSN` never reached the Vite build even though it was
+set on all three frontend services; the `if (import.meta.env.VITE_SENTRY_DSN)` guard in
+`main.tsx` folded to `false` and the whole `Sentry.init` call was tree-shaken out of every
+deployed bundle. No browser error was reported from any environment. The scrubbers now run
+because the SDK actually initialises -- so they are worth re-reading as live code rather
+than as documentation of an intent.
 
 ## Secrets
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,9 +11,18 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-# API URL injected at build time via Railway env vars
+# Build-time values injected via Railway env vars. Every VITE_* variable the SPA
+# reads has to be declared here: Railway passes service variables as build args, and
+# Vite only inlines a variable that exists in the builder's environment when
+# `npm run build` runs. An undeclared one is simply absent, and the code reading it
+# collapses to `undefined` -- which is how the Sentry init below went missing from
+# all three deployed bundles while VITE_SENTRY_DSN was set on every service.
 ARG VITE_API_URL
 ENV VITE_API_URL=${VITE_API_URL}
+ARG VITE_SENTRY_DSN
+ENV VITE_SENTRY_DSN=${VITE_SENTRY_DSN}
+ARG VITE_APP_ENV
+ENV VITE_APP_ENV=${VITE_APP_ENV}
 
 # Copy package files first for better caching
 COPY package.json package-lock.json ./

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -32,12 +32,30 @@ Make sure the backend is running:
 cd .. && SECRET_KEY=dev-secret uv run uvicorn api.main:app --reload
 ```
 
+## Environment variables
+
+`VITE_API_URL` (API base), `VITE_SENTRY_DSN` (browser error tracking; absent disables it),
+and `VITE_APP_ENV` (the `dev`/`test`/`prod` tag on Sentry events).
+
+Every one of them has to be declared as an `ARG`/`ENV` pair in `Dockerfile`, before
+`RUN npm run build`. Railway passes service variables to the build as build args, but Docker
+only exposes the ones the Dockerfile declares, and Vite inlines `undefined` for anything it
+cannot see -- with no error and no warning. That is how `VITE_SENTRY_DSN` stayed set on all
+three Railway services while `Sentry.init` was tree-shaken out of every deployed bundle.
+Adding a new `VITE_*` variable means editing three places: `Dockerfile`, the Railway service,
+and the `ImportMetaEnv` interface in `src/vite-env.d.ts`.
+
 ## Docker
 
 Build and run with Docker:
 ```bash
 docker build -t become-frontend .
 docker run -p 3000:80 become-frontend
+```
+
+To reproduce a deployed build locally, pass the build args explicitly:
+```bash
+docker build --build-arg VITE_API_URL=https://api.becomify.app/api/v1 --build-arg VITE_APP_ENV=prod -t become-frontend .
 ```
 
 Or use docker-compose from the project root:

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -2,6 +2,10 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_URL?: string;
+  /** Sentry DSN for the browser SDK. Absent means error tracking stays off. */
+  readonly VITE_SENTRY_DSN?: string;
+  /** Environment tag on Sentry events: dev, test, or prod. */
+  readonly VITE_APP_ENV?: string;
 }
 
 interface ImportMeta {

--- a/tests/unit/api/test_config.py
+++ b/tests/unit/api/test_config.py
@@ -904,3 +904,73 @@ class TestLoggingSettings:
         # THEN
         assert settings.betterstack_source_token is None
         assert settings.betterstack_ingesting_host is None
+
+
+class TestProfileLogLevelDefault:
+    """Tests for the per-profile LOG_LEVEL fallback."""
+
+    @pytest.mark.parametrize(
+        ("app_env", "expected"),
+        [("dev", "DEBUG"), ("test", "INFO"), ("prod", "INFO")],
+    )
+    def test_unset_log_level_follows_the_profile(self, monkeypatch, tmp_path, app_env, expected):
+        """
+        GIVEN LOG_LEVEL is not set anywhere
+        WHEN Settings is constructed under a given profile
+        THEN log_level is that profile's default, not the bare field default
+        """
+        # GIVEN
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        monkeypatch.setenv("APP_ENV", app_env)
+        monkeypatch.setenv("TESTING", "1")
+        monkeypatch.setenv("SECRET_KEY", "a-sufficiently-strong-secret-value-for-tests")
+        monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@host:5432/db")
+        monkeypatch.setenv("MIGRATION_DATABASE_URL", "postgresql://mig:pass@host:5432/db")
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        monkeypatch.setenv("CLOUDFLARE_ORIGIN_SECRET", "an-origin-verify-secret-for-tests")
+        monkeypatch.setenv("CORS_ORIGINS", '["https://app.example.com"]')
+        monkeypatch.setenv("FRONTEND_BASE_URL", "https://app.example.com")
+        monkeypatch.setenv("EMAIL_PROVIDER", "http")
+        monkeypatch.setenv("EMAIL_API_KEY", "a-resend-api-key-for-tests")
+
+        # WHEN
+        settings = Settings()
+
+        # THEN
+        assert settings.log_level == expected
+
+    def test_explicit_log_level_beats_the_profile_default(self, monkeypatch, tmp_path):
+        """
+        GIVEN LOG_LEVEL is set explicitly on a profile whose default differs
+        WHEN Settings is constructed
+        THEN the explicit value wins
+        """
+        # GIVEN
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("APP_ENV", "dev")
+        monkeypatch.setenv("SECRET_KEY", "irrelevant-for-dev")
+        monkeypatch.setenv("LOG_LEVEL", "WARNING")
+
+        # WHEN
+        settings = Settings()
+
+        # THEN -- the dev default is DEBUG, so this proves the override, not the default
+        assert settings.log_level == "WARNING"
+
+    def test_explicit_kwarg_beats_the_profile_default(self, monkeypatch, tmp_path):
+        """
+        GIVEN log_level passed directly as a keyword argument
+        WHEN Settings is constructed under the dev profile
+        THEN the keyword wins over the profile default
+        """
+        # GIVEN
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        monkeypatch.setenv("APP_ENV", "dev")
+
+        # WHEN
+        settings = Settings(secret_key="irrelevant-for-dev", log_level="ERROR")
+
+        # THEN
+        assert settings.log_level == "ERROR"

--- a/tests/unit/api/test_logging_config.py
+++ b/tests/unit/api/test_logging_config.py
@@ -5,7 +5,7 @@ import logging
 from logging.handlers import RotatingFileHandler
 
 from api.config import Environment, Settings
-from api.logging_config import JsonLogFormatter, setup_logging
+from api.logging_config import _EXTERNAL_LOG_LEVELS, JsonLogFormatter, setup_logging
 from api.logging_context import ContextFilter
 
 
@@ -16,8 +16,14 @@ def _settings(
     debug=False,
     betterstack_source_token=None,
     betterstack_ingesting_host=None,
+    railway_environment_name=None,
 ):
-    """Build a Settings instance valid across all environment profiles."""
+    """Build a Settings instance valid across all environment profiles.
+
+    ``railway_environment_name`` is passed under its ``RAILWAY_ENVIRONMENT_NAME``
+    validation alias: the field declares one and the model does not set
+    ``populate_by_name``, so the field name alone would be silently ignored.
+    """
     return Settings(
         environment=environment,
         log_level=log_level,
@@ -25,6 +31,7 @@ def _settings(
         debug=debug,
         betterstack_source_token=betterstack_source_token,
         betterstack_ingesting_host=betterstack_ingesting_host,
+        RAILWAY_ENVIRONMENT_NAME=railway_environment_name,
         secret_key="a-sufficiently-strong-secret-value-for-tests",
         database_url="postgresql://user:pass@host:5432/db",
         redis_url="redis://localhost:6379/0",
@@ -195,7 +202,7 @@ class TestSetupLogging:
 
     def test_uses_text_formatter_in_development(self):
         """
-        GIVEN the development profile
+        GIVEN the development profile on a laptop (no Railway marker)
         WHEN setup_logging runs
         THEN the stream handler uses a plain text formatter
         """
@@ -208,6 +215,25 @@ class TestSetupLogging:
         # THEN
         handler = logging.getLogger("api").handlers[0]
         assert not isinstance(handler.formatter, JsonLogFormatter)
+
+    def test_uses_json_formatter_on_a_deployed_dev_service(self):
+        """
+        GIVEN the dev profile running on Railway
+        WHEN setup_logging runs
+        THEN the stream handler still uses the JSON formatter
+
+        The dev service is a deploy that happens to run the dev profile. Emitting text
+        there would leave every ``extra`` field unindexable in the log drain.
+        """
+        # GIVEN
+        settings = _settings(environment=Environment.DEV, railway_environment_name="dev")
+
+        # WHEN
+        setup_logging(settings)
+
+        # THEN
+        handler = logging.getLogger("api").handlers[0]
+        assert isinstance(handler.formatter, JsonLogFormatter)
 
     def test_repeated_calls_do_not_stack_handlers(self):
         """
@@ -333,6 +359,118 @@ class TestSetupLogging:
 
         # THEN
         mock_handler.assert_not_called()
+
+
+class TestExternalLoggers:
+    """Tests for the third-party loggers wired into the same handlers."""
+
+    def test_every_external_logger_shares_the_api_handlers(self):
+        """
+        GIVEN application settings
+        WHEN setup_logging runs
+        THEN each external logger carries the very same handler objects as 'api'
+
+        Sharing the objects, not just the types, is what keeps the Better Stack
+        handler a single HTTP client with a single buffer instead of one per logger.
+        """
+        # GIVEN
+        settings = _settings(
+            betterstack_source_token="a-source-token",
+            betterstack_ingesting_host="in.example.com",
+        )
+
+        # WHEN
+        setup_logging(settings)
+
+        # THEN
+        api_handlers = logging.getLogger("api").handlers
+        for name in _EXTERNAL_LOG_LEVELS:
+            assert logging.getLogger(name).handlers == api_handlers
+
+    def test_every_external_logger_stops_propagating(self):
+        """
+        GIVEN application settings
+        WHEN setup_logging runs
+        THEN each external logger has propagation disabled
+
+        They already carry the full handler set, so propagation would emit each
+        record a second time through an ancestor.
+        """
+        # GIVEN
+        settings = _settings()
+
+        # WHEN
+        setup_logging(settings)
+
+        # THEN
+        for name in _EXTERNAL_LOG_LEVELS:
+            assert logging.getLogger(name).propagate is False
+
+    def test_external_levels_match_the_mapping(self):
+        """
+        GIVEN application settings
+        WHEN setup_logging runs
+        THEN each external logger sits at its pinned level
+        """
+        # GIVEN
+        settings = _settings()
+
+        # WHEN
+        setup_logging(settings)
+
+        # THEN
+        for name, level in _EXTERNAL_LOG_LEVELS.items():
+            assert logging.getLogger(name).level == level
+
+    def test_uvicorn_error_is_kept_at_info(self):
+        """
+        GIVEN the external logger mapping
+        WHEN it is read
+        THEN uvicorn.error sits at INFO
+
+        It carries startup, shutdown, and protocol failures -- the records that explain
+        a boot that never finished. Raising it would hide them from the drain.
+        """
+        # GIVEN / WHEN / THEN
+        assert _EXTERNAL_LOG_LEVELS["uvicorn.error"] == logging.INFO
+
+    def test_sqlalchemy_stays_above_debug_even_when_log_level_is_debug(self):
+        """
+        GIVEN settings asking for DEBUG everywhere
+        WHEN setup_logging runs
+        THEN sqlalchemy.engine is still pinned at WARNING
+
+        Regression guard for a PII leak, not a style preference: sqlalchemy.engine's
+        DEBUG level prints bound query parameters -- password hashes, raw addresses,
+        reset-token hashes -- and the dev deploy runs at DEBUG against a real database.
+        """
+        # GIVEN
+        settings = _settings(log_level="DEBUG")
+
+        # WHEN
+        setup_logging(settings)
+
+        # THEN
+        assert logging.getLogger("api").level == logging.DEBUG
+        assert logging.getLogger("sqlalchemy.engine").level == logging.WARNING
+
+    def test_repeated_calls_do_not_stack_external_handlers(self):
+        """
+        GIVEN setup_logging has already run
+        WHEN it runs again
+        THEN the external loggers' handler counts stay the same
+        """
+        # GIVEN
+        settings = _settings()
+        setup_logging(settings)
+        before = {name: len(logging.getLogger(name).handlers) for name in _EXTERNAL_LOG_LEVELS}
+
+        # WHEN
+        setup_logging(settings)
+
+        # THEN
+        after = {name: len(logging.getLogger(name).handlers) for name in _EXTERNAL_LOG_LEVELS}
+        assert after == before
 
 
 class TestCreateAppLogging:

--- a/tests/unit/api/test_logging_events.py
+++ b/tests/unit/api/test_logging_events.py
@@ -1,0 +1,541 @@
+"""Tests that refusals, external calls, and reads emit the log records they promise.
+
+Grouped by the layer that emits them rather than by module, because the point of each
+record is the question it answers for whoever reads the drain -- "was the request
+refused, and why" -- not which file happens to raise it.
+
+Several of these assert on what is *absent*: a CSRF record must not carry the token it
+just compared, a throttle record must not carry the account it throttled. Those are the
+assertions worth keeping when the code around them changes.
+"""
+
+import logging
+from time import perf_counter
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import httpx
+import pytest
+import redis
+from starlette.requests import Request
+
+from api.auth import cookies, email_throttle, login_throttle, revocation_store
+from api.auth import jwt as jwt_module
+from api.middleware.body_size import RequestBodyTooLarge, body_too_large_handler
+from api.middleware.csrf import CSRFMiddleware
+from api.routes import invitations as invitations_route
+from api.routes import users as users_route
+from api.services import project_query_service, registration_service
+from api.services.email import resend_email_sender
+
+
+def _request(method: str = "POST", path: str = "/api/v1/projects") -> Request:
+    """Build a minimal request the middleware helpers can read."""
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": method,
+            "path": path,
+            "raw_path": path.encode(),
+            "query_string": b"",
+            "root_path": "",
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "client": ("203.0.113.5", 51234),
+            "headers": [],
+        }
+    )
+
+
+def _extras(mock_call) -> dict:
+    """Return the ``extra`` dict of a mocked logger call."""
+    return mock_call[1]["extra"]
+
+
+class TestCsrfRejectionLogging:
+    """A refused CSRF check is logged, without the token it compared."""
+
+    @pytest.mark.parametrize("reason", ["missing_header", "token_mismatch"])
+    def test_rejection_logs_event_and_reason(self, reason):
+        """
+        GIVEN a request the CSRF check refuses
+        WHEN the refusal is built
+        THEN a csrf_rejected warning names the reason, method, and path
+        """
+        # GIVEN
+        request = _request(method="DELETE", path="/api/v1/projects/abc")
+
+        # WHEN
+        with patch("api.middleware.csrf.logger") as mock_logger:
+            response = CSRFMiddleware._reject(reason, request)
+
+        # THEN
+        extra = _extras(mock_logger.warning.call_args)
+        assert extra["event"] == "csrf_rejected"
+        assert extra["reason"] == reason
+        assert extra["method"] == "DELETE"
+        assert extra["path"] == "/api/v1/projects/abc"
+        assert response.status_code == 403
+
+    def test_rejection_does_not_log_the_token(self):
+        """
+        GIVEN a CSRF refusal
+        WHEN the record is built
+        THEN no field carries a token value
+
+        The cookie and header are the secret being compared: a record carrying either
+        hands a log reader what they need to forge the request that was just blocked.
+        """
+        # GIVEN / WHEN
+        with patch("api.middleware.csrf.logger") as mock_logger:
+            CSRFMiddleware._reject("token_mismatch", _request())
+
+        # THEN
+        assert set(_extras(mock_logger.warning.call_args)) == {
+            "event",
+            "reason",
+            "method",
+            "path",
+            "ip",
+        }
+
+
+class TestBodySizeRejectionLogging:
+    """An over-large body is logged whichever way it was caught."""
+
+    def test_streamed_overflow_logs_event(self):
+        """
+        GIVEN a body that streamed past the cap
+        WHEN the handler answers 413
+        THEN a request_body_rejected warning names the streamed_overflow reason
+        """
+        # GIVEN
+        request = _request(method="POST", path="/api/v1/calculate")
+
+        # WHEN
+        with patch("api.middleware.body_size.logger") as mock_logger:
+            response = body_too_large_handler(request, RequestBodyTooLarge())
+
+        # THEN
+        extra = _extras(mock_logger.warning.call_args)
+        assert extra["event"] == "request_body_rejected"
+        assert extra["reason"] == "streamed_overflow"
+        assert extra["path"] == "/api/v1/calculate"
+        assert response.status_code == 413
+
+
+class TestTokenRejectionLogging:
+    """Token refusals split by level: routine traffic at DEBUG, signal at WARNING."""
+
+    @pytest.mark.parametrize("reason", ["invalid_or_expired", "invalid_user_id"])
+    def test_routine_refusals_are_debug(self, reason):
+        """
+        GIVEN an expired or malformed token
+        WHEN it is refused
+        THEN the record is DEBUG
+
+        Every active session hits this every 15 minutes and every stale browser tab
+        hits it too; at WARNING it would bury the refusals that mean something.
+        """
+        # GIVEN / WHEN
+        with patch("api.auth.jwt.logger") as mock_logger:
+            error = jwt_module._reject(reason, "nope", expected_type="access")
+
+        # THEN
+        assert mock_logger.log.call_args[0][0] == logging.DEBUG
+        assert isinstance(error, jwt_module.TokenError)
+
+    @pytest.mark.parametrize(
+        "reason",
+        ["jti_revoked", "session_revoked", "store_unavailable", "issued_before_valid_after"],
+    )
+    def test_meaningful_refusals_are_warning(self, reason):
+        """
+        GIVEN a revoked token or an unreachable store
+        WHEN it is refused
+        THEN the record is WARNING
+        """
+        # GIVEN / WHEN
+        with patch("api.auth.jwt.logger") as mock_logger:
+            jwt_module._reject(reason, "nope", jti="abc123")
+
+        # THEN
+        assert mock_logger.log.call_args[0][0] == logging.WARNING
+        assert _extras(mock_logger.log.call_args)["event"] == "token_rejected"
+
+    def test_refusal_carries_no_token_string(self):
+        """
+        GIVEN a refused token
+        WHEN the record is built
+        THEN only the reason and opaque identifiers are logged
+        """
+        # GIVEN / WHEN
+        with patch("api.auth.jwt.logger") as mock_logger:
+            jwt_module._reject("jti_revoked", "nope", jti="abc123")
+
+        # THEN
+        assert set(_extras(mock_logger.log.call_args)) == {"event", "reason", "jti"}
+
+
+class TestCsrfHeaderSuppressionLogging:
+    """Refusing to echo a client-chosen CSRF value leaves a trace."""
+
+    def test_non_printable_token_is_logged(self):
+        """
+        GIVEN a CSRF token carrying a newline
+        WHEN set_csrf_header refuses to echo it
+        THEN a csrf_header_suppressed warning records the refusal
+
+        That guard blocks a response-splitting primitive and previously left no trace
+        whatsoever, so an attempt was indistinguishable from nothing happening.
+        """
+        # GIVEN
+        response = MagicMock()
+        response.headers = {}
+
+        # WHEN
+        with patch("api.auth.cookies.logger") as mock_logger:
+            cookies.set_csrf_header(response, "\nX-Injected: 1")
+
+        # THEN
+        extra = _extras(mock_logger.warning.call_args)
+        assert extra == {"event": "csrf_header_suppressed", "reason": "non_printable"}
+        assert response.headers == {}
+
+    def test_a_clean_token_is_echoed_without_a_warning(self):
+        """
+        GIVEN a well-formed token
+        WHEN set_csrf_header runs
+        THEN the header is set and nothing is logged
+        """
+        # GIVEN
+        response = MagicMock()
+        response.headers = {}
+
+        # WHEN
+        with patch("api.auth.cookies.logger") as mock_logger:
+            cookies.set_csrf_header(response, "a-normal-url-safe-token")
+
+        # THEN
+        assert response.headers[cookies.CSRF_HEADER] == "a-normal-url-safe-token"
+        mock_logger.warning.assert_not_called()
+
+
+class TestRevocationStoreLogging:
+    """A fail-closed store that cannot be reached says so."""
+
+    def test_store_error_logs_the_operation(self):
+        """
+        GIVEN Redis raising on a revocation lookup
+        WHEN the error is built
+        THEN a revocation_store_unavailable warning names the operation
+
+        Callers turn this into a plain 401, so without the record a Redis outage is
+        indistinguishable from a wave of bad tokens.
+        """
+        # GIVEN
+        exc = redis.RedisError("connection refused")
+
+        # WHEN
+        with patch("api.auth.revocation_store.logger") as mock_logger:
+            error = revocation_store._store_error("is_jti_revoked", exc)
+
+        # THEN
+        extra = _extras(mock_logger.warning.call_args)
+        assert extra == {"event": "revocation_store_unavailable", "op": "is_jti_revoked"}
+        assert mock_logger.warning.call_args[1]["exc_info"] is exc
+        assert isinstance(error, revocation_store.RevocationStoreError)
+
+    def test_backend_selection_is_logged_once(self):
+        """
+        GIVEN no Redis configured
+        WHEN the store is selected
+        THEN a revocation_store_selected record names the memory backend
+        """
+        # GIVEN
+        revocation_store.get_revocation_store.cache_clear()
+
+        # WHEN
+        with patch("api.auth.revocation_store.logger") as mock_logger:
+            store = revocation_store.get_revocation_store()
+
+        # THEN
+        extra = _extras(mock_logger.info.call_args)
+        assert extra == {"event": "revocation_store_selected", "backend": "memory"}
+        assert isinstance(store, revocation_store.InMemoryRevocationStore)
+        revocation_store.get_revocation_store.cache_clear()
+
+    def test_call_trace_carries_timing(self):
+        """
+        GIVEN a completed store round trip
+        WHEN it is traced
+        THEN the DEBUG record carries the operation and its duration
+        """
+        # GIVEN / WHEN
+        with patch("api.auth.revocation_store.logger") as mock_logger:
+            revocation_store._log_call("revoke_session", perf_counter(), sid="s1")
+
+        # THEN
+        extra = _extras(mock_logger.debug.call_args)
+        assert extra["event"] == "revocation_store_call"
+        assert extra["op"] == "revoke_session"
+        assert extra["duration_ms"] >= 0
+
+
+class TestThrottleLogging:
+    """Both throttles fail open, so an outage has to be visible."""
+
+    def test_login_throttle_outage_is_logged_without_the_account(self):
+        """
+        GIVEN Redis raising while the lockout counter is read
+        WHEN the failure is recorded
+        THEN a throttle_store_unavailable warning names the flow, not the account
+
+        _digest() is an unkeyed SHA-256: logging it would let anyone holding the logs
+        confirm an address by hashing a guess.
+        """
+        # GIVEN
+        exc = redis.RedisError("down")
+
+        # WHEN
+        with patch("api.auth.login_throttle.logger") as mock_logger:
+            login_throttle._log_store_unavailable("is_locked", exc, "login")
+
+        # THEN
+        extra = _extras(mock_logger.warning.call_args)
+        assert extra == {
+            "event": "throttle_store_unavailable",
+            "op": "is_locked",
+            "key_prefix": "login",
+        }
+
+    def test_email_throttle_outage_is_logged_without_the_address(self):
+        """
+        GIVEN Redis raising while the per-address cap is checked
+        WHEN the failure is recorded
+        THEN the record names the flow only
+        """
+        # GIVEN
+        exc = redis.RedisError("down")
+
+        # WHEN
+        with patch("api.auth.email_throttle.logger") as mock_logger:
+            email_throttle._log_store_unavailable("allow", exc, "reset")
+
+        # THEN
+        extra = _extras(mock_logger.warning.call_args)
+        assert extra == {
+            "event": "throttle_store_unavailable",
+            "op": "allow",
+            "key_prefix": "reset",
+        }
+
+    def test_in_memory_denial_logs_without_an_identifier(self):
+        """
+        GIVEN an address inside its cooldown
+        WHEN the in-memory throttle refuses a second send
+        THEN an email_throttle_denied record names the reason, not the address
+        """
+        # GIVEN
+        throttle = email_throttle.InMemoryEmailSendThrottle()
+        address = "victim@example.com"
+        assert throttle.allow(address) is True
+
+        # WHEN
+        with patch("api.auth.email_throttle.logger") as mock_logger:
+            allowed = throttle.allow(address)
+
+        # THEN
+        assert allowed is False
+        extra = _extras(mock_logger.debug.call_args)
+        assert extra["event"] == "email_throttle_denied"
+        assert extra["reason"] == "cooldown"
+        assert address not in str(mock_logger.debug.call_args)
+        assert email_throttle._digest(address) not in str(mock_logger.debug.call_args)
+
+
+class TestEmailSenderLogging:
+    """The provider call is traced, and its failure stays below ERROR."""
+
+    def test_success_logs_status_and_timing(self):
+        """
+        GIVEN a provider call that returned 200
+        WHEN the outcome is recorded
+        THEN an email_sent record carries the status, timing, and keyed address tag
+        """
+        # GIVEN / WHEN
+        with patch("api.services.email.resend_email_sender.logger") as mock_logger:
+            resend_email_sender._log_send_result(
+                "password_reset", "abcdef0123456789", start=perf_counter(), status_code=200
+            )
+
+        # THEN
+        extra = _extras(mock_logger.info.call_args)
+        assert extra["event"] == "email_sent"
+        assert extra["kind"] == "password_reset"
+        assert extra["status_code"] == 200
+        assert extra["email_hash"] == "abcdef0123456789"
+
+    def test_failure_is_warning_not_error(self):
+        """
+        GIVEN a provider call that failed
+        WHEN the outcome is recorded
+        THEN it is a WARNING and never an ERROR
+
+        api/routes/auth.py already logs the swallowed EmailSendError at ERROR so Sentry
+        raises exactly one issue per outage; a second ERROR here would double them.
+        """
+        # GIVEN
+        exc = httpx.ConnectError("no route to host")
+
+        # WHEN
+        with patch("api.services.email.resend_email_sender.logger") as mock_logger:
+            resend_email_sender._log_send_result(
+                "verification", "abcdef0123456789", start=perf_counter(), exc=exc
+            )
+
+        # THEN
+        assert _extras(mock_logger.warning.call_args)["event"] == "email_send_failed"
+        mock_logger.error.assert_not_called()
+
+    def test_failure_records_the_provider_status_when_there_is_one(self):
+        """
+        GIVEN a provider that answered 422
+        WHEN the failure is recorded
+        THEN the status reaches the record
+        """
+        # GIVEN
+        response = httpx.Response(422, request=httpx.Request("POST", "https://api.resend.com"))
+        exc = httpx.HTTPStatusError("rejected", request=response.request, response=response)
+
+        # WHEN
+        with patch("api.services.email.resend_email_sender.logger") as mock_logger:
+            resend_email_sender._log_send_result(
+                "registration_notice", "abcdef0123456789", start=perf_counter(), exc=exc
+            )
+
+        # THEN
+        assert _extras(mock_logger.warning.call_args)["status_code"] == 422
+
+
+class TestRegistrationLogging:
+    """The registration branch is traced without making it joinable to an address."""
+
+    @pytest.mark.parametrize("branch", ["created", "pending_unverified", "already_verified"])
+    def test_branch_is_debug_and_anonymous(self, branch):
+        """
+        GIVEN a registration submission
+        WHEN its branch is traced
+        THEN the DEBUG record names the branch and nothing about the address
+        """
+        # GIVEN / WHEN
+        with patch("api.services.registration_service.logger") as mock_logger:
+            registration_service._log_branch(branch)
+
+        # THEN
+        assert _extras(mock_logger.debug.call_args) == {
+            "event": "registration_branch",
+            "branch": branch,
+        }
+
+
+class TestProjectQueryLogging:
+    """Reads are traced by shape and timing, never by statement."""
+
+    def test_query_trace_carries_shape_and_timing(self):
+        """
+        GIVEN a completed project query
+        WHEN it is traced
+        THEN the DEBUG record carries the variant, row count, and duration
+        """
+        # GIVEN
+        user_id = uuid4()
+
+        # WHEN
+        with patch("api.services.project_query_service.logger") as mock_logger:
+            project_query_service._log_query(
+                "with_roles", user_id, 7, perf_counter(), limit=20, offset=0
+            )
+
+        # THEN
+        extra = _extras(mock_logger.debug.call_args)
+        assert extra["event"] == "user_projects_queried"
+        assert extra["variant"] == "with_roles"
+        assert extra["row_count"] == 7
+        assert extra["user_id"] == str(user_id)
+        assert extra["duration_ms"] >= 0
+
+
+class TestRouteRefusalLogging:
+    """Route-level refusals are raised as HTTPException, so they log here or nowhere."""
+
+    def test_invitation_rejection_tags_the_address(self):
+        """
+        GIVEN an invitation for an address with no account
+        WHEN the refusal is logged
+        THEN the address is a keyed tag, never the address itself
+
+        This endpoint is the application's email-enumeration surface, so a log of the
+        addresses people probed for would be the registry the rate limit denies them.
+        """
+        # GIVEN
+        project_id, inviter_id = uuid4(), uuid4()
+        address = "stranger@example.com"
+
+        # WHEN
+        with patch("api.routes.invitations.logger") as mock_logger:
+            invitations_route._log_invitation_rejected(
+                "invitee_not_found", project_id, inviter_id, address
+            )
+
+        # THEN
+        extra = _extras(mock_logger.warning.call_args)
+        assert extra["event"] == "invitation_rejected"
+        assert extra["reason"] == "invitee_not_found"
+        assert extra["project_id"] == str(project_id)
+        assert address not in str(mock_logger.warning.call_args)
+        assert len(extra["email_hash"]) == 16
+
+    @pytest.mark.parametrize(
+        "reason", ["storage_unavailable", "content_type", "too_large", "content_mismatch"]
+    )
+    def test_photo_upload_rejections_are_logged(self, reason):
+        """
+        GIVEN a photo upload refused by one of the validation gates
+        WHEN the refusal is logged
+        THEN a photo_upload_rejected warning names which gate refused it
+        """
+        # GIVEN
+        user_id = uuid4()
+
+        # WHEN
+        with patch("api.routes.users.logger") as mock_logger:
+            users_route._photo_upload_rejected(reason, user_id)
+
+        # THEN
+        extra = _extras(mock_logger.warning.call_args)
+        assert extra["event"] == "photo_upload_rejected"
+        assert extra["reason"] == reason
+        assert extra["user_id"] == str(user_id)
+
+    def test_photo_not_found_is_debug(self):
+        """
+        GIVEN the public photo proxy answering 404
+        WHEN the miss is logged
+        THEN it is DEBUG
+
+        The endpoint is public and fires on every avatar render, so a missing photo is
+        ordinary traffic rather than a signal.
+        """
+        # GIVEN
+        user_id = uuid4()
+
+        # WHEN
+        with patch("api.routes.users.logger") as mock_logger:
+            users_route._photo_not_found("object_missing", user_id)
+
+        # THEN
+        extra = _extras(mock_logger.debug.call_args)
+        assert extra["event"] == "photo_not_found"
+        assert extra["reason"] == "object_missing"

--- a/tests/unit/api/test_logging_pii.py
+++ b/tests/unit/api/test_logging_pii.py
@@ -1,0 +1,131 @@
+"""Static guard against personal data reaching the logs.
+
+Every log record in ``api/`` carries its structured context through ``extra={...}``,
+so the keys of those dict literals are the complete list of field names the drain can
+ever receive. This walks the package's syntax tree and fails on a key that names a
+credential or a raw identifier, which keeps the rule from depending on a reviewer
+noticing it. ``docs/security.md`` states the rule; this enforces it.
+
+The check is deliberately about *names*, not values: a field called ``password`` is
+wrong whatever it holds, and a keyed tag like ``email_hash`` is fine even though it
+derives from an address.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+API_ROOT = Path(__file__).resolve().parents[3] / "api"
+
+# Field names that must never appear as an ``extra`` key. Substring matching, so
+# ``reset_token`` and ``api_key`` are caught by ``token`` and ``api_key`` alike.
+FORBIDDEN_KEY_PARTS = (
+    "password",
+    "token",
+    "secret",
+    "authorization",
+    "api_key",
+    "cookie",
+    "credential",
+    "digest",
+)
+
+# Names that contain a forbidden substring but are safe, with the reason they are safe.
+ALLOWED_KEYS = frozenset(
+    {
+        # Opaque per-request/session identifiers from the JWT, not credentials on their
+        # own: holding a jti or sid does not let anyone mint or replay a token.
+        "jti",
+        "sid",
+        # The count of tokens issued, never a token.
+        "token_count",
+    }
+)
+
+
+def _extra_keys(path: Path) -> list[tuple[str, int]]:
+    """Collect every literal ``extra={...}`` key in one module.
+
+    :param path: Module to scan.
+    :return: ``(key, line number)`` pairs.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    found: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for keyword in node.keywords:
+            if keyword.arg != "extra" or not isinstance(keyword.value, ast.Dict):
+                continue
+            for key in keyword.value.keys:
+                if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                    found.append((key.value, key.lineno))
+    return found
+
+
+def _api_modules() -> list[Path]:
+    """Return every Python module under ``api/``."""
+    return sorted(API_ROOT.rglob("*.py"))
+
+
+@pytest.mark.parametrize("module", _api_modules(), ids=lambda p: str(p.relative_to(API_ROOT)))
+def test_no_log_field_names_a_credential_or_raw_identifier(module):
+    """
+    GIVEN a module under api/
+    WHEN its literal ``extra={...}`` log fields are collected
+    THEN none of them names a credential, a raw address, or an unkeyed digest
+    """
+    # GIVEN / WHEN
+    offenders = [
+        (key, lineno)
+        for key, lineno in _extra_keys(module)
+        if key not in ALLOWED_KEYS and any(part in key.lower() for part in FORBIDDEN_KEY_PARTS)
+    ]
+
+    # THEN
+    assert not offenders, (
+        f"{module.relative_to(API_ROOT)} logs forbidden field(s) {offenders}. "
+        "Log an id, a keyed tag (api.auth.logging.hash_email), or a count instead -- "
+        "see the logging rules in docs/security.md."
+    )
+
+
+def test_the_guard_actually_catches_a_bad_key(tmp_path):
+    """
+    GIVEN a module that logs a raw password field
+    WHEN its extra keys are collected
+    THEN the forbidden substring check flags it
+
+    Without this the parametrised test above would pass just as happily if
+    ``_extra_keys`` silently returned nothing.
+    """
+    # GIVEN
+    module = tmp_path / "bad.py"
+    module.write_text(
+        'logger.info("oops", extra={"event": "login", "password": pw})\n',
+        encoding="utf-8",
+    )
+
+    # WHEN
+    keys = [key for key, _ in _extra_keys(module)]
+
+    # THEN
+    assert "event" in keys
+    assert any(part in key for key in keys for part in FORBIDDEN_KEY_PARTS)
+
+
+def test_the_guard_reads_real_log_calls():
+    """
+    GIVEN the request-logging middleware, which is known to log via ``extra``
+    WHEN its extra keys are collected
+    THEN the known field names are found
+
+    Guards against the AST walk silently matching nothing, which would make the
+    parametrised test vacuous across the whole package.
+    """
+    # GIVEN / WHEN
+    keys = {key for key, _ in _extra_keys(API_ROOT / "middleware" / "request_logging.py")}
+
+    # THEN
+    assert {"request_id", "method", "path", "status_code", "duration_ms"} <= keys


### PR DESCRIPTION
## Summary

Promotes `develop` to `staging`. No new code: every commit here was reviewed and merged
through PR #338, which expanded backend logging, made the log level explicit per
environment profile, and fixed the frontend Sentry build args.

What changes for the staging services once this lands:

- **Backend** starts emitting the new structured records — every refusal (CSRF, over-large
  body, rejected token, denied invitation, refused photo upload), every mutating action,
  and the throttle/revocation-store failures that previously left no trace. Staging runs at
  `INFO`, so the DEBUG read-tracing stays off there.
- **Backend** wires `uvicorn.error`, `httpx`, and `botocore` into the same handlers, so a
  boot that never finishes is visible in the drain. `uvicorn.access` is silenced;
  `sqlalchemy.engine` is pinned at WARNING and deliberately does not follow `LOG_LEVEL`.
- **Frontend** finally initialises Sentry: `frontend/Dockerfile` now declares
  `VITE_SENTRY_DSN` and `VITE_APP_ENV` as build args, so the Vite build can inline them.
  Until now the guard in `main.tsx` folded to `false` and the whole `Sentry.init` call was
  tree-shaken out of every deployed bundle.

Railway variables are already in place and need no action: `LOG_LEVEL=INFO` was set on
`test-backend` with `--skip-deploys`, and `VITE_SENTRY_DSN` / `VITE_APP_ENV` were already
present on `test-frontend`. This deploy is what makes them take effect.

Verified on dev after the same code deployed there: DEBUG records reach the console and
Better Stack, `event` / `reason` / `request_id` arrive as queryable fields, `uvicorn.access`
is quiet, `/api/v1/health` stays unlogged, and a scan of the live drain for `Bearer`, `eyJ`,
`password`, `csrf_token`, and `Authorization` returns nothing.

**Merge with `--merge`, not `--rebase`** — a rebased promotion rewrites the commits under
new SHAs, freezes the merge base, and makes every later promotion replay both lineages.
